### PR TITLE
fix crash due to missing import of STOP_PROPAGATION

### DIFF
--- a/src/js/game/hud/parts/base_toolbar.js
+++ b/src/js/game/hud/parts/base_toolbar.js
@@ -1,5 +1,5 @@
 import { gMetaBuildingRegistry } from "../../../core/global_registries";
-import { Signal } from "../../../core/signal";
+import { Signal, STOP_PROPAGATION } from "../../../core/signal";
 import { TrackedState } from "../../../core/tracked_state";
 import { makeDiv } from "../../../core/utils";
 import { KEYMAPPINGS } from "../../key_action_mapper";


### PR DESCRIPTION
can be triggered by pressing the hotkey for a not yet unlocked toolbar item on beta.shapez.io.

![crash message](https://cdn.discordapp.com/attachments/706122201077645333/726137704437383179/unknown.png)