### PR TITLE
Statistics screen will now sort pinned shapes above non-pinned shapes

### DIFF
--- a/src/css/ingame_hud/statistics.scss
+++ b/src/css/ingame_hud/statistics.scss
@@ -80,6 +80,7 @@
             background: #f4f4f4;
             @include S(margin-bottom, 4px);
             display: grid;
+            position: relative;
 
             @include DarkThemeOverride {
                 background: #222428;
@@ -102,6 +103,19 @@
                 @include SuperSmallText;
 
                 @include S(padding, 0, 3px);
+            }
+
+            div.pin {
+                @include S(width, 12px);
+                @include S(height, 12px);
+                @include S(padding, 0px);
+                background: uiResource("icons/pin.png") center center / 95% no-repeat;
+                position: absolute;
+
+                opacity: 0.6;
+                transition: opacity 0.12s ease-in-out;
+
+                @include DarkThemeInvert;
             }
         }
     }
@@ -135,6 +149,13 @@
                     background: rgba(0, 10, 20, 0.05);
                     justify-self: end;
                 }
+
+                .pin {
+                    grid-column: 2 / 2;
+                    grid-row: 1 / 3;
+                    @include S(top, 4px);
+                    @include S(right, 8px);
+                }
             }
         }
         &[data-displaymode="detailed"] .content.hasEntries {
@@ -151,6 +172,13 @@
                     align-self: center;
                     text-align: right;
                     color: #55595a;
+                }
+
+                .pin {
+                    grid-column: 1 / 2;
+                    grid-row: 1 / 3;
+                    @include S(top, 4px);
+                    @include S(left, 40px);
                 }
 
                 canvas.graph {

--- a/src/css/ingame_hud/statistics.scss
+++ b/src/css/ingame_hud/statistics.scss
@@ -105,7 +105,7 @@
                 @include S(padding, 0, 3px);
             }
 
-            div.pin {
+            button.pin {
                 @include S(width, 12px);
                 @include S(height, 12px);
                 @include S(padding, 0px);
@@ -114,8 +114,50 @@
 
                 opacity: 0.6;
                 transition: opacity 0.12s ease-in-out;
+                opacity: 0.6;
+                cursor: pointer;
+                pointer-events: all;
+                @include IncreasedClickArea(5px);
+                transition: opacity 0.12s ease-in-out;
 
                 @include DarkThemeInvert;
+
+                $disabledOpacity: 0.2;
+                $enabledOpacity: 0.6;
+
+                &:hover {
+                    opacity: $enabledOpacity + 0.1;
+                }
+
+                &.alreadyPinned {
+                    opacity: $disabledOpacity !important;
+
+                    &:hover {
+                        opacity: $disabledOpacity + 0.1 !important;
+                    }
+                }
+
+                &.isGoal {
+                    background: uiResource("icons/current_goal_marker.png") center center / 95%
+                        no-repeat;
+                    opacity: $disabledOpacity !important;
+                    cursor: default;
+                    pointer-events: none;
+                }
+
+                &.pinned {
+                    opacity: $disabledOpacity;
+                    &:hover {
+                        opacity: $disabledOpacity + 0.1;
+                    }
+                }
+
+                &.unpinned {
+                    opacity: $enabledOpacity;
+                    &:hover {
+                        opacity: $enabledOpacity + 0.1;
+                    }
+                }
             }
         }
     }

--- a/src/js/game/hud/parts/statistics.js
+++ b/src/js/game/hud/parts/statistics.js
@@ -175,7 +175,15 @@ export class HUDStatistics extends BaseHUDPart {
             }
         }
 
-        entries.sort((a, b) => b[1] - a[1]);
+        // Reach into the Hud to get the object that tracks which parts are pinned
+        const { pinnedShapes } = this.root.hud.parts;
+        entries.sort((a, b) => {
+            // do a sort calculation based on if the shapes are pinned
+            const pinSort =
+                Number(pinnedShapes.isShapePinned(b[0])) - Number(pinnedShapes.isShapePinned(a[0]));
+            // if the pinning of shapes is not equal, sort on that, otherwise, sort on the rates
+            return pinSort !== 0 ? pinSort : b[1] - a[1];
+        });
 
         let rendered = new Set();
 

--- a/src/js/game/hud/parts/statistics.js
+++ b/src/js/game/hud/parts/statistics.js
@@ -96,6 +96,11 @@ export class HUDStatistics extends BaseHUDPart {
 
         this.lastFullRerender = 0;
 
+        // since pinning shapes changes sort-order, the list should rerender
+        // every time a shape is pinned or unpinned
+        this.root.hud.signals.shapePinRequested.add(this.rerenderFull, this);
+        this.root.hud.signals.shapeUnpinRequested.add(this.rerenderFull, this);
+
         this.close();
         this.rerenderFull();
     }

--- a/src/js/game/hud/parts/statistics_handle.js
+++ b/src/js/game/hud/parts/statistics_handle.js
@@ -36,11 +36,11 @@ export class HUDShapeStatisticsHandle {
         this.element.setAttribute("data-shape-key", shape);
         const pinButton = document.createElement("button");
         pinButton.classList.add("pin");
-        const pinDetector = new ClickDetector(pinButton, {
+        this.pinDetector = new ClickDetector(pinButton, {
             consumeEvents: true,
             preventDefault: true,
         });
-        pinDetector.click.add(() => {
+        this.pinDetector.click.add(() => {
             if (this.root.hud.parts.pinnedShapes.isShapePinned(shape)) {
                 this.root.hud.signals.shapeUnpinRequested.dispatch(shape);
             } else {
@@ -236,6 +236,11 @@ export class HUDShapeStatisticsHandle {
             this.graphCanvas.remove();
             delete this.graphCanvas;
             delete this.graphContext;
+        }
+
+        if (this.pinDetector) {
+            this.pinDetector.cleanup();
+            delete this.pinDetector;
         }
     }
 

--- a/src/js/game/hud/parts/statistics_handle.js
+++ b/src/js/game/hud/parts/statistics_handle.js
@@ -32,7 +32,11 @@ export class HUDShapeStatisticsHandle {
     initElement() {
         this.element = document.createElement("div");
         this.element.setAttribute("data-shape-key", this.definition.getHash());
-
+        if (this.root.hud.parts.pinnedShapes.isShapePinned(this.definition.getHash())) {
+            const pinButton = document.createElement("div");
+            pinButton.classList.add("pin");
+            this.element.appendChild(pinButton);
+        }
         this.counter = document.createElement("span");
         this.counter.classList.add("counter");
         this.element.appendChild(this.counter);


### PR DESCRIPTION
Issue #54

> Improvement: Pinned Shapes should be on top of the list in the Statistics Dialog
This would make it easier to check progress on the shapes that the player has already marked as important.

This code change causes pinned shapes to appear at the top of the list in the statistics dialog. Items with the same pin status are sorted as normal.
![image](https://user-images.githubusercontent.com/1641167/84728677-60d7ea80-af57-11ea-8b2e-0183e3333383.png)


