### PR TITLE
Optimize ejector cache

### DIFF
--- a/src/js/game/components/item_ejector.js
+++ b/src/js/game/components/item_ejector.js
@@ -3,13 +3,16 @@ import { BaseItem } from "../base_item";
 import { Component } from "../component";
 import { types } from "../../savegame/serialization";
 import { gItemRegistry } from "../../core/global_registries";
+import { Entity } from "../entity";
 
 /**
  * @typedef {{
  *    pos: Vector,
  *    direction: enumDirection,
  *    item: BaseItem,
- *    progress: number?
+ *    progress: number?,
+ *    cachedDestSlot?: import("./item_acceptor").ItemAcceptorLocatedSlot,
+ *    cachedTargetEntity?: Entity
  * }} ItemEjectorSlot
  */
 
@@ -19,6 +22,8 @@ export class ItemEjectorComponent extends Component {
     }
 
     static getSchema() {
+        // The cachedDestSlot, cachedTargetEntity, and cachedConnectedSlots fields
+        // are not serialized.
         return {
             instantEject: types.bool,
             slots: types.array(
@@ -61,6 +66,9 @@ export class ItemEjectorComponent extends Component {
         this.instantEject = instantEject;
 
         this.setSlots(slots);
+
+        /** @type {ItemEjectorSlot[]} */
+        this.cachedConnectedSlots = null;
     }
 
     /**
@@ -76,6 +84,8 @@ export class ItemEjectorComponent extends Component {
                 direction: slot.direction,
                 item: null,
                 progress: 0,
+                cachedDestSlot: null,
+                cachedTargetEntity: null,
             });
         }
     }

--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -27,8 +27,8 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
     }
 
     /**
-     * 
-     * @param {Entity} entity 
+     *
+     * @param {Entity} entity
      */
     invalidateCache(entity) {
         if (!entity.components.StaticMapEntity) {
@@ -63,7 +63,6 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                 const entity = this.allEntities[i];
                 entryCount += this.recomputeSingleEntityCache(entity);
             }
-
         }
         logger.log("Found", entryCount, "entries to update");
 
@@ -71,8 +70,8 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
     }
 
     /**
-     * 
-     * @param {Rectangle} area 
+     *
+     * @param {Rectangle} area
      */
     recomputeAreaCaches(area) {
         let entryCount = 0;
@@ -88,8 +87,8 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
     }
 
     /**
-     * 
-     * @param {Entity} entity 
+     *
+     * @param {Entity} entity
      */
     recomputeSingleEntityCache(entity) {
         const ejectorComp = entity.components.ItemEjector;


### PR DESCRIPTION
This commit optimizes the ejector cache for clicking and dragging belts, or adding/removing a building. It's a big performance improvement for large maps; on average, it only has to visit 60 slots per update, compared to 20,000+ slots.