### PR TITLE
Made About this game translatable

### DIFF
--- a/src/js/states/about.js
+++ b/src/js/states/about.js
@@ -15,17 +15,9 @@ export class AboutState extends TextualGameState {
     }
 
     getMainContentHTML() {
-        return `
-            This game is open source and developed by <a href="https://github.com/tobspr" target="_blank">Tobias Springer</a> (this is me).
-            <br><br>
-            If you want to contribute, check out <a href="${THIRDPARTY_URLS.github}" target="_blank">shapez.io on github</a>.
-            <br><br>
-            This game wouldn't have been possible without the great discord community around my games - You should really join the <a href="${THIRDPARTY_URLS.discord}" target="_blank">discord server</a>!
-            <br><br>
-            The soundtrack was made by <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsen</a> - He's awesome. 
-            <br><br>
-            Finally, huge thanks to my best friend <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Without our factorio sessions this game would never have existed. 
-        `;
+        return T.about.body
+            .replace("<githublink>", THIRDPARTY_URLS.github)
+            .replace("<discordlink>", THIRDPARTY_URLS.discord);
     }
 
     onEnter() {

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -729,6 +729,12 @@ keybindings:
 
 about:
     title: About this Game
+    body: >-
+        This game is open source and developed by <a href="https://github.com/tobspr" target="_blank">Tobias Springer</a> (this is me).<br><br>
+        If you want to contribute, check out <a href="<githublink>" target="_blank">shapez.io on github</a>.<br><br>
+        This game wouldn't have been possible without the great discord community around my games - You should really join the <a href="<discordlink>" target="_blank">discord server</a>!<br><br>
+        The soundtrack was made by <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsen</a> - He's awesome.<br><br>
+        Finally, huge thanks to my best friend <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Without our factorio sessions this game would never have existed. 
 
 changelog:
     title: Changelog

--- a/translations/base-pl.yaml
+++ b/translations/base-pl.yaml
@@ -745,6 +745,12 @@ keybindings:
 
 about:
     title: O Grze
+    body: >-
+        Ta gra jest open-source. Rozwijana jest przez <a href="https://github.com/tobspr" target="_blank">Tobiasa Springera</a> (to ja).<br><br>
+        Jeżeli chcesz pomóc w rozwoju gry, sprawdź <a href="<githublink>" target="_blank">repozytorium shapez.io na Githubie</a>.<br><br>
+        Ta gra nie byłaby możliwa bez wspaniałej społeczności Discord skupionej na moich grach - Naprawdę powinieneś dołączyć do <a href="<discordlink>" target="_blank">mojego serwera Discord</a>!<br><br>
+        Ścieżka dźwiękowa tej gry została stworzona przez <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsena</a> - Jest niesamowity.<br><br>
+        Na koniec, wielkie dzięki mojemu najlepszemu przyjacielowi: <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Bez naszego wspólnego grania w Factorio, ta gra nigdy by nie powstała.
 
 changelog:
     title: Dziennik zmian


### PR DESCRIPTION
Made the `About this game` section body translatable. It looks like it wouldn't change, so I added a translation key to be able to translate this to all supported languages.

Quick summary:
- [x] Added new translation key: `about.body` - For translating the `About this game` section's body
- [x] Translated `about.body` to Polish
- [x] Tested if this works - it works. 