### PR TITLE
Add keybind to enable/disable vignette effect.

### DIFF
--- a/src/js/game/hud/parts/vignette_overlay.js
+++ b/src/js/game/hud/parts/vignette_overlay.js
@@ -1,10 +1,23 @@
 import { BaseHUDPart } from "../base_hud_part";
 import { makeDiv } from "../../../core/utils";
+import { DynamicDomAttach } from "../dynamic_dom_attach";
+import { KEYMAPPINGS } from "../../key_action_mapper";
 
 export class HUDVignetteOverlay extends BaseHUDPart {
     createElements(parent) {
         this.element = makeDiv(parent, "ingame_VignetteOverlay");
     }
 
-    initialize() {}
+    initialize() {
+        this.visible = true;
+        this.domAttach = new DynamicDomAttach(this.root, this.element);
+        this.domAttach.update(this.visible);
+
+        this.root.keyMapper.getBinding(KEYMAPPINGS.ingame.toggleVignette).add(() => this.toggle());
+    }
+
+    toggle() {
+        this.visible = !this.visible;
+        this.domAttach.update(this.visible);
+    }
 }

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -26,6 +26,7 @@ export const KEYMAPPINGS = {
         toggleHud: { keyCode: 113 }, // F2
         exportScreenshot: { keyCode: 114 }, // F3
         toggleFPSInfo: { keyCode: 115 }, // F4
+        toggleVignette: { keyCode: 116 }, // F5
     },
 
     navigation: {

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -704,6 +704,7 @@ keybindings:
         toggleHud: Toggle HUD
         toggleFPSInfo: Toggle FPS and Debug Info
         exportScreenshot: Export whole Base as Image
+        toggleVignette: Toggle Vignette Effect
         belt: *belt
         splitter: *splitter
         underground_belt: *underground_belt


### PR DESCRIPTION
By default, the button is F5 (displays as F4 ingame due to a bug). Useful for taking building screenshots. I also personally don't like vignette effects, but here everything is way too bright when you disable it.