### PR TITLE
fix belt cloning bug

### DIFF
--- a/src/js/game/components/item_ejector.js
+++ b/src/js/game/components/item_ejector.js
@@ -44,7 +44,7 @@ export class ItemEjectorComponent extends Component {
 
         return new ItemEjectorComponent({
             slots: slotsCopy,
-            instantEject: false,
+            instantEject: this.instantEject,
         });
     }
 


### PR DESCRIPTION
belt_base is the only object with `instantEject: true`, which is not correctly cloned