### PR TITLE
Fix crash when deleting buildings.

### DIFF
--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -162,6 +162,7 @@ export class HUDBuildingPlacer extends BaseHUDPart {
 
             // Check for direction lock
             if (
+                metaBuilding &&
                 metaBuilding.getHasDirectionLockAvailable() &&
                 this.root.keyMapper.getBinding(KEYMAPPINGS.placement.lockBeltDirection).isCurrentlyPressed()
             ) {


### PR DESCRIPTION
Can't check getHasDirectionLockAvailable() on a building you are currently deleting because it doesn't exist.