### PR TITLE
Fix tunnel incorrect delete bug

### DIFF
--- a/src/js/game/systems/underground_belt.js
+++ b/src/js/game/systems/underground_belt.js
@@ -88,10 +88,12 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
                 }
 
                 const contentsUndergroundComp = contents.components.UndergroundBelt;
+                const contentsStaticComp = contents.components.StaticMapEntity;
                 if (
                     contentsUndergroundComp &&
                     contentsUndergroundComp.tier === undergroundComp.tier &&
-                    contentsUndergroundComp.mode === enumUndergroundBeltMode.sender
+                    contentsUndergroundComp.mode === enumUndergroundBeltMode.sender &&
+                    enumAngleToDirection[contentsStaticComp.rotation] === direction
                 ) {
                     matchingEntrance = {
                         entity: contents,


### PR DESCRIPTION
When trying to place tunnels vertically underneath horizontally run tunnel exits, previously placed tunnel connectors would get removed.

Placed exit at 1# Both exit, and entrance (which were placed previously) at 2# got removed.
![image](https://user-images.githubusercontent.com/165293/85912240-4e2ba400-b7e8-11ea-8644-5b711feac158.png)

There was no direction check on the code to identify the connecting tunnel piece, so it was picking up the exit just below the 2# area as it's farthest connector - and then deciding that since that was a viable connector, it didn't need the two tunnel pieces in between.

This adds the direction check in so it doesn't pick up the wrong tunnel connector.