### PR TITLE
Prevent invalid connection if existing underground tunnel entrance exists

### DIFF
--- a/src/js/game/buildings/underground_belt.js
+++ b/src/js/game/buildings/underground_belt.js
@@ -175,6 +175,8 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                                 rotationVariant: 0,
                                 connectedEntities: [contents],
                             };
+                        } else {
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
This Fixes the issue where it allows a valid underground connection even though an entryway already blocks its path.

## Before

![image](https://user-images.githubusercontent.com/9077125/84406505-897f7d80-ac01-11ea-882f-7d62fd196b93.png)

## After

![image](https://user-images.githubusercontent.com/9077125/84406579-a320c500-ac01-11ea-9a86-c0551466f182.png)

works as usual when nothing blocks its way

![image](https://user-images.githubusercontent.com/9077125/84406602-ad42c380-ac01-11ea-824c-54756e4027d4.png)

## Notes

Original issue found on trello board: https://trello.com/c/4Gp1HC6J