### PR TITLE
Translate base-de.yaml settings

### DIFF
--- a/translations/base-de.yaml
+++ b/translations/base-de.yaml
@@ -436,10 +436,10 @@ buildings:
     cutter:
         default:
             name: &cutter Zerschneider
-            description: Zerschneidet Formen von oben nach unten und gibt beide aus. <strong>Wenn du nur eine Hälfte benutzst, stelle sicher das die andere zerstört wird, sonst verstopft die Maschine!</strong>
+            description: Zerschneidet Formen von oben nach unten. <strong>Benutze oder zerstöre beide Hälften, sonst verstopft die Maschine!</strong>
         quad:
-            name: Zerschneider (4-Fach)
-            description: Zerschneidet Formen in vier Teile. <strong>>Wenn du nur ein Viertel benutzst, stelle sicher das die anderen zerstört wird, sonst verstopft die Maschine!</strong>
+            name: Zerschneider (4-fach)
+            description: Zerschneidet Formen in vier Teile. <strong>>Benutze oder zerstöre alle Viertel, sonst verstopft die Maschine!</strong>
 
     rotater:
         default:
@@ -587,74 +587,72 @@ settings:
         uiScale:
             title: HUD Größe
             description: >-
-                Changes the size of the user interface. The interface will still scale based on your device resolution, but this setting controls the amount of scale.
+                Ändert die Größe der Benutzeroberfläche, basierend auf der Bildschirmauflösung.
             scales:
-                super_small: Super small
-                small: Small
-                regular: Regular
-                large: Large
-                huge: Huge
+                super_small: Sehr klein
+                small: Klein
+                regular: Normal
+                large: Groß
+                huge: Riesig
 
         scrollWheelSensitivity:
-            title: Zoom sensitivität
+            title: Zoomempfindlichkeit
             description: >-
-                Changes how sensitive the zoom is (Either mouse wheel or trackpad).
+                Ändert die Sensitivität des Zooms (Sowohl Mausrad, als auch Trackpad).
             sensitivity:
-                super_slow: Super slow
-                slow: Slow
-                regular: Regular
-                fast: Fast
-                super_fast: Super fast
+                super_slow: Sehr langsam
+                slow: Langsam
+                regular: Normal
+                fast: Schnell
+                super_fast: Sehr schnell
 
         fullscreen:
             title: Vollbild
             description: >-
-                It is recommended to play the game in fullscreen to get the best experience. Only available in the standalone.
+                Für das beste Erlebnis im Spiel wird der Vollbildmodus empfohlen (Nur in der Standalone-Version verfügbar).
 
         soundsMuted:
-            title: Sounds stummschalten
+            title: Geräusche stummschalten
             description: >-
-                If enabled, mutes all sound effects.
+                Bei Aktivierung werden alle Geräusche stummgeschaltet.
 
         musicMuted:
-            title: Music stummschalten
+            title: Musik stummschalten
             description: >-
-                If enabled, mutes all music.
+                Bei Aktivierung wird die Musik stummgeschaltet.
 
         theme:
-            title: Spiel-Thema
+            title: Farbmodus
             description: >-
-                Choose the game theme (light / dark).
+                Wähle zwischen dunklem und hellem Farbmodus.
 
             themes:
-                dark: Dark
-                light: Light
-
+                dark: Dunkel
+                light: Hell
         refreshRate:
-            title: Simulations-Ziel
+            title: Zielbildwiederholrate
             description: >-
-                If you have a 144hz monitor, change the refresh rate here so the game will properly simulate at higher refresh rates. This might actually decrease the FPS if your computer is too slow.
+                Für z.B einen 144-Hz-Monitor kann die Bildwiederholrate hier korrekt eingestellt werden. Bei einem zu langsamen Computer kann dies die Leistung beeinträchtigen.
 
         alwaysMultiplace:
             title: Mehrfachplatzierung
             description: >-
-                If enabled, all buildings will stay selected after placement until you cancel it. This is equivalent to holding SHIFT permanently.
+                Bei Aktivierung wird das platzierte Gebäude nicht abgewählt. Das hat den gleichen Effekt wie beim Platzieren permanent UMSCH gedrückt zu halten.
 
         offerHints:
             title: Hinweise & Tutorials
             description: >-
-                Whether to offer hints and tutorials while playing. Also hides certain UI elements onto a given level to make it easier to get into the game.
+                Schaltet Hinweise und das Tutorial beim Spielen an und aus. Außerdem werden zu den Levels bestimmte Textfelder versteckt, die den Einstieg erleichtern sollen.
 
         language:
-            title: Language
+            title: Sprache
             description: >-
-                Change the language. All translations are user contributed and might be
-                incomplete!
+                Ändere die Sprache. Alle Übersetzungen werden von Nutzern erstellt und sind möglicherweise unvollständig!
 
 keybindings:
     title: Tastenkürzel
     hint: >-
-        Tipp: Benutze STRG, UMSCH and ALT! Sie aktivieren verschiedene Platzierungs-Optionen!
+        Tipp: Benutze STRG, UMSCH and ALT! Sie aktivieren verschiedene Platzierungsoptionen!
 
     resetKeybindings: Tastenkürzel zurücksetzen.
 


### PR DESCRIPTION
Translated the settings section and shortened two building descriptions, causing the game to display the UI in a strange way. Minor grammar checking.