### PR TITLE
Cycle backwards through building types & variants

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -331,8 +331,11 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             );
 
             // #51 Cycle backwards if SHIFT is pressed
+            const cycleBackwards = this.root.keyMapper.getBinding(
+                KEYMAPPINGS.placement.cycleBuildingVariantsInverseModifier
+            ).pressed;
             let newIndex;
-            if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.cycleBuildingsInverseModifier).pressed) {
+            if (cycleBackwards) {
                 newIndex = (index - 1 + availableVariants.length) % availableVariants.length;
             } else {
                 newIndex = (index + 1) % availableVariants.length;

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -329,7 +329,15 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
                 index >= 0,
                 "Current variant was invalid: " + this.currentVariant.get() + " out of " + availableVariants
             );
-            const newIndex = (index + 1) % availableVariants.length;
+
+            // #51 Cycle backwards if SHIFT is pressed
+            let newIndex;
+            if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.cycleBuildingsInverseModifier).pressed) {
+                newIndex = (index - 1 + availableVariants.length) % availableVariants.length;
+            } else {
+                newIndex = (index + 1) % availableVariants.length;
+            }
+
             const newVariant = availableVariants[newIndex];
             this.currentVariant.set(newVariant);
 

--- a/src/js/game/hud/parts/buildings_toolbar.js
+++ b/src/js/game/hud/parts/buildings_toolbar.js
@@ -109,8 +109,15 @@ export class HUDBuildingsToolbar extends BaseHUDPart {
     }
 
     cycleBuildings() {
+        const cycleBackwards = this.root.keyMapper.getBinding(
+            KEYMAPPINGS.placement.cycleBuildingsInverseModifier
+        ).pressed;
         let newIndex = this.lastSelectedIndex;
-        for (let i = 0; i < toolbarBuildings.length; ++i, ++newIndex) {
+        for (
+            let i = 0;
+            i < toolbarBuildings.length;
+            ++i, newIndex += toolbarBuildings.length + (cycleBackwards ? -1 : 1)
+        ) {
             newIndex %= toolbarBuildings.length;
             const metaBuilding = gMetaBuildingRegistry.findByClass(toolbarBuildings[newIndex]);
             const handle = this.buildingHandles[metaBuilding.id];

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -61,6 +61,7 @@ export const KEYMAPPINGS = {
         rotateInverseModifier: { keyCode: 16 }, // SHIFT
         cycleBuildingVariants: { keyCode: key("T") },
         cycleBuildings: { keyCode: 9 }, // TAB
+        cycleBuildingsInverseModifier: { keyCode: 16 }, // SHIFT
         switchDirectionLockSide: { keyCode: key("R") },
     },
 

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -60,6 +60,7 @@ export const KEYMAPPINGS = {
         rotateWhilePlacing: { keyCode: key("R") },
         rotateInverseModifier: { keyCode: 16 }, // SHIFT
         cycleBuildingVariants: { keyCode: key("T") },
+        cycleBuildingVariantsInverseModifier: { keyCode: 16 }, // SHIFT
         cycleBuildings: { keyCode: 9 }, // TAB
         cycleBuildingsInverseModifier: { keyCode: 16 }, // SHIFT
         switchDirectionLockSide: { keyCode: key("R") },


### PR DESCRIPTION
Now users can cycle through the building types and variants using the `SHIFT` key.

- Cycle through building variants using `T`:
> ![cycle-t](https://user-images.githubusercontent.com/67031075/85202897-2ddb8100-b2e0-11ea-8434-3e873181bed8.gif)

- Cycle backwards through building variants using `SHIFT+T`:
> ![cycle-t-backwards](https://user-images.githubusercontent.com/67031075/85202907-451a6e80-b2e0-11ea-9d67-f85acd831432.gif)

- Cycle forward and backwards through the building types in the toolbar using `T` and `SHIFT+TAB`:
> ![cycle-toolbar](https://user-images.githubusercontent.com/67031075/85202915-52cff400-b2e0-11ea-9e91-9f844857e2af.gif)


This PR resolves #51 