### PR TITLE
Improved debug info (position and version)

### DIFF
--- a/src/css/ingame_hud/debug_info.scss
+++ b/src/css/ingame_hud/debug_info.scss
@@ -10,7 +10,7 @@
     flex-direction: column;
     color: #fff;
 
-    &:not([data-mode="full"]) {
+    &:not([data-mode="detailed"]) {
         .mousePosition,
         .cameraPosition {
             display: none;

--- a/src/css/ingame_hud/debug_info.scss
+++ b/src/css/ingame_hud/debug_info.scss
@@ -10,7 +10,7 @@
     flex-direction: column;
     color: #fff;
 
-    &:not(.debugFull) {
+    &:not([data-mode="full"]) {
         .mousePosition,
         .cameraPosition {
             display: none;

--- a/src/css/ingame_hud/debug_info.scss
+++ b/src/css/ingame_hud/debug_info.scss
@@ -9,4 +9,11 @@
     line-height: 15px;
     flex-direction: column;
     color: #fff;
+
+    &:not(.debugFull) {
+        .mousePosition,
+        .cameraPosition {
+            display: none;
+        }
+    }
 }

--- a/src/js/game/hud/parts/debug_info.js
+++ b/src/js/game/hud/parts/debug_info.js
@@ -2,6 +2,7 @@ import { BaseHUDPart } from "../base_hud_part";
 import { makeDiv, round3Digits, round2Digits } from "../../../core/utils";
 import { DynamicDomAttach } from "../dynamic_dom_attach";
 import { KEYMAPPINGS } from "../../key_action_mapper";
+import { Vector } from "../../../core/vector";
 
 export class HUDDebugInfo extends BaseHUDPart {
     createElements(parent) {
@@ -9,20 +10,54 @@ export class HUDDebugInfo extends BaseHUDPart {
 
         this.tickRateElement = makeDiv(this.element, null, ["tickRate"], "Ticks /s: 120");
         this.fpsElement = makeDiv(this.element, null, ["fps"], "FPS: 60");
-        this.tickDurationElement = makeDiv(this.element, null, ["tickDuration"], "Update time: 0.5ms");
+        this.tickDurationElement = makeDiv(this.element, null, ["tickDuration"], "Tick dur: 0.5ms");
+        this.mousePositionElement = makeDiv(this.element, null, ["mousePosition"], "Pos: 0 0");
+        this.cameraPositionElement = makeDiv(this.element, null, ["cameraPosition"], "Center: 0 0");
+        this.versionElement = makeDiv(this.element, null, ["version"], "version unknown");
     }
 
     initialize() {
         this.lastTick = 0;
 
         this.visible = false;
+        this.full = false;
         this.domAttach = new DynamicDomAttach(this.root, this.element);
 
         this.root.keyMapper.getBinding(KEYMAPPINGS.ingame.toggleFPSInfo).add(() => this.toggle());
     }
 
+    updateFullText() {
+        this.element.classList.toggle("debugFull", this.full);
+
+        let version = `version ${G_BUILD_VERSION}`;
+        if (this.full) {
+            version += ` @ ${G_APP_ENVIRONMENT} @ ${G_BUILD_COMMIT_HASH}`;
+        }
+
+        this.versionElement.innerText = version;
+    }
+
+    updatePositions() {
+        let mousePos = this.root.app.mousePosition || new Vector(0, 0);
+        mousePos = this.root.camera.screenToWorld(mousePos).toTileSpace();
+        const cameraPos = this.root.camera.center.toTileSpace();
+
+        this.mousePositionElement.innerText = `Pos: ${mousePos.x} ${mousePos.y}`;
+        this.cameraPositionElement.innerText = `Center: ${cameraPos.x} ${cameraPos.y}`;
+    }
+
     toggle() {
-        this.visible = !this.visible;
+        if (this.visible) {
+            if (this.full) {
+                this.visible = false;
+                this.full = false;
+            } else {
+                this.full = true;
+            }
+        } else {
+            this.visible = true;
+        }
+        this.updateFullText();
         this.domAttach.update(this.visible);
     }
 
@@ -40,5 +75,7 @@ export class HUDDebugInfo extends BaseHUDPart {
             this.tickDurationElement.innerText =
                 "Tick Dur: " + round3Digits(this.root.dynamicTickrate.averageTickDuration) + "ms";
         }
+
+        this.updatePositions();
     }
 }

--- a/src/js/game/hud/parts/debug_info.js
+++ b/src/js/game/hud/parts/debug_info.js
@@ -29,7 +29,7 @@ export class HUDDebugInfo extends BaseHUDPart {
     }
 
     updateFullText() {
-        this.element.classList.toggle("debugFull", this.full);
+        this.element.setAttribute("data-mode", this.mode);
 
         let version = `version ${G_BUILD_VERSION}`;
         if (this.full) {
@@ -61,12 +61,14 @@ export class HUDDebugInfo extends BaseHUDPart {
                 break;
         }
         this.updateFullText();
-        this.domAttach.update(this.mode != enumDebugOverlayMode.disabled);
+        this.domAttach.update(this.mode !== enumDebugOverlayMode.disabled);
     }
 
     update() {
         const now = this.root.time.realtimeNow();
-        if (now - this.lastTick > 0.25 && this.visible) {
+        if (!this.visible) return;
+        
+        if (now - this.lastTick > 0.25) {
             this.lastTick = now;
             this.tickRateElement.innerText = "Tickrate: " + this.root.dynamicTickrate.currentTickRate;
             this.fpsElement.innerText =

--- a/src/js/game/hud/parts/debug_info.js
+++ b/src/js/game/hud/parts/debug_info.js
@@ -4,6 +4,8 @@ import { DynamicDomAttach } from "../dynamic_dom_attach";
 import { KEYMAPPINGS } from "../../key_action_mapper";
 import { Vector } from "../../../core/vector";
 
+export const enumDebugOverlayMode = { disabled: 'disabled', regular: 'regular', detailed: 'detailed'};
+
 export class HUDDebugInfo extends BaseHUDPart {
     createElements(parent) {
         this.element = makeDiv(parent, "ingame_HUD_DebugInfo", []);
@@ -19,8 +21,7 @@ export class HUDDebugInfo extends BaseHUDPart {
     initialize() {
         this.lastTick = 0;
 
-        this.visible = false;
-        this.full = false;
+        this.mode = enumDebugOverlayMode.disabled;
         this.domAttach = new DynamicDomAttach(this.root, this.element);
 
         this.root.keyMapper.getBinding(KEYMAPPINGS.ingame.toggleFPSInfo).add(() => this.toggle());
@@ -47,18 +48,19 @@ export class HUDDebugInfo extends BaseHUDPart {
     }
 
     toggle() {
-        if (this.visible) {
-            if (this.full) {
-                this.visible = false;
-                this.full = false;
-            } else {
-                this.full = true;
-            }
-        } else {
-            this.visible = true;
+        switch (this.mode) {
+            case enumDebugOverlayMode.detailed:
+                this.mode = enumDebugOverlayMode.disabled;
+                break;
+            case enumDebugOverlayMode.regular:
+                this.mode = enumDebugOverlayMode.detailed;
+                break;
+            default:
+                this.mode = enumDebugOverlayMode.regular;
+                break;
         }
         this.updateFullText();
-        this.domAttach.update(this.visible);
+        this.domAttach.update(this.mode != enumDebugOverlayMode.disabled);
     }
 
     update() {

--- a/src/js/game/hud/parts/debug_info.js
+++ b/src/js/game/hud/parts/debug_info.js
@@ -4,6 +4,7 @@ import { DynamicDomAttach } from "../dynamic_dom_attach";
 import { KEYMAPPINGS } from "../../key_action_mapper";
 import { Vector } from "../../../core/vector";
 
+/** @enum {string} */
 export const enumDebugOverlayMode = { disabled: "disabled", regular: "regular", detailed: "detailed" };
 
 export class HUDDebugInfo extends BaseHUDPart {

--- a/src/js/game/hud/parts/debug_info.js
+++ b/src/js/game/hud/parts/debug_info.js
@@ -67,7 +67,7 @@ export class HUDDebugInfo extends BaseHUDPart {
     update() {
         const now = this.root.time.realtimeNow();
         if (!this.visible) return;
-        
+
         if (now - this.lastTick > 0.25) {
             this.lastTick = now;
             this.tickRateElement.innerText = "Tickrate: " + this.root.dynamicTickrate.currentTickRate;

--- a/src/js/game/hud/parts/debug_info.js
+++ b/src/js/game/hud/parts/debug_info.js
@@ -4,7 +4,7 @@ import { DynamicDomAttach } from "../dynamic_dom_attach";
 import { KEYMAPPINGS } from "../../key_action_mapper";
 import { Vector } from "../../../core/vector";
 
-export const enumDebugOverlayMode = { disabled: 'disabled', regular: 'regular', detailed: 'detailed'};
+export const enumDebugOverlayMode = { disabled: "disabled", regular: "regular", detailed: "detailed" };
 
 export class HUDDebugInfo extends BaseHUDPart {
     createElements(parent) {


### PR DESCRIPTION
This PR adds another mode to debug info overlay (by default, toggled by `F4`). Now, when pressing `F4` once it will show basic info, but if you press it second time, it will also display more information - mouse and camera center positions, version commit and environment (unlocalized). Also, when basic info mode is on, version number (such as `1.1.19`) is shown.

If you press `F4` while full debug info mode is on, debug info will become invisible and mode is changed to basic.