### PR TITLE
Clumsy clicker fix

### DIFF
--- a/src/js/core/click_detector.js
+++ b/src/js/core/click_detector.js
@@ -316,6 +316,7 @@ export class ClickDetector {
                 // Ignore right clicks
                 this.rightClick.dispatch(position, event);
                 this.cancelled = true;
+                this.clickDownPosition = null;
                 return;
             }
         }


### PR DESCRIPTION
Possible fix for Issue #189 

Reproduce issue by pressing left-mouse button over UI button. While left-button is depressed, click right-button. Release left-button.  UI button no longer responds to clicks. Console warning `Ignoring double click` is visible when left-button is clicked on UI button.

Solution:
Since right-mouse button sets `ClickDetector.cancelled = true` the mouse-up handler is never able to clear `ClickDetector.clickDownPosition`. So clear `clickDownPosition` when `cancelled` is set to `true`.