### PR TITLE
Fix layer handling in cutter

### DIFF
--- a/src/js/game/shape_definition.js
+++ b/src/js/game/shape_definition.js
@@ -177,6 +177,11 @@ export class ShapeDefinition extends BasicSerializableObject {
      */
     static isValidShortKeyInternal(key) {
         const sourceLayers = key.split(":");
+
+        if (sourceLayers.length === 0 || sourceLayers.length > 4) {
+            return false;
+        }
+
         let layers = [];
         for (let i = 0; i < sourceLayers.length; ++i) {
             const text = sourceLayers[i];
@@ -220,10 +225,6 @@ export class ShapeDefinition extends BasicSerializableObject {
                 return false;
             }
             layers.push(quads);
-        }
-
-        if (layers.length === 0 || layers.length > 4) {
-            return false;
         }
 
         return true;

--- a/src/js/game/shape_definition.js
+++ b/src/js/game/shape_definition.js
@@ -444,7 +444,6 @@ export class ShapeDefinition extends BasicSerializableObject {
         let lastNonEmptyLayer = -1;
         for (let layerIndex = 0; layerIndex < newLayers.length; ++layerIndex) {
             const quadrants = newLayers[layerIndex];
-            let anyContents = false;
             for (let quadrantIndex = 0; quadrantIndex < 4; ++quadrantIndex) {
                 if (includeQuadrants.indexOf(quadrantIndex) < 0) {
                     quadrants[quadrantIndex] = null;

--- a/src/js/game/shape_definition.js
+++ b/src/js/game/shape_definition.js
@@ -441,6 +441,7 @@ export class ShapeDefinition extends BasicSerializableObject {
      */
     cloneFilteredByQuadrants(includeQuadrants) {
         const newLayers = this.internalCloneLayers();
+        let lastNonEmptyLayer = -1;
         for (let layerIndex = 0; layerIndex < newLayers.length; ++layerIndex) {
             const quadrants = newLayers[layerIndex];
             let anyContents = false;
@@ -448,16 +449,16 @@ export class ShapeDefinition extends BasicSerializableObject {
                 if (includeQuadrants.indexOf(quadrantIndex) < 0) {
                     quadrants[quadrantIndex] = null;
                 } else if (quadrants[quadrantIndex]) {
-                    anyContents = true;
+                    lastNonEmptyLayer = layerIndex;
                 }
             }
-
-            // Check if the layer is entirely empty
-            if (!anyContents) {
-                newLayers.splice(layerIndex, 1);
-                layerIndex -= 1;
-            }
         }
+
+        // Remove top most empty layers which aren't needed anymore
+        if (lastNonEmptyLayer !== newLayers.length - 1) {
+            newLayers.splice(lastNonEmptyLayer + 1);
+        }
+
         return new ShapeDefinition({ layers: newLayers });
     }
 

--- a/src/js/game/shape_definition.js
+++ b/src/js/game/shape_definition.js
@@ -220,10 +220,11 @@ export class ShapeDefinition extends BasicSerializableObject {
                 }
             }
 
-            if (!anyFilled) {
-                // Empty layer
+            if (!anyFilled && i === sourceLayers.length - 1) {
+                // Topmost layer isn't allowed being empty
                 return false;
             }
+
             layers.push(quads);
         }
 


### PR DESCRIPTION
This PR fixes cutting multi layered shapes. Previously all empty layers got dropped which would result in a single second layer quad pushed to the first layer. The fix works by removing only the topmost empty layers.
It's the same fix I already posted in https://github.com/tobspr/shapez.io/issues/157#issuecomment-650397342