### PR TITLE
Add the js step in build.dev

### DIFF
--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -233,6 +233,7 @@ gulp.task("build.dev", cb => {
         "imgres.copyImageResources",
         "imgres.copyNonImageResources",
         "translations.fullBuild",
+        "js.dev",
         "css.dev",
         "html.dev"
     )(cb);


### PR DESCRIPTION
While trying to build shapez.io locally to be served by nginx, I noticed a missing js step in the `buid.dev` step