### PR TITLE
press alt key in belt planner to reverse direction

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -558,8 +558,15 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
         // Figure which points the line visits
         const worldPos = this.root.camera.screenToWorld(mousePosition);
-        const mouseTile = worldPos.toTileSpace();
-        const startTile = this.lastDragTile;
+        let endTile = worldPos.toTileSpace();
+        let startTile = this.lastDragTile;
+
+        // if the alt key is pressed, reverse belt planner direction by switching start and end tile
+        if (this.root.keyMapper.getBinding(KEYMAPPINGS.placementModifiers.placeInverse).pressed) {
+            let tmp = startTile;
+            startTile = endTile;
+            endTile = tmp;
+        }
 
         // Place from start to corner
         const pathToCorner = this.currentDirectionLockCorner.sub(startTile);
@@ -580,7 +587,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         }
 
         // Place from corner to end
-        const pathFromCorner = mouseTile.sub(this.currentDirectionLockCorner);
+        const pathFromCorner = endTile.sub(this.currentDirectionLockCorner);
         const deltaFromCorner = pathFromCorner.normalize().round();
         const lengthFromCorner = Math.round(pathFromCorner.length());
 


### PR DESCRIPTION
this is done by swapping the start and end tile when computing the preview path.
I renamed the `mouseTile` variable to `endTile` since the the path may start with the mouse now.