### PR TITLE
Better big number formatting

### DIFF
--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -24,9 +24,7 @@ export const BOTTOM = new Vector(0, 1);
 export const LEFT = new Vector(-1, 0);
 export const ALL_DIRECTIONS = [TOP, RIGHT, BOTTOM, LEFT];
 
-export const thousand = 1000;
-export const million = 1000 * 1000;
-export const billion = 1000 * 1000 * 1000;
+const bigNumberSuffixes = ["k", "M", "B", "T"];
 
 /**
  * Returns the build id
@@ -435,21 +433,21 @@ export function formatBigNumber(num, divider = ".") {
 
     if (num < 1000) {
         return sign + "" + num;
+    } else {
+        let leadingDigits = num;
+        let suffix = "";
+        for (let suffixIndex = 0; suffixIndex < bigNumberSuffixes.length; ++suffixIndex) {
+            leadingDigits = leadingDigits / 1000;
+            suffix = bigNumberSuffixes[suffixIndex];
+            if (leadingDigits < 1000) {
+                break;
+            }
+        }
+        // round down to nearest 0.1
+        const leadingDigitsRounded = Math_floor(leadingDigits * 10) / 10;
+        const leadingDigitsNoTrailingDecimal = leadingDigitsRounded.toString().replace(".0", "");
+        return sign + leadingDigitsNoTrailingDecimal + suffix;
     }
-    if (num > 10000) {
-        return Math_floor(num / 1000.0) + "k";
-    }
-
-    let rest = num;
-    let out = "";
-
-    while (rest >= 1000) {
-        out = (rest % 1000).toString().padStart(3, "0") + (out !== "" ? divider : "") + out;
-        rest = Math_floor(rest / 1000);
-    }
-
-    out = rest + divider + out;
-    return sign + out;
 }
 
 /**
@@ -731,14 +729,14 @@ export function checkTimerExpired(now, lastTick, tickRate) {
     Client A computes the timer and checks T > lastTick + interval. He computes
 
     30 >= 29.90 + 0.1   <=> 30 >= 30.0000  <=> True  <=> Tick performed
-    
+
     However, this is what it looks on client B:
-    
+
     33 >= 32.90 + 0.1   <=> 33 >= 32.999999999999998 <=> False <=> No tick performed!
-    
+
     This means that Client B will only tick at the *next* frame, which means it from now is out
     of sync by one tick, which means the game will resync further or later and be not able to recover,
-    since it will run into the same issue over and over. 
+    since it will run into the same issue over and over.
     */
 
     // The next tick, in our example it would be 30.0000 / 32.99999999998. In order to fix it, we quantize
@@ -913,5 +911,5 @@ export function formatItemsPerSecond(speed, double = false) {
     return speed === 1.0
         ? T.ingame.buildingPlacement.infoTexts.oneItemPerSecond
         : T.ingame.buildingPlacement.infoTexts.itemsPerSecond.replace("<x>", "" + round2Digits(speed)) +
-              (double ? "  " + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "");
+        (double ? "  " + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "");
 }

--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -911,5 +911,5 @@ export function formatItemsPerSecond(speed, double = false) {
     return speed === 1.0
         ? T.ingame.buildingPlacement.infoTexts.oneItemPerSecond
         : T.ingame.buildingPlacement.infoTexts.itemsPerSecond.replace("<x>", "" + round2Digits(speed)) +
-        (double ? "  " + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "");
+              (double ? "  " + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "");
 }

--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -24,7 +24,7 @@ export const BOTTOM = new Vector(0, 1);
 export const LEFT = new Vector(-1, 0);
 export const ALL_DIRECTIONS = [TOP, RIGHT, BOTTOM, LEFT];
 
-const bigNumberSuffixes = ["k", "M", "B", "T"];
+const bigNumberSuffixTranslationKeys = ["thousands", "millions", "billions", "trillions"];
 
 /**
  * Returns the build id
@@ -436,15 +436,14 @@ export function formatBigNumber(num, divider = ".") {
     } else {
         let leadingDigits = num;
         let suffix = "";
-        for (let suffixIndex = 0; suffixIndex < bigNumberSuffixes.length; ++suffixIndex) {
+        for (let suffixIndex = 0; suffixIndex < bigNumberSuffixTranslationKeys.length; ++suffixIndex) {
             leadingDigits = leadingDigits / 1000;
-            suffix = bigNumberSuffixes[suffixIndex];
+            suffix = T.global.suffix[bigNumberSuffixTranslationKeys[suffixIndex]];
             if (leadingDigits < 1000) {
                 break;
             }
         }
-        // round down to nearest 0.1
-        const leadingDigitsRounded = Math_floor(leadingDigits * 10) / 10;
+        const leadingDigitsRounded = round1Digit(leadingDigits);
         const leadingDigitsNoTrailingDecimal = leadingDigitsRounded.toString().replace(".0", "");
         return sign + leadingDigitsNoTrailingDecimal + suffix;
     }

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -26,6 +26,13 @@ global:
     # How big numbers are rendered, e.g. "10,000"
     thousandsDivider: ","
 
+    # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
+    suffix:
+        thousands: k
+        millions: M
+        billions: B
+        trillions: T
+
     # Shown for infinitely big numbers
     infinite: inf
 


### PR DESCRIPTION
I redid the formatBigNumber() function to include a decimal point, and it also supports numbers up to 999.9T (although it isn't really necessary). Results below: 
![Screenshot from 2020-05-29 18-49-10](https://user-images.githubusercontent.com/25755516/83311593-ab2e3d00-a1dd-11ea-9298-cc477090218b.png)
