### PR TITLE
Allow deselect through toolbar

### DIFF
--- a/src/js/game/hud/parts/buildings_toolbar.js
+++ b/src/js/game/hud/parts/buildings_toolbar.js
@@ -143,8 +143,25 @@ export class HUDBuildingsToolbar extends BaseHUDPart {
             return;
         }
 
-        this.root.soundProxy.playUiClick();
-        this.sigBuildingSelected.dispatch(metaBuilding);
-        this.onSelectedPlacementBuildingChanged(metaBuilding);
+        let previouslySelected = false;
+        for (const buildingId in this.buildingHandles) {
+            const handle = this.buildingHandles[buildingId];
+            if (handle.metaBuilding === metaBuilding) {
+                if (handle.index === this.lastSelectedIndex) {
+                    previouslySelected = true;
+                }
+                break;
+            }
+        }
+
+        const buildingPlacer = this.root.hud.parts.buildingPlacer;
+
+        if (previouslySelected && buildingPlacer.currentMetaBuilding.get()) {
+            buildingPlacer.abortPlacement();
+        } else {
+            this.root.soundProxy.playUiClick();
+            this.sigBuildingSelected.dispatch(metaBuilding);
+            this.onSelectedPlacementBuildingChanged(metaBuilding);
+        }
     }
 }

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -362,7 +362,9 @@ export class KeyActionMapper {
         for (const key in this.keybindings) {
             /** @type {Keybinding} */
             const binding = this.keybindings[key];
-            if (binding.keyCode === keyCode /* && binding.shift === shift && binding.alt === alt */) {
+
+            /* && binding.shift === shift && binding.alt === alt */
+            if (binding.keyCode === keyCode && !binding.currentlyDown ) {
                 binding.currentlyDown = true;
 
                 /** @type {Signal} */


### PR DESCRIPTION
When I first tried playing the game I found it annoying how I couldn't deselect a building by pressing on its icon in the toolbar. This small tweak that allows users, stop building placement by simply pressing on the toolbar icon or hotkey a second time.

This also includes a slight update to the key action mapper that changes its behavior from sending a signal periodically when a key is held to only sending a signal on the initial key stroke. This was done to prevent flickering if a building hotkey is held down. I was unable to find any instances where this change negatively affected other parts of the game.