### PR TITLE
Clear cursor when trying to pipette the same building twice.

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -322,7 +322,12 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
         // Try to extract the building
         const extracted = this.hack_reconstructMetaBuildingAndVariantFromBuilding(contents);
-        if (!extracted) {
+        // If the building we are picking is the same as the one we have, clear the cursor.
+        if (
+            !extracted ||
+            (extracted.metaBuilding === this.currentMetaBuilding.get() &&
+                extracted.variant === this.currentVariant.get())
+        ) {
             this.currentMetaBuilding.set(null);
             return;
         }


### PR DESCRIPTION
Whenever I find myself using the pipette, I inevitably try to press Q to clear my cursor afterward, only to have it do nothing since there is a building under my cursor, and it just pipetted that instead. This makes it so that you can use Q to clear your cursor, but preserves the functionality of being able to pipette a different building without clearing your cursor.