### PR TITLE
Fix duplicate waypoints with the same shape key displaying wrong

### DIFF
--- a/src/js/game/hud/parts/waypoints.js
+++ b/src/js/game/hud/parts/waypoints.js
@@ -153,7 +153,16 @@ export class HUDWaypoints extends BaseHUDPart {
 
             if (ShapeDefinition.isValidShortKey(label)) {
                 const canvas = this.getWaypointCanvas(waypoint);
-                element.appendChild(canvas);
+                /**
+                 * Create a clone of the cached canvas, as calling appendElement when a canvas is
+                 * already in the document will move the existing canvas to the new position.
+                 */
+                const [newCanvas, context] = makeOffscreenBuffer(48, 48, {
+                    smooth: true,
+                    label: canvas.label + "-waypoint-" + i,
+                });
+                context.drawImage(canvas, 0, 0);
+                element.appendChild(newCanvas);
                 element.classList.add("shapeIcon");
             } else {
                 element.innerText = label;


### PR DESCRIPTION
Fix #294. The reason this happened is because if you call appendElement twice with the same canvas, it will simply move the existing canvas to the new position rather than produce a copy of the canvas. The way to resolve this is to duplicate the canvas before attaching it to the waypoint display.

![image](https://user-images.githubusercontent.com/25755516/85786733-881d7d00-b6f8-11ea-883e-1dd1723779bf.png)
