### PR TITLE
Made debug overlay able to be translated

### DIFF
--- a/src/js/game/hud/parts/debug_info.js
+++ b/src/js/game/hud/parts/debug_info.js
@@ -3,6 +3,7 @@ import { makeDiv, round3Digits, round2Digits } from "../../../core/utils";
 import { Math_round } from "../../../core/builtins";
 import { DynamicDomAttach } from "../dynamic_dom_attach";
 import { KEYMAPPINGS } from "../../key_action_mapper";
+import { T } from "../../../translations.js";
 
 export class HUDDebugInfo extends BaseHUDPart {
     createElements(parent) {
@@ -31,15 +32,17 @@ export class HUDDebugInfo extends BaseHUDPart {
         const now = this.root.time.realtimeNow();
         if (now - this.lastTick > 0.25 && this.visible) {
             this.lastTick = now;
-            this.tickRateElement.innerText = "Tickrate: " + this.root.dynamicTickrate.currentTickRate;
-            this.fpsElement.innerText =
-                "FPS: " +
-                Math_round(this.root.dynamicTickrate.averageFps) +
-                " (" +
-                round2Digits(1000 / this.root.dynamicTickrate.averageFps) +
-                " ms)";
-            this.tickDurationElement.innerText =
-                "Tick Dur: " + round3Digits(this.root.dynamicTickrate.averageTickDuration) + "ms";
+            this.tickRateElement.innerText = T.ingame.debug.tickrate.replace(
+                "<x>",
+                this.root.dynamicTickrate.currentTickRate.toString()
+            );
+            this.fpsElement.innerText = T.ingame.debug.fps
+                .replace("<fps>", Math_round(this.root.dynamicTickrate.averageFps).toString())
+                .replace("<ms>", round2Digits(1000 / this.root.dynamicTickrate.averageFps).toString());
+            this.tickDurationElement.innerText = T.ingame.debug.tickDuration.replace(
+                "<ms>",
+                round3Digits(this.root.dynamicTickrate.averageTickDuration).toString()
+            );
         }
     }
 }

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -381,6 +381,16 @@ ingame:
             1_3_expand: >-
                 This is <strong>NOT</strong> an idle game! Build more extractors and belts to finish the goal quicker.<br><br>Tip: Hold <strong>SHIFT</strong> to place multiple extractors, and use <strong>R</strong> to rotate them.
 
+    # The debug overlay (F4)
+    # This doesn't need to be translated.
+    debug:
+        tickrate: >-
+            Tickrate: <x>
+        tickDuration: >-
+            Tick Dur: <ms>ms
+        fps: >-
+            FPS: <fps> (<ms> ms)
+
 # All shop upgrades
 shopUpgrades:
     belt:


### PR DESCRIPTION
The F4 debug overlay (Tickrate, FPS & Tick duration) can now be translated.

I know that this doesn't need to be translated... so there is a comment in base-en.yaml stating this.
Only added English translations for this. At least this makes it a little less hard-coded.