### PR TITLE
Prevents some smart tunnel wrong belt removals (Issue #230).

### DIFF
--- a/src/js/game/systems/underground_belt.js
+++ b/src/js/game/systems/underground_belt.js
@@ -104,9 +104,13 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
                 return;
             }
 
-            // Remove any belts between entrance and exit which have the same direction
+            // Remove any belts between entrance and exit
+            // - which have the same direction
+            // - if the last belt is pointed into the exit
+            let endSameDirection = false;
             currentPos = tile.copy();
-            for (let i = 0; i < matchingEntrance.range; ++i) {
+            const end = matchingEntrance.range - 1;
+            for (let i = end; i >= 0; i--) {
                 currentPos.addInplace(offset);
 
                 const contents = this.root.map.getTileContent(currentPos);
@@ -121,9 +125,11 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
                     // It's a belt
                     if (
                         contentsBeltComp.direction === enumDirection.top &&
-                        enumAngleToDirection[contentsStaticComp.rotation] === direction
+                        enumAngleToDirection[contentsStaticComp.rotation] === direction &&
+                        (endSameDirection || i == end)
                     ) {
                         // It's same rotation, drop it
+                        endSameDirection = endSameDirection || i == end;
                         this.root.logic.tryDeleteBuilding(contents);
                     }
                 }


### PR DESCRIPTION
This is a simple fix to prevent the most common instances of smart tunnel placement removing belts it shouldn't. Belt removal is only performed if the final belt points in the same direction as the tunnel exit.
It does not pathfind to make sure the removed belt actually ends at the exit, so wrong removals can still be reproduced but should happen less. 
![HJY78GAdbc](https://user-images.githubusercontent.com/1004386/85196634-e521c900-b2db-11ea-9812-3ffac67f594f.gif)
