### PR TITLE
Make selection relative to world

### DIFF
--- a/src/js/game/hud/parts/mass_selector.js
+++ b/src/js/game/hud/parts/mass_selector.js
@@ -41,6 +41,7 @@ export class HUDMassSelector extends BaseHUDPart {
         this.deletionMarker = Loader.getSprite("sprites/misc/deletion_marker.png");
 
         this.currentSelectionStart = null;
+        this.currentSelectionStartWorld = null;
         this.currentSelectionEnd = null;
         this.selectedUids = new Set();
 
@@ -147,6 +148,7 @@ export class HUDMassSelector extends BaseHUDPart {
         }
 
         this.currentSelectionStart = pos.copy();
+        this.currentSelectionStartWorld = this.root.camera.screenToWorld(this.currentSelectionStart);
         this.currentSelectionEnd = pos.copy();
         return STOP_PROPAGATION;
     }
@@ -163,7 +165,7 @@ export class HUDMassSelector extends BaseHUDPart {
 
     onMouseUp() {
         if (this.currentSelectionStart) {
-            const worldStart = this.root.camera.screenToWorld(this.currentSelectionStart);
+            const worldStart = this.currentSelectionStartWorld;
             const worldEnd = this.root.camera.screenToWorld(this.currentSelectionEnd);
 
             const tileStart = worldStart.toTileSpace();
@@ -182,6 +184,7 @@ export class HUDMassSelector extends BaseHUDPart {
             }
 
             this.currentSelectionStart = null;
+            this.currentSelectionStartWorld = null;
             this.currentSelectionEnd = null;
         }
     }
@@ -198,7 +201,7 @@ export class HUDMassSelector extends BaseHUDPart {
         const boundsBorder = 2;
 
         if (this.currentSelectionStart) {
-            const worldStart = this.root.camera.screenToWorld(this.currentSelectionStart);
+            const worldStart = this.currentSelectionStartWorld;
             const worldEnd = this.root.camera.screenToWorld(this.currentSelectionEnd);
 
             const realWorldStart = worldStart.min(worldEnd);

--- a/src/js/game/hud/parts/mass_selector.js
+++ b/src/js/game/hud/parts/mass_selector.js
@@ -40,7 +40,6 @@ export class HUDMassSelector extends BaseHUDPart {
     initialize() {
         this.deletionMarker = Loader.getSprite("sprites/misc/deletion_marker.png");
 
-        this.currentSelectionStart = null;
         this.currentSelectionStartWorld = null;
         this.currentSelectionEnd = null;
         this.selectedUids = new Set();
@@ -147,8 +146,7 @@ export class HUDMassSelector extends BaseHUDPart {
             this.selectedUids = new Set();
         }
 
-        this.currentSelectionStart = pos.copy();
-        this.currentSelectionStartWorld = this.root.camera.screenToWorld(this.currentSelectionStart);
+        this.currentSelectionStartWorld = this.root.camera.screenToWorld(pos.copy());
         this.currentSelectionEnd = pos.copy();
         return STOP_PROPAGATION;
     }
@@ -158,13 +156,13 @@ export class HUDMassSelector extends BaseHUDPart {
      * @param {Vector} pos
      */
     onMouseMove(pos) {
-        if (this.currentSelectionStart) {
+        if (this.currentSelectionStartWorld) {
             this.currentSelectionEnd = pos.copy();
         }
     }
 
     onMouseUp() {
-        if (this.currentSelectionStart) {
+        if (this.currentSelectionStartWorld) {
             const worldStart = this.currentSelectionStartWorld;
             const worldEnd = this.root.camera.screenToWorld(this.currentSelectionEnd);
 
@@ -183,7 +181,6 @@ export class HUDMassSelector extends BaseHUDPart {
                 }
             }
 
-            this.currentSelectionStart = null;
             this.currentSelectionStartWorld = null;
             this.currentSelectionEnd = null;
         }
@@ -200,7 +197,7 @@ export class HUDMassSelector extends BaseHUDPart {
     draw(parameters) {
         const boundsBorder = 2;
 
-        if (this.currentSelectionStart) {
+        if (this.currentSelectionStartWorld) {
             const worldStart = this.currentSelectionStartWorld;
             const worldEnd = this.root.camera.screenToWorld(this.currentSelectionEnd);
 


### PR DESCRIPTION
Currently selection is relative to camera, and moves when camera is moved by WASD
This commit fixes that.