### PR TITLE
Rotation remembered by building type

### DIFF
--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -82,9 +82,9 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
         this.buildingInfoElements.tutorialImage.setAttribute(
             "data-icon",
             "building_tutorials/" +
-            metaBuilding.getId() +
-            (variant === defaultBuildingVariant ? "" : "-" + variant) +
-            ".png"
+                metaBuilding.getId() +
+                (variant === defaultBuildingVariant ? "" : "-" + variant) +
+                ".png"
         );
 
         removeAllChildren(this.buildingInfoElements.additionalInfo);
@@ -122,10 +122,10 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
             T.ingame.buildingPlacement.cycleBuildingVariants.replace(
                 "<key>",
                 "<code class='keybinding'>" +
-                this.root.keyMapper
-                    .getBinding(KEYMAPPINGS.placement.cycleBuildingVariants)
-                    .getKeyCodeString() +
-                "</code>"
+                    this.root.keyMapper
+                        .getBinding(KEYMAPPINGS.placement.cycleBuildingVariants)
+                        .getKeyCodeString() +
+                    "</code>"
             )
         );
 

--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -82,9 +82,9 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
         this.buildingInfoElements.tutorialImage.setAttribute(
             "data-icon",
             "building_tutorials/" +
-                metaBuilding.getId() +
-                (variant === defaultBuildingVariant ? "" : "-" + variant) +
-                ".png"
+            metaBuilding.getId() +
+            (variant === defaultBuildingVariant ? "" : "-" + variant) +
+            ".png"
         );
 
         removeAllChildren(this.buildingInfoElements.additionalInfo);
@@ -122,10 +122,10 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
             T.ingame.buildingPlacement.cycleBuildingVariants.replace(
                 "<key>",
                 "<code class='keybinding'>" +
-                    this.root.keyMapper
-                        .getBinding(KEYMAPPINGS.placement.cycleBuildingVariants)
-                        .getKeyCodeString() +
-                    "</code>"
+                this.root.keyMapper
+                    .getBinding(KEYMAPPINGS.placement.cycleBuildingVariants)
+                    .getKeyCodeString() +
+                "</code>"
             )
         );
 
@@ -201,7 +201,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
         } = metaBuilding.computeOptimalDirectionAndRotationVariantAtTile(
             this.root,
             mouseTile,
-            this.currentBaseRotation,
+            this.getBaseRotation(),
             this.currentVariant.get()
         );
 

--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -201,7 +201,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
         } = metaBuilding.computeOptimalDirectionAndRotationVariantAtTile(
             this.root,
             mouseTile,
-            this.getBaseRotation(),
+            this.currentBaseRotation,
             this.currentVariant.get()
         );
 

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -128,9 +128,9 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         if (!this.root.app.settings.getAllSettings().rotationByBuilding) {
             return this.currentBaseRotationGeneral;
         }
-        const building = this.currentMetaBuilding.get();
-        if (building != undefined && this.preferredBaseRotations.hasOwnProperty(building.getId())) {
-            return this.preferredBaseRotations[building.getId()];
+        const metaBuilding = this.currentMetaBuilding.get();
+        if (metaBuilding && this.preferredBaseRotations.hasOwnProperty(metaBuilding.getId())) {
+            return this.preferredBaseRotations[metaBuilding.getId()];
         } else {
             return this.currentBaseRotationGeneral;
         }
@@ -138,14 +138,15 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
     /**
      * Sets the base rotation for the current meta-building.
+     * @param {number} rotation The new rotation/angle.
      */
     set currentBaseRotation(rotation) {
         if (!this.root.app.settings.getAllSettings().rotationByBuilding) {
             this.currentBaseRotationGeneral = rotation;
         } else {
-            const building = this.currentMetaBuilding.get();
-            if (building != undefined) {
-                this.preferredBaseRotations[building.getId()] = rotation;
+            const metaBuilding = this.currentMetaBuilding.get();
+            if (metaBuilding) {
+                this.preferredBaseRotations[metaBuilding.getId()] = rotation;
             } else {
                 this.currentBaseRotationGeneral = rotation;
             }

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -125,26 +125,30 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
      * @returns {number}
      */
     get currentBaseRotation() {
-        const rotationByBuilding = this.root.app.settings.getAllSettings().rotationByBuilding;
-        if (!rotationByBuilding) {
+        if (!this.root.app.settings.getAllSettings().rotationByBuilding) {
             return this.currentBaseRotationGeneral;
         }
-        const id = this.currentMetaBuilding.get().getId();
-        return this.preferredBaseRotations[id] == null
-            ? this.currentBaseRotationGeneral
-            : this.preferredBaseRotations[id];
+        const building = this.currentMetaBuilding.get();
+        if (building != undefined && this.preferredBaseRotations.hasOwnProperty(building.getId())) {
+            return this.preferredBaseRotations[building.getId()];
+        } else {
+            return this.currentBaseRotationGeneral;
+        }
     }
 
     /**
      * Sets the base rotation for the current meta-building.
      */
     set currentBaseRotation(rotation) {
-        const rotationByBuilding = this.root.app.settings.getAllSettings().rotationByBuilding;
-        if (!rotationByBuilding) {
+        if (!this.root.app.settings.getAllSettings().rotationByBuilding) {
             this.currentBaseRotationGeneral = rotation;
         } else {
-            const id = this.currentMetaBuilding.get().getId();
-            this.preferredBaseRotations[id] = rotation;
+            const building = this.currentMetaBuilding.get();
+            if (building != undefined) {
+                this.preferredBaseRotations[building.getId()] = rotation;
+            } else {
+                this.currentBaseRotationGeneral = rotation;
+            }
         }
     }
 

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -1,4 +1,3 @@
-
 import { Math_abs, Math_degrees, Math_round } from "../../../core/builtins";
 import { globalConfig } from "../../../core/config";
 import { gMetaBuildingRegistry } from "../../../core/global_registries";
@@ -61,8 +60,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             }
             const id = this.currentMetaBuilding.get().getId();
             return this.preferredRotations[id] || this.currentBaseRotationGeneral;
-
-        }
+        };
 
         this.setBaseRotation = function (rotation) {
             const rotationByBuilding = this.root.app.settings.getAllSettings().rotationByBuilding;
@@ -72,8 +70,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
                 const id = this.currentMetaBuilding.get().getId();
                 this.preferredRotations[id] = rotation;
             }
-        }
-
+        };
 
         /**
          * Whether we are currently dragging

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -530,7 +530,6 @@ export class ApplicationSettings extends ReadWriteProxy {
         }
 
         if (data.version < 13) {
-<<<<<<< HEAD
             data.settings.compactBuildingInfo = false;
             data.version = 13;
         }
@@ -554,11 +553,10 @@ export class ApplicationSettings extends ReadWriteProxy {
         if (data.version < 17) {
             data.settings.enableColorBlindHelper = false;
             data.version = 17;
-=======
+        }
+        if(data.version < 18) {
             data.settings.rotationByBuilding = true;
-            data.version = 13;
-
->>>>>>> 655c356... Adds tracking for rotation per building type.
+            data.version = 18;
         }
 
         return ExplainedResult.good();

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -248,7 +248,7 @@ export const allApplicationSettings = [
 
     new BoolSetting("alwaysMultiplace", categoryGame, (app, value) => {}),
     new BoolSetting("enableTunnelSmartplace", categoryGame, (app, value) => {}),
-    new BoolSetting("vignette", categoryGame, (app, value) => {}),<<<<<<< HEAD
+    new BoolSetting("vignette", categoryGame, (app, value) => {}),
     new BoolSetting("compactBuildingInfo", categoryGame, (app, value) => {}),
     new BoolSetting("disableCutDeleteWarnings", categoryGame, (app, value) => {}),
     new BoolSetting("rotationByBuilding", categoryGame, (app, value) => {}),
@@ -279,7 +279,6 @@ class SettingsStorage {
         this.compactBuildingInfo = false;
         this.disableCutDeleteWarnings = false;
         this.rotationByBuilding = true;
-
 
         this.enableColorBlindHelper = false;
 
@@ -554,7 +553,7 @@ export class ApplicationSettings extends ReadWriteProxy {
             data.settings.enableColorBlindHelper = false;
             data.version = 17;
         }
-        if(data.version < 18) {
+        if (data.version < 18) {
             data.settings.rotationByBuilding = true;
             data.version = 18;
         }

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -248,9 +248,10 @@ export const allApplicationSettings = [
 
     new BoolSetting("alwaysMultiplace", categoryGame, (app, value) => {}),
     new BoolSetting("enableTunnelSmartplace", categoryGame, (app, value) => {}),
-    new BoolSetting("vignette", categoryGame, (app, value) => {}),
+    new BoolSetting("vignette", categoryGame, (app, value) => {}),<<<<<<< HEAD
     new BoolSetting("compactBuildingInfo", categoryGame, (app, value) => {}),
     new BoolSetting("disableCutDeleteWarnings", categoryGame, (app, value) => {}),
+    new BoolSetting("rotationByBuilding", categoryGame, (app, value) => {}),
 ];
 
 export function getApplicationSettingById(id) {
@@ -277,6 +278,8 @@ class SettingsStorage {
         this.vignette = true;
         this.compactBuildingInfo = false;
         this.disableCutDeleteWarnings = false;
+        this.rotationByBuilding = true;
+
 
         this.enableColorBlindHelper = false;
 
@@ -527,6 +530,7 @@ export class ApplicationSettings extends ReadWriteProxy {
         }
 
         if (data.version < 13) {
+<<<<<<< HEAD
             data.settings.compactBuildingInfo = false;
             data.version = 13;
         }
@@ -550,6 +554,11 @@ export class ApplicationSettings extends ReadWriteProxy {
         if (data.version < 17) {
             data.settings.enableColorBlindHelper = false;
             data.version = 17;
+=======
+            data.settings.rotationByBuilding = true;
+            data.version = 13;
+
+>>>>>>> 655c356... Adds tracking for rotation per building type.
         }
 
         return ExplainedResult.good();

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -721,6 +721,11 @@ settings:
             title: Vignette
             description: >-
                 Enables the vignette which darkens the screen corners and makes text easier to read.
+        
+        rotationByBuilding: 
+            title: Rotation by building type
+            description: >-
+                Each building type remembers the rotation you last set it to individually. This may be more comfortable if you frequently switch between placing different building types.
 
         compactBuildingInfo:
             title: Compact Building Infos


### PR DESCRIPTION
While playing the early game I noticed I was often needing to place painters in one direction and then place mixers in the opposite direction. That caused a lot of rotation key presses that kinda felt like busywork. 
Obviously blueprints eventually make this less of a hassle, but I still thought a setting allowing rotation to be set per building type instead of globally would make sense. 