### PR TITLE
Add option to disable warnings

### DIFF
--- a/src/js/game/hud/parts/mass_selector.js
+++ b/src/js/game/hud/parts/mass_selector.js
@@ -70,7 +70,10 @@ export class HUDMassSelector extends BaseHUDPart {
     }
 
     confirmDelete() {
-        if (this.selectedUids.size > 100) {
+        if (
+            !this.root.app.settings.getAllSettings().disableCutDeleteWarnings &&
+            this.selectedUids.size > 100
+        ) {
             const { ok } = this.root.hud.parts.dialogs.showWarning(
                 T.dialogs.massDeleteConfirm.title,
                 T.dialogs.massDeleteConfirm.desc.replace(
@@ -120,7 +123,10 @@ export class HUDMassSelector extends BaseHUDPart {
                 T.dialogs.blueprintsNotUnlocked.title,
                 T.dialogs.blueprintsNotUnlocked.desc
             );
-        } else if (this.selectedUids.size > 100) {
+        } else if (
+            !this.root.app.settings.getAllSettings().disableCutDeleteWarnings &&
+            this.selectedUids.size > 100
+        ) {
             const { ok } = this.root.hud.parts.dialogs.showWarning(
                 T.dialogs.massCutConfirm.title,
                 T.dialogs.massCutConfirm.desc.replace(

--- a/src/js/game/hud/parts/mass_selector.js
+++ b/src/js/game/hud/parts/mass_selector.js
@@ -77,7 +77,7 @@ export class HUDMassSelector extends BaseHUDPart {
                     "<count>",
                     "" + formatBigNumberFull(this.selectedUids.size)
                 ),
-                ["cancel:good", "ok:bad"]
+                ["cancel:good:escape", "ok:bad:enter"]
             );
             ok.add(() => this.doDelete());
         } else {
@@ -127,7 +127,7 @@ export class HUDMassSelector extends BaseHUDPart {
                     "<count>",
                     "" + formatBigNumberFull(this.selectedUids.size)
                 ),
-                ["cancel:good", "ok:bad"]
+                ["cancel:good:escape", "ok:bad:enter"]
             );
             ok.add(() => this.doCut());
         } else {

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -201,6 +201,7 @@ export const allApplicationSettings = [
     new BoolSetting("enableTunnelSmartplace", categoryGame, (app, value) => {}),
     new BoolSetting("vignette", categoryGame, (app, value) => {}),
     new BoolSetting("compactBuildingInfo", categoryGame, (app, value) => {}),
+    new BoolSetting("disableCutDeleteWarnings", categoryGame, (app, value) => {}),
 ];
 
 export function getApplicationSettingById(id) {
@@ -225,6 +226,7 @@ class SettingsStorage {
         this.enableTunnelSmartplace = true;
         this.vignette = true;
         this.compactBuildingInfo = false;
+        this.disableCutDeleteWarnings = false;
 
         /**
          * @type {Object.<string, number>}
@@ -414,7 +416,7 @@ export class ApplicationSettings extends ReadWriteProxy {
     }
 
     getCurrentVersion() {
-        return 13;
+        return 14;
     }
 
     /** @param {{settings: SettingsStorage, version: number}} data */
@@ -466,6 +468,10 @@ export class ApplicationSettings extends ReadWriteProxy {
             data.version = 13;
         }
 
+        if (data.version < 14) {
+            data.settings.disableCutDeleteWarnings = false;
+            data.version = 14;
+        }
         return ExplainedResult.good();
     }
 }

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -281,7 +281,7 @@ ingame:
         toggleHud: Toggle HUD
         placeBuilding: Place building
         createMarker: Create Marker
-        delete: Destroy
+        delete: Delete
         pasteLastBlueprint: Paste last blueprint
         lockBeltDirection: Enable belt planner
         plannerSwitchSide: Flip planner side
@@ -749,7 +749,7 @@ keybindings:
         rotateInverseModifier: >-
             Modifier: Rotate CCW instead
         cycleBuildingVariants: Cycle Variants
-        confirmMassDelete: Confirm Mass Delete
+        confirmMassDelete: Delete area
         pasteLastBlueprint: Paste last blueprint
         cycleBuildings: Cycle Buildings
         lockBeltDirection: Enable belt planner

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -692,6 +692,11 @@ settings:
             description: >-
                 Shortens info boxes for buildings by only showing their ratios. Otherwise a description and image is shown.
 
+        disableCutDeleteWarnings:
+            title: Disable Cut/Delete Warnings
+            description: >-
+                Disable the warning dialogs brought up when cutting/deleting more than 100 entities.
+
 keybindings:
     title: Keybindings
     hint: >-


### PR DESCRIPTION
Resolve issue #240 by adding a setting to disable the warning dialogs, making the dialogs interactable with keyboard, and changing some localizations slightly.