### PR TITLE
Fix keybindings button label text not changing with language

### DIFF
--- a/src/js/states/settings.js
+++ b/src/js/states/settings.js
@@ -19,7 +19,7 @@ export class SettingsState extends TextualGameState {
             ${
                 this.app.platformWrapper.getSupportsKeyboard()
                     ? `
-                        <button class="styledButton editKeybindings">Keybindings</button>
+                        <button class="styledButton editKeybindings">${T.keybindings.title}</button>
             `
                     : ""
             }


### PR DESCRIPTION
Before this PR the keybindings button (in settings) had the same label text, regardless of selected language. This PR fixes that. It's label text is now pulled from translations in the same way, as the `About this game` button does (which is next to it and didn't have this bug). This is a simple, 1-line fix.