### PR TITLE
Fix Building Placer Sound Bug

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -389,7 +389,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             originalRotation: this.currentBaseRotation,
             building: this.currentMetaBuilding.get(),
             variant: this.currentVariant.get(),
-            sound: ((options.supressSound!=null)? !options.supressSound : true)
+            sound: options.suppressSound != null ? !options.suppressSound : true,
         });
 
         if (entity) {
@@ -456,11 +456,13 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
                 this.currentBaseRotation = rotation;
                 // Add supressSound flag
-                let addedBuilding = this.tryPlaceCurrentBuildingAt(tile, {supressSound: ((i==0||needSound)? false : true)});
-                if (!addedBuilding && (i==0 || needSound)){
-                  needSound = true;
-                }else {
-                  needSound = false;
+                let addedBuilding = this.tryPlaceCurrentBuildingAt(tile, {
+                    suppressSound: i == 0 || needSound ? false : true,
+                });
+                if (!addedBuilding && (i == 0 || needSound)) {
+                    needSound = true;
+                } else {
+                    needSound = false;
                 }
             }
         });

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -374,7 +374,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             return;
         }
 
-        // Set sound to true if no options.suppressSound or set to opposite of options.suppressSound.
+        // Set sound to the opposite of suppressSound.
         const sound = !suppressSound;
 
         const metaBuilding = this.currentMetaBuilding.get();

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -366,8 +366,9 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
     /**
      * Tries to place the current building at the given tile
      * @param {Vector} tile
+     * @param {Object} options
      */
-    tryPlaceCurrentBuildingAt(tile) {
+    tryPlaceCurrentBuildingAt(tile, options = {}) {
         if (this.root.camera.zoomLevel < globalConfig.mapChunkOverviewMinZoom) {
             // Dont allow placing in overview mode
             return;
@@ -388,6 +389,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             originalRotation: this.currentBaseRotation,
             building: this.currentMetaBuilding.get(),
             variant: this.currentVariant.get(),
+            sound: ((options.supressSound!=null)? !options.supressSound : true)
         });
 
         if (entity) {
@@ -447,12 +449,19 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
      */
     executeDirectionLockedPlacement() {
         const path = this.computeDirectionLockPath();
+        let needSound = false;
         this.root.logic.performBulkOperation(() => {
             for (let i = 0; i < path.length; ++i) {
                 const { rotation, tile } = path[i];
 
                 this.currentBaseRotation = rotation;
-                this.tryPlaceCurrentBuildingAt(tile);
+                // Add supressSound flag
+                let addedBuilding = this.tryPlaceCurrentBuildingAt(tile, {supressSound: ((i==0||needSound)? false : true)});
+                if (!addedBuilding && (i==0 || needSound)){
+                  needSound = true;
+                }else {
+                  needSound = false;
+                }
             }
         });
     }

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -368,14 +368,11 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
      * @param {Vector} tile
      * @param {boolean} suppressSound
      */
-    tryPlaceCurrentBuildingAt(tile, suppressSound = false) {
+    tryPlaceCurrentBuildingAt(tile, playSound = true) {
         if (this.root.camera.zoomLevel < globalConfig.mapChunkOverviewMinZoom) {
             // Dont allow placing in overview mode
             return;
         }
-
-        // Set sound to the opposite of suppressSound.
-        const sound = !suppressSound;
 
         const metaBuilding = this.currentMetaBuilding.get();
         const { rotation, rotationVariant } = metaBuilding.computeOptimalDirectionAndRotationVariantAtTile(
@@ -419,7 +416,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             }
 
             // Building has been placed, play sound
-            if (sound) {
+            if (playSound) {
                 this.root.soundProxy.playUi(metaBuilding.getPlacementSound());
             }
 
@@ -467,10 +464,11 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
                 /*
                   Trys to place building.
                   Includes check to see if we should play sound.
+                  2nd Argument is playSound.
                 */
                 const placedBuilding = this.tryPlaceCurrentBuildingAt(
                     tile,
-                    i == 0 || trySound ? false : true
+                    i == 0 || trySound ? true : false
                 );
                 /*
                   If placedBuilding is false then the building didn't place.

--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -151,9 +151,11 @@ export class GameLogic {
      * @param {number} param0.rotationVariant
      * @param {string} param0.variant
      * @param {MetaBuilding} param0.building
+     * @param {boolean} param0.sound
      * @returns {Entity}
      */
-    tryPlaceBuilding({ origin, rotation, rotationVariant, originalRotation, variant, building }) {
+    tryPlaceBuilding({ origin, rotation, rotationVariant, originalRotation, variant, building, sound  }) {
+        sound = (sound!==null)? sound : true; // Check for sound argument
         if (this.checkCanPlaceBuilding({ origin, rotation, rotationVariant, variant, building })) {
             // Remove any removeable entities below
             const checker = new StaticMapEntityComponent({
@@ -186,7 +188,10 @@ export class GameLogic {
                 variant,
             });
 
-            this.root.soundProxy.playUi(building.getPlacementSound());
+            // Play sound
+            if (sound){
+              this.root.soundProxy.playUi(building.getPlacementSound());
+            }
             return entity;
         }
         return null;

--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -154,8 +154,8 @@ export class GameLogic {
      * @param {boolean} param0.sound
      * @returns {Entity}
      */
-    tryPlaceBuilding({ origin, rotation, rotationVariant, originalRotation, variant, building, sound  }) {
-        sound = (sound!==null)? sound : true; // Check for sound argument
+    tryPlaceBuilding({ origin, rotation, rotationVariant, originalRotation, variant, building, sound }) {
+        sound = sound !== null ? sound : true; // Check for sound argument
         if (this.checkCanPlaceBuilding({ origin, rotation, rotationVariant, variant, building })) {
             // Remove any removeable entities below
             const checker = new StaticMapEntityComponent({
@@ -189,8 +189,8 @@ export class GameLogic {
             });
 
             // Play sound
-            if (sound){
-              this.root.soundProxy.playUi(building.getPlacementSound());
+            if (sound) {
+                this.root.soundProxy.playUi(building.getPlacementSound());
             }
             return entity;
         }

--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -6,7 +6,6 @@ import { StaticMapEntityComponent } from "./components/static_map_entity";
 import { Math_abs, performanceNow } from "../core/builtins";
 import { createLogger } from "../core/logging";
 import { MetaBeltBaseBuilding, arrayBeltVariantToRotation } from "./buildings/belt_base";
-import { SOUNDS } from "../platform/sound";
 import { round2Digits } from "../core/utils";
 
 const logger = createLogger("ingame/logic");
@@ -151,11 +150,9 @@ export class GameLogic {
      * @param {number} param0.rotationVariant
      * @param {string} param0.variant
      * @param {MetaBuilding} param0.building
-     * @param {boolean} param0.sound
      * @returns {Entity}
      */
-    tryPlaceBuilding({ origin, rotation, rotationVariant, originalRotation, variant, building, sound }) {
-        sound = sound !== null ? sound : true; // Check for sound argument
+    tryPlaceBuilding({ origin, rotation, rotationVariant, originalRotation, variant, building }) {
         if (this.checkCanPlaceBuilding({ origin, rotation, rotationVariant, variant, building })) {
             // Remove any removeable entities below
             const checker = new StaticMapEntityComponent({
@@ -188,10 +185,6 @@ export class GameLogic {
                 variant,
             });
 
-            // Play sound
-            if (sound) {
-                this.root.soundProxy.playUi(building.getPlacementSound());
-            }
             return entity;
         }
         return null;


### PR DESCRIPTION
Fixes the sound distortion when using the building placer caused by many buildings trying to play their sounds at once.
This will only play 1 building sound.
Includes checks for if the building was actually placed, so if no buildings were placed then no sound is played and can handle the first buildings not being placed but if at least one is placed it will work.