### PR TITLE
Make CycleBuildings work properly

### DIFF
--- a/src/js/game/hud/parts/buildings_toolbar.js
+++ b/src/js/game/hud/parts/buildings_toolbar.js
@@ -110,8 +110,8 @@ export class HUDBuildingsToolbar extends BaseHUDPart {
 
     cycleBuildings() {
         let newIndex = this.lastSelectedIndex;
-        for (let i = 0; i < toolbarBuildings.length; ++i) {
-            newIndex = (newIndex + 1) % toolbarBuildings.length;
+        for (let i = 0; i < toolbarBuildings.length; ++i, ++newIndex) {
+            newIndex %= toolbarBuildings.length;
             const metaBuilding = gMetaBuildingRegistry.findByClass(toolbarBuildings[newIndex]);
             const handle = this.buildingHandles[metaBuilding.id];
             if (!handle.selected && handle.unlocked) {

--- a/src/js/game/hud/parts/buildings_toolbar.js
+++ b/src/js/game/hud/parts/buildings_toolbar.js
@@ -109,7 +109,15 @@ export class HUDBuildingsToolbar extends BaseHUDPart {
     }
 
     cycleBuildings() {
-        const newIndex = (this.lastSelectedIndex + 1) % toolbarBuildings.length;
+        let newIndex = this.lastSelectedIndex;
+        for (let i = 0; i < toolbarBuildings.length; ++i) {
+            newIndex = (newIndex + 1) % toolbarBuildings.length;
+            const metaBuilding = gMetaBuildingRegistry.findByClass(toolbarBuildings[newIndex]);
+            const handle = this.buildingHandles[metaBuilding.id];
+            if (!handle.selected && handle.unlocked) {
+                break;
+            }
+        }
         const metaBuildingClass = toolbarBuildings[newIndex];
         const metaBuilding = gMetaBuildingRegistry.findByClass(metaBuildingClass);
         this.selectBuildingForPlacement(metaBuilding);


### PR DESCRIPTION
Make CycleBuildings work properly
 - ignore locked (instead of: raise error sound)
 - select last used if empty (instead of: select next)