### PR TITLE
Mirror buildings and blueprints

### DIFF
--- a/src/js/core/vector.js
+++ b/src/js/core/vector.js
@@ -520,6 +520,49 @@ export class Vector {
     }
 
     /**
+     * Mirrors this vector
+     * @param {boolean} mirror
+     * @returns {Vector} new vector
+     */
+    mirror(mirror = true) {
+        if (mirror) {
+                return new Vector(-this.x, this.y);
+        }
+        else {
+                return new Vector(this.x, this.y);
+        }
+    }
+
+    /**
+     * Helper method to mirror a direction
+     * @param {enumDirection} direction
+     * @param {boolean} mirror
+     * @returns {enumDirection}
+     */
+    static mirrorDirection(direction, mirror = true) {
+        if (mirror) {
+            switch (direction) {
+                case enumDirection.left: return enumDirection.right;
+                case enumDirection.right: return enumDirection.left;
+            }
+        }
+        return direction;
+    }
+
+    /**
+     * Helper method to mirror an angle
+     * @param {number} angle
+     * @param {boolean} mirror
+     * @returns {number}
+     */
+    static mirrorAngle(angle, mirror = true) {
+        if (mirror && (angle == 90 || angle == 270) ) {
+            return 360 - angle;
+        }
+        return angle;
+    }
+
+    /**
      * Helper method to rotate a direction
      * @param {enumDirection} direction
      * @param {number} angle

--- a/src/js/game/buildings/belt_base.js
+++ b/src/js/game/buildings/belt_base.js
@@ -141,7 +141,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
      * @param {string} variant
      * @return {{ rotation: number, rotationVariant: number }}
      */
-    computeOptimalDirectionAndRotationVariantAtTile(root, tile, rotation, variant) {
+    computeOptimalDirectionAndRotationVariantAtTile(root, tile, rotation, mirrored, variant) {
         const topDirection = enumAngleToDirection[rotation];
         const rightDirection = enumAngleToDirection[(rotation + 90) % 360];
         const bottomDirection = enumAngleToDirection[(rotation + 180) % 360];
@@ -191,6 +191,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
             if (hasRightEjector && !hasLeftEjector) {
                 return {
                     rotation: (rotation + 270) % 360,
+                    mirrored: false,
                     rotationVariant: 2,
                 };
             }
@@ -200,6 +201,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
             if (hasLeftEjector && !hasRightEjector) {
                 return {
                     rotation: (rotation + 90) % 360,
+                    mirrored: false,
                     rotationVariant: 1,
                 };
             }
@@ -213,6 +215,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
             if (hasRightAcceptor && !hasLeftAcceptor) {
                 return {
                     rotation,
+                    mirrored: false,
                     rotationVariant: 2,
                 };
             }
@@ -222,6 +225,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
             if (hasLeftAcceptor && !hasRightAcceptor) {
                 return {
                     rotation,
+                    mirrored: false,
                     rotationVariant: 1,
                 };
             }
@@ -229,6 +233,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
 
         return {
             rotation,
+            mirrored: false,
             rotationVariant: 0,
         };
     }

--- a/src/js/game/buildings/hub.js
+++ b/src/js/game/buildings/hub.js
@@ -24,6 +24,10 @@ export class MetaHubBuilding extends MetaBuilding {
         return false;
     }
 
+    isMirrorable(variant) {
+        return false;
+    }
+
     getBlueprintSprite() {
         return null;
     }

--- a/src/js/game/buildings/rotater.js
+++ b/src/js/game/buildings/rotater.js
@@ -18,6 +18,10 @@ export class MetaRotaterBuilding extends MetaBuilding {
         super("rotater");
     }
 
+    isMirrorable(variant) {
+        return false;
+    }
+
     getSilhouetteColor() {
         return "#7dc6cd";
     }

--- a/src/js/game/buildings/trash.js
+++ b/src/js/game/buildings/trash.js
@@ -24,6 +24,10 @@ export class MetaTrashBuilding extends MetaBuilding {
         return variant !== defaultBuildingVariant;
     }
 
+    isMirrorable(variant) {
+        return variant !== defaultBuildingVariant;
+    }
+
     getSilhouetteColor() {
         return "#cd7d86";
     }

--- a/src/js/game/buildings/underground_belt.js
+++ b/src/js/game/buildings/underground_belt.js
@@ -137,7 +137,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
      * @param {string} variant
      * @return {{ rotation: number, rotationVariant: number, connectedEntities?: Array<Entity> }}
      */
-    computeOptimalDirectionAndRotationVariantAtTile(root, tile, rotation, variant) {
+    computeOptimalDirectionAndRotationVariantAtTile(root, tile, rotation, mirrored, variant) {
         const searchDirection = enumAngleToDirection[rotation];
         const searchVector = enumDirectionToVector[searchDirection];
         const tier = enumUndergroundBeltVariantToTier[variant];
@@ -164,6 +164,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                         }
                         return {
                             rotation: targetRotation,
+                            mirrored: false,
                             rotationVariant: 1,
                             connectedEntities: [contents],
                         };
@@ -172,6 +173,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                         if (undergroundComp.mode === enumUndergroundBeltMode.receiver) {
                             return {
                                 rotation: rotation,
+                                mirrored: false,
                                 rotationVariant: 0,
                                 connectedEntities: [contents],
                             };
@@ -185,6 +187,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
 
         return {
             rotation,
+            mirrored: false,
             rotationVariant: 0,
         };
     }

--- a/src/js/game/hud/parts/blueprint.js
+++ b/src/js/game/hud/parts/blueprint.js
@@ -8,6 +8,7 @@ import { findNiceIntegerValue } from "../../../core/utils";
 import { Math_pow } from "../../../core/builtins";
 import { blueprintShape } from "../../upgrades";
 import { globalConfig } from "../../../core/config";
+import { enumItemProcessorTypes } from "../../components/item_processor";
 
 const logger = createLogger("blueprint");
 
@@ -127,6 +128,36 @@ export class Blueprint {
         // Well ...
         for (let i = 0; i < 3; ++i) {
             this.rotateCw();
+        }
+    }
+
+    /**
+     * Mirrors the blueprint horizontally
+     */
+    mirror() {
+        for (let i = 0; i < this.entities.length; ++i) {
+            const entity = this.entities[i];
+            const staticComp = entity.components.StaticMapEntity;
+            const beltComp = entity.components.Belt;
+            const itemProcComp = entity.components.ItemProcessor;
+
+            staticComp.rotation = Vector.mirrorAngle(staticComp.rotation)
+            staticComp.originalRotation = Vector.mirrorAngle(staticComp.originalRotation)
+            staticComp.origin = staticComp.origin.mirror();
+
+            if (beltComp) {
+                // It is a belt! Flipping the direction is enough.
+                beltComp.direction = Vector.mirrorDirection( beltComp.direction );
+                staticComp.blueprintSpriteKey = "sprites/blueprints/belt_" + beltComp.direction + ".png";
+            } else if ( itemProcComp && (
+                    itemProcComp.type == enumItemProcessorTypes.rotater ||
+                    itemProcComp.type == enumItemProcessorTypes.rotaterCCW
+                ) ) {
+                // Don't flip the rotater
+            } else {
+                staticComp.mirrored = !staticComp.mirrored;
+            }
+
         }
     }
 

--- a/src/js/game/hud/parts/blueprint_placer.js
+++ b/src/js/game/hud/parts/blueprint_placer.js
@@ -37,6 +37,7 @@ export class HUDBlueprintPlacer extends BaseHUDPart {
         keyActionMapper.getBinding(KEYMAPPINGS.general.back).add(this.abortPlacement, this);
         keyActionMapper.getBinding(KEYMAPPINGS.placement.pipette).add(this.abortPlacement, this);
         keyActionMapper.getBinding(KEYMAPPINGS.placement.rotateWhilePlacing).add(this.rotateBlueprint, this);
+        keyActionMapper.getBinding(KEYMAPPINGS.placement.mirrorWhilePlacing).add(this.mirrorBlueprint, this);
         keyActionMapper.getBinding(KEYMAPPINGS.massSelect.pasteLastBlueprint).add(this.pasteBlueprint, this);
 
         this.root.camera.downPreHandler.add(this.onMouseDown, this);
@@ -135,6 +136,20 @@ export class HUDBlueprintPlacer extends BaseHUDPart {
                 this.currentBlueprint.get().rotateCcw();
             } else {
                 this.currentBlueprint.get().rotateCw();
+            }
+        }
+    }
+
+    mirrorBlueprint() {
+        if (this.currentBlueprint.get()) {
+            if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateInverseModifier).pressed) {
+                // Mirror vertically
+                this.currentBlueprint.get().rotateCw();
+                this.currentBlueprint.get().mirror();
+                this.currentBlueprint.get().rotateCcw();
+            } else {
+                // Mirror horizontally
+                this.currentBlueprint.get().mirror();
             }
         }
     }

--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -229,11 +229,13 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
         const {
             rotation,
             rotationVariant,
+            mirrored,
             connectedEntities,
         } = metaBuilding.computeOptimalDirectionAndRotationVariantAtTile(
             this.root,
             mouseTile,
             this.currentBaseRotation,
+            this.currentMirrored,
             this.currentVariant.get()
         );
 
@@ -272,6 +274,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
         const staticComp = this.fakeEntity.components.StaticMapEntity;
         staticComp.origin = mouseTile;
         staticComp.rotation = rotation;
+        staticComp.mirrored = mirrored;
         staticComp.tileSize = metaBuilding.getDimensions(this.currentVariant.get());
         metaBuilding.updateVariants(this.fakeEntity, rotationVariant, this.currentVariant.get());
 
@@ -280,6 +283,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
             origin: mouseTile,
             rotation,
             rotationVariant,
+            mirrored,
             building: metaBuilding,
             variant: this.currentVariant.get(),
         });

--- a/src/js/game/hud/parts/keybinding_overlay.js
+++ b/src/js/game/hud/parts/keybinding_overlay.js
@@ -208,6 +208,13 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
             },
 
             {
+                // Mirror
+                label: T.ingame.keybindingsOverlay.mirrorBuilding,
+                keys: [k.placement.mirrorWhilePlacing],
+                condition: () => this.anyPlacementActive && !this.beltPlannerActive,
+            },
+
+            {
                 // [BELT PLANNER] Flip Side
                 label: T.ingame.keybindingsOverlay.plannerSwitchSide,
                 keys: [k.placement.switchDirectionLockSide],

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -61,6 +61,7 @@ export const KEYMAPPINGS = {
     placement: {
         pipette: { keyCode: key("Q") },
         rotateWhilePlacing: { keyCode: key("R") },
+        mirrorWhilePlacing: { keyCode: key("N") },
         rotateInverseModifier: { keyCode: 16 }, // SHIFT
         cycleBuildingVariants: { keyCode: key("T") },
         cycleBuildings: { keyCode: 9 }, // TAB

--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -56,11 +56,12 @@ export class GameLogic {
      * @param {MetaBuilding} param0.building
      * @returns {boolean}
      */
-    isAreaFreeToBuild({ origin, rotation, rotationVariant, variant, building }) {
+    isAreaFreeToBuild({ origin, rotation, mirrored, rotationVariant, variant, building }) {
         const checker = new StaticMapEntityComponent({
             origin,
             tileSize: building.getDimensions(variant),
             rotation,
+            mirrored,
             blueprintSpriteKey: "",
         });
 
@@ -76,6 +77,7 @@ export class GameLogic {
                             origin,
                             building,
                             rotation,
+                            mirrored,
                             rotationVariant,
                         })
                     ) {
@@ -95,10 +97,11 @@ export class GameLogic {
      * @param {Vector} param0.origin
      * @param {number} param0.rotation
      * @param {number} param0.rotationVariant
+     * @param {boolean} param0.mirrored
      * @param {MetaBuilding} param0.building
      * @returns {boolean}
      */
-    checkCanReplaceBuilding({ original, origin, building, rotation, rotationVariant }) {
+    checkCanReplaceBuilding({ original, origin, building, rotation, mirrored, rotationVariant }) {
         if (!original.components.ReplaceableMapEntity) {
             // Can not get replaced at all
             return false;
@@ -128,7 +131,7 @@ export class GameLogic {
      * @param {string} param0.variant
      * @param {MetaBuilding} param0.building
      */
-    checkCanPlaceBuilding({ origin, rotation, rotationVariant, variant, building }) {
+    checkCanPlaceBuilding({ origin, rotation, mirrored, rotationVariant, variant, building }) {
         if (!building.getIsUnlocked(this.root)) {
             return false;
         }
@@ -136,6 +139,7 @@ export class GameLogic {
         return this.isAreaFreeToBuild({
             origin,
             rotation,
+            mirrored,
             rotationVariant,
             variant,
             building,
@@ -153,13 +157,14 @@ export class GameLogic {
      * @param {MetaBuilding} param0.building
      * @returns {Entity}
      */
-    tryPlaceBuilding({ origin, rotation, rotationVariant, originalRotation, variant, building }) {
-        if (this.checkCanPlaceBuilding({ origin, rotation, rotationVariant, variant, building })) {
+    tryPlaceBuilding({ origin, rotation, rotationVariant, originalRotation, mirrored, variant, building }) {
+        if (this.checkCanPlaceBuilding({ origin, rotation, mirrored, rotationVariant, variant, building })) {
             // Remove any removeable entities below
             const checker = new StaticMapEntityComponent({
                 origin,
                 tileSize: building.getDimensions(variant),
                 rotation,
+                mirrored,
                 blueprintSpriteKey: "",
             });
 
@@ -182,6 +187,7 @@ export class GameLogic {
                 origin,
                 rotation,
                 rotationVariant,
+                mirrored,
                 originalRotation,
                 variant,
             });

--- a/src/js/game/meta_building.js
+++ b/src/js/game/meta_building.js
@@ -130,6 +130,15 @@ export class MetaBuilding {
     }
 
     /**
+     * Returns whether this building can be mirrored
+     * @param {string} variant
+     * @returns {boolean}
+     */
+    isMirrorable(variant) {
+        return true;
+    }
+
+    /**
      * Returns whether this building is unlocked for the given game
      * @param {GameRoot} root
      */
@@ -151,15 +160,17 @@ export class MetaBuilding {
      * @param {Vector} param0.origin Origin tile
      * @param {number=} param0.rotation Rotation
      * @param {number} param0.originalRotation Original Rotation
+     * @param {boolean} param0.mirrored
      * @param {number} param0.rotationVariant Rotation variant
      * @param {string} param0.variant
      */
-    createAndPlaceEntity({ root, origin, rotation, originalRotation, rotationVariant, variant }) {
+    createAndPlaceEntity({ root, origin, rotation, originalRotation, mirrored, rotationVariant, variant }) {
         const entity = this.createEntity({
             root,
             origin,
             rotation,
             originalRotation,
+            mirrored,
             rotationVariant,
             variant,
         });
@@ -175,10 +186,11 @@ export class MetaBuilding {
      * @param {Vector} param0.origin Origin tile
      * @param {number=} param0.rotation Rotation
      * @param {number} param0.originalRotation Original Rotation
+     * @param {boolean} param0.mirrored
      * @param {number} param0.rotationVariant Rotation variant
      * @param {string} param0.variant
      */
-    createEntity({ root, origin, rotation, originalRotation, rotationVariant, variant }) {
+    createEntity({ root, origin, rotation, originalRotation, mirrored, rotationVariant, variant }) {
         const entity = new Entity(root);
         const blueprintSprite = this.getBlueprintSprite(rotationVariant, variant);
         entity.addComponent(
@@ -191,6 +203,7 @@ export class MetaBuilding {
                 origin: new Vector(origin.x, origin.y),
                 rotation,
                 originalRotation,
+                mirrored,
                 tileSize: this.getDimensions(variant).copy(),
                 silhouetteColor: this.getSilhouetteColor(),
                 blueprintSpriteKey: blueprintSprite ? blueprintSprite.spriteName : "",
@@ -207,17 +220,18 @@ export class MetaBuilding {
      * @param {Vector} tile
      * @param {number} rotation
      * @param {string} variant
-     * @return {{ rotation: number, rotationVariant: number, connectedEntities?: Array<Entity> }}
+     * @return {{ rotation: number, rotationVariant: number, mirrored: boolean, connectedEntities?: Array<Entity> }}
      */
-    computeOptimalDirectionAndRotationVariantAtTile(root, tile, rotation, variant) {
+    computeOptimalDirectionAndRotationVariantAtTile(root, tile, rotation, mirrored, variant) {
         if (!this.isRotateable(variant)) {
-            return {
-                rotation: 0,
-                rotationVariant: 0,
-            };
+          rotation = 0;
+        }
+        if (!this.isMirrorable(variant)) {
+            mirrored = false;
         }
         return {
             rotation,
+            mirrored,
             rotationVariant: 0,
         };
     }

--- a/src/js/game/systems/belt.js
+++ b/src/js/game/systems/belt.js
@@ -100,6 +100,7 @@ export class BeltSystem extends GameSystemWithFilter {
                                 this.root,
                                 new Vector(x, y),
                                 targetStaticComp.originalRotation,
+                                false,
                                 defaultBuildingVariant
                             );
                             targetStaticComp.rotation = rotation;

--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -311,11 +311,9 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                 continue;
             }
 
-            const realPosition = slot.pos.rotateFastMultipleOf90(staticComp.rotation);
-            const realDirection = Vector.transformDirectionFromMultipleOf90(
-                slot.direction,
-                staticComp.rotation
-            );
+            const realPosition = staticComp.applyRotationToVector(slot.pos);
+            const realDirection = staticComp.localDirectionToWorld(slot.direction);
+
             const realDirectionVector = enumDirectionToVector[realDirection];
 
             const tileX =

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -276,6 +276,7 @@ ingame:
         selectBuildings: Select area
         stopPlacement: Stop placement
         rotateBuilding: Rotate building
+        mirrorBuilding: Mirror building
         placeMultiple: Place multiple
         reverseOrientation: Reverse orientation
         disableAutoOrientation: Disable auto orientation
@@ -802,6 +803,7 @@ keybindings:
 
         pipette: Pipette
         rotateWhilePlacing: Rotate
+        mirrorWhilePlacing: Mirror
         rotateInverseModifier: >-
             Modifier: Rotate CCW instead
         cycleBuildingVariants: Cycle Variants


### PR DESCRIPTION
This patch allows to mirror buildings and blueprints, see #174, #257, #284.

The only problem is that it breaks the saves. The `StaticMapEntityComponent` has a new variable in its `schema` and I do not know how to incorporate this into the savegame version logic.