### PR TITLE
Fix camera inertia problem with mouse movement

### DIFF
--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -722,7 +722,7 @@ export class Camera extends BasicSerializableObject {
             this.currentlyPinching = false;
             this.lastMovingPosition = null;
             this.lastMovingPositionLastTick = null;
-            this.numTicksStandingStill = null;
+            this.numTicksStandingStill = 0;
             this.lastPinchPositions = null;
             this.userInteraction.dispatch(USER_INTERACT_TOUCHEND);
             this.didMoveSinceTouchStart = false;
@@ -822,12 +822,15 @@ export class Camera extends BasicSerializableObject {
 
         // Check if the camera is being dragged but standing still: if not, zero out `touchPostMoveVelocity`.
         if (this.currentlyMoving && this.desiredCenter === null) {
-            if (this.lastMovingPositionLastTick === this.lastMovingPosition) {
-                this.numTicksStandingStill += 1;
+            if (
+                this.lastMovingPositionLastTick !== null &&
+                this.lastMovingPositionLastTick.equalsEpsilon(this.lastMovingPosition)
+            ) {
+                this.numTicksStandingStill++;
             } else {
                 this.numTicksStandingStill = 0;
             }
-            this.lastMovingPositionLastTick = this.lastMovingPosition;
+            this.lastMovingPositionLastTick = this.lastMovingPosition.copy();
 
             if (this.numTicksStandingStill >= ticksBeforeErasingVelocity) {
                 this.touchPostMoveVelocity.x = 0;


### PR DESCRIPTION
Currently when moving the camera with the mouse, there is an annoying feature that if you hold the camera still and then let go, there is some stored velocity that gets applied after you let go instead of it just staying still where you let go. I fix this behavior by adding some code to `internalUpdatePanning()` that checks if `lastMovingPosition` has been constant for the last 2 ticks: if it has, then zero out `touchPostMoveVelocity`. 

Note: I have not tested this on touch devices, and that should probably be done before pulling this.