### PR TITLE
Fixed standalone only setting hint not being translated

### DIFF
--- a/src/js/profile/setting_types.js
+++ b/src/js/profile/setting_types.js
@@ -7,8 +7,6 @@ import { T } from "../translations";
 
 const logger = createLogger("setting_types");
 
-const standaloneOnlySettingHtml = `<span class="standaloneOnlyHint">${T.demo.settingNotAvailable}</span>`;
-
 export class BaseSetting {
     /**
      *
@@ -115,7 +113,7 @@ export class EnumSetting extends BaseSetting {
     getHtml() {
         return `
             <div class="setting cardbox ${this.enabled ? "enabled" : "disabled"}">
-                ${this.enabled ? "" : standaloneOnlySettingHtml}
+                ${this.enabled ? "" : `<span class="standaloneOnlyHint">${T.demo.settingNotAvailable}</span>`}
                 <div class="row">
                     <label>${T.settings.labels[this.id].title}</label>
                     <div class="value enum" data-setting="${this.id}"></div>
@@ -189,7 +187,7 @@ export class BoolSetting extends BaseSetting {
     getHtml() {
         return `
         <div class="setting cardbox ${this.enabled ? "enabled" : "disabled"}">
-            ${this.enabled ? "" : standaloneOnlySettingHtml}
+            ${this.enabled ? "" : `<span class="standaloneOnlyHint">${T.demo.settingNotAvailable}</span>`}
                 
             <div class="row">
                 <label>${T.settings.labels[this.id].title}</label>


### PR DESCRIPTION
This PR fixes that "Not available in demo" text always being in english, even if english wasn't the selected language.
This does not add any new translation keys, as one was already present.