### PR TITLE
German suffix for large numbers corrected

### DIFF
--- a/translations/base-de.yaml
+++ b/translations/base-de.yaml
@@ -76,9 +76,9 @@ global:
     # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
     suffix:
         thousands: T
-        millions: M
-        billions: B
-        trillions: tr
+        millions: Mio
+        billions: Mrd
+        trillions: Bio
 
     # Shown for infinitely big numbers
     infinite: unend

--- a/translations/base-de.yaml
+++ b/translations/base-de.yaml
@@ -75,10 +75,10 @@ global:
 
     # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
     suffix:
-        thousands: T
-        millions: Mio
-        billions: Mrd
-        trillions: Bio
+        thousands: k
+        millions: M
+        billions: G
+        trillions: T
 
     # Shown for infinitely big numbers
     infinite: unend


### PR DESCRIPTION
Changed the suffix for large numbers to reflect the German naming convention.
million -> "Millionen" (Mio)
billion-> "Milliarden" (Mrd)
trillion -> "Billionen" (Bio)