### PR TITLE
Added movement speed setting

### DIFF
--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -901,8 +901,8 @@ export class Camera extends BasicSerializableObject {
                 forceX += 1;
             }
 
-            this.center.x += moveAmount * forceX;
-            this.center.y += moveAmount * forceY;
+            this.center.x += moveAmount * forceX * this.root.app.settings.getMovementSpeed();
+            this.center.y += moveAmount * forceY * this.root.app.settings.getMovementSpeed();
         }
     }
 }

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -62,6 +62,33 @@ export const scrollWheelSensitivities = [
     },
 ];
 
+export const movementSpeeds = [
+    {
+        id: "super_slow",
+        multiplier: 0.25,
+    },
+    {
+        id: "slow",
+        multiplier: 0.5,
+    },
+    {
+        id: "regular",
+        multiplier: 1,
+    },
+    {
+        id: "fast",
+        multiplier: 2,
+    },
+    {
+        id: "super_fast",
+        multiplier: 4,
+    },
+    {
+        id: "extremely_fast",
+        multiplier: 8,
+    },
+];
+
 /** @type {Array<BaseSetting>} */
 export const allApplicationSettings = [
     new EnumSetting("language", {
@@ -131,6 +158,14 @@ export const allApplicationSettings = [
     }),
 
     // GAME
+    new EnumSetting("movementSpeed", {
+        options: movementSpeeds.sort((a, b) => a.multiplier - b.multiplier),
+        valueGetter: multiplier => multiplier.id,
+        textGetter: multiplier => T.settings.labels.movementSpeed.speeds[multiplier.id],
+        category: categoryGame,
+        restartRequired: false,
+        changeCb: (app, id) => {},
+    }),
     new EnumSetting("theme", {
         options: Object.keys(THEMES),
         valueGetter: theme => theme,
@@ -176,6 +211,7 @@ class SettingsStorage {
         this.theme = "light";
         this.refreshRate = "60";
         this.scrollWheelSensitivity = "regular";
+        this.movementSpeed = "regular";
         this.language = "auto-detect";
 
         this.alwaysMultiplace = false;
@@ -260,6 +296,17 @@ export class ApplicationSettings extends ReadWriteProxy {
             }
         }
         logger.error("Unknown scroll wheel sensitivity id:", id);
+        return 1;
+    }
+
+    getMovementSpeed() {
+        const id = this.getAllSettings().movementSpeed;
+        for (let i = 0; i < movementSpeeds.length; ++i) {
+            if (movementSpeeds[i].id === id) {
+                return movementSpeeds[i].multiplier;
+            }
+        }
+        logger.error("Unknown movement speed id:", id);
         return 1;
     }
 
@@ -358,7 +405,7 @@ export class ApplicationSettings extends ReadWriteProxy {
     }
 
     getCurrentVersion() {
-        return 9;
+        return 10;
     }
 
     /** @param {{settings: SettingsStorage, version: number}} data */
@@ -388,6 +435,11 @@ export class ApplicationSettings extends ReadWriteProxy {
         if (data.version < 9) {
             data.settings.language = "auto-detect";
             data.version = 9;
+        }
+
+        if (data.version < 10) {
+            data.settings.movementSpeed = "regular";
+            data.version = 10;
         }
 
         return ExplainedResult.good();

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -603,6 +603,18 @@ settings:
                 fast: Fast
                 super_fast: Super fast
 
+        movementSpeed:
+            title: Movement speed
+            description: >-
+                Changes how fast the view moves when using the keyboard.
+            speeds:
+                super_slow: Super slow
+                slow: Slow
+                regular: Regular
+                fast: Fast
+                super_fast: Super Fast
+                extremely_fast: Extremely Fast
+
         language:
             title: Language
             description: >-

--- a/translations/base-pl.yaml
+++ b/translations/base-pl.yaml
@@ -626,6 +626,18 @@ settings:
                 fast: Duża
                 super_fast: Bardzo Duża
 
+        movementSpeed:
+            title: Prędkość poruszania
+            description: >-
+                Zmienia, jak szybko widok porusza się, używając skrótów klawiszowych.
+            speeds:
+                super_slow: Bardzo wolna
+                slow: Wolna
+                regular: Zwykła
+                fast: Szybka
+                super_fast: Bardzo szybka
+                extremely_fast: Ekstremalnie szybka
+
         language:
             title: Język
             description: >-


### PR DESCRIPTION
I added a movement speed setting. It has 6 values from super slow to extremely fast. Each step multiplies/divides the movement speed by 2.

Quick summary:
- Added a new setting: movement speed with 6 available values (defaults to `regular`).
- The camera movement speed can now be changed using that setting.
- New translation key(s):  `settings.labels.movementSpeed` - For translating that newly added setting.
- Added & translated `settings.labels.movementSpeed` to English & Polish
- Incremented the settings data version to 10.