### PR TITLE
Change auto save interval to 10 min

### DIFF
--- a/src/js/game/automatic_save.js
+++ b/src/js/game/automatic_save.js
@@ -15,7 +15,7 @@ export const enumSavePriority = {
 const logger = createLogger("autosave");
 
 // Internals
-let MIN_INTERVAL_SECS = 60;
+let MIN_INTERVAL_SECS = 600;
 
 export class AutomaticSave {
     constructor(root) {


### PR DESCRIPTION
Due to late game save times taking 10+ seconds taking up 1/6 of in game time. 
When auto save while Quitting is already implemented,  a one minute interval seems excessive.