### PR TITLE
Fix bug where belts in blueprints don't orient correctly.

### DIFF
--- a/src/js/game/hud/parts/blueprint.js
+++ b/src/js/game/hud/parts/blueprint.js
@@ -203,10 +203,10 @@ export class Blueprint {
                                     "Can not delete entity for blueprint"
                                 );
                                 if (!root.logic.tryDeleteBuilding(contents)) {
-                                    logger.error(
+                                    assertAlways(
+                                        false,
                                         "Building has replaceable component but is also unremovable in blueprint"
                                     );
-                                    return false;
                                 }
                             }
                         }

--- a/src/js/game/hud/parts/blueprint.js
+++ b/src/js/game/hud/parts/blueprint.js
@@ -176,6 +176,7 @@ export class Blueprint {
     tryPlace(root, tile) {
         return root.logic.performBulkOperation(() => {
             let anyPlaced = false;
+            const beltsToRegisterLater = [];
             for (let i = 0; i < this.entities.length; ++i) {
                 let placeable = true;
                 const entity = this.entities[i];
@@ -215,9 +216,21 @@ export class Blueprint {
                     clone.components.StaticMapEntity.origin.addInplace(tile);
 
                     root.map.placeStaticEntity(clone);
-                    root.entityMgr.registerEntity(clone);
+
+                    // Registering a belt immediately triggers a recalculation of surrounding belt
+                    // directions, which is no good when not all belts have been placed. To resolve
+                    // this, only register belts after all entities have been placed.
+                    if (!clone.components.Belt) {
+                        root.entityMgr.registerEntity(clone);
+                    } else {
+                        beltsToRegisterLater.push(clone);
+                    }
                     anyPlaced = true;
                 }
+            }
+
+            for (let i = 0; i < beltsToRegisterLater.length; i++) {
+                root.entityMgr.registerEntity(beltsToRegisterLater[i]);
             }
             return anyPlaced;
         });


### PR DESCRIPTION
The bug: copying the left hand side results in the right hand side when pasted.
![image](https://user-images.githubusercontent.com/25755516/84611322-7a136500-ae8b-11ea-838e-4d360f3955d5.png)

The problem: This is happening because as part of `EntityManager.registerEntity`, the `entityAdded` signal is raised immediately, which then is received by `BeltSystem.updateSurroundingBeltPlacement`, which is a problem since we are reorienting the belt before all the belts have been placed down, resulting in the belt changing from the correct direction to the wrong direction. 

The fix: We simply don't register belt entities until all entities from the blueprint have been placed down, ensuring that `BeltSystem.updateSurroundingBeltPlacement` won't change the direction of the belt since all the belts are actually down.