### PR TITLE
Fix issue where pressing B just after loading crashes the game.

### DIFF
--- a/src/js/game/hub_goals.js
+++ b/src/js/game/hub_goals.js
@@ -106,13 +106,14 @@ export class HubGoals extends BasicSerializableObject {
 
         // Allow quickly switching goals in dev mode
         if (G_IS_DEV) {
-            if (G_IS_DEV) {
-                window.addEventListener("keydown", ev => {
-                    if (ev.key === "b") {
+            window.addEventListener("keydown", ev => {
+                if (ev.key === "b") {
+                    // root is not guaranteed to exist within ~0.5s after loading in
+                    if (this.root && this.root.app && this.root.app.gameAnalytics) {
                         this.onGoalCompleted();
                     }
-                });
-            }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
This is something I have encountered while testing that is infuriating personally. This happens because root hasn't fully initialized yet, so trying to resolve `this.root.gameAnalytics.handleLevelCompleted()` in `onGoalCompleted()` results in an "Can't access property x of undefined" error.