### PR TITLE
Goal amounts on existing pins change when you upgrade

### DIFF
--- a/src/js/game/hud/parts/pinned_shapes.js
+++ b/src/js/game/hud/parts/pinned_shapes.js
@@ -89,6 +89,10 @@ export class HUDPinnedShapes extends BaseHUDPart {
         }
     }
 
+    /**
+     * Updates the goal amounts in the pins when an upgrade is made.
+     * @param {string} upgradeId
+     */
     recalculateGoals(upgradeId) {
         const amountForUpgradeShape = {};
 


### PR DESCRIPTION
As is in the title. It has been repeatedly pointed out, so I decided to fix it by adding a new function to `HUDPinnedShapes` and intercepting the existing `upgradePurchased` signal. Feel free to make changes wherever they are necessary.

Note: When you upgrade from Tier V -> Tier VI, the shapes that are removed from the goal are not automatically unpinned by this. They are simply left up as-is, and can be manually clicked away.