### PR TITLE
Change of "Spanish (Latin America)" to just "Spanish"

### DIFF
--- a/translations/README.md
+++ b/translations/README.md
@@ -19,7 +19,7 @@ The base translation is `base-en.yaml`. It will always contain the latest phrase
 -   [Swedish](base-sv.yaml)
 -   [Chinese (Simplified)](base-zh-CN.yaml)
 -   [Chinese (Traditional)](base-zh-TW.yaml)
--   [Spanish (Latin America)](base-es.yaml)
+-   [Spanish](base-es.yaml)
 -   [Hungarian](base-hu.yaml)
 -   [Turkish](base-tr.yaml)
 


### PR DESCRIPTION
I made the Spanish translation and as I used a fairly neutral spanish I think it'd be better to just state that the game is in spanish and not make a separation between both, as it can create a bit of confusion.