### PR TITLE
Initial planner direction based on cursor movement

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -92,6 +92,12 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
          */
         this.currentDirectionLockSide = 0;
 
+        /**
+         * Whether the side for direction lock has not yet been determined.
+         * @type {boolean}
+         */
+        this.currentDirectionLockSideIndeterminate = true;
+
         this.initializeBindings();
     }
 
@@ -203,6 +209,17 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         // Figure which points the line visits
         const worldPos = this.root.camera.screenToWorld(mousePosition);
         const mouseTile = worldPos.toTileSpace();
+
+        // Figure initial direction
+        const dx = Math.abs(this.lastDragTile.x - mouseTile.x);
+        const dy = Math.abs(this.lastDragTile.y - mouseTile.y);
+        if (dx === 0 && dy === 0) {
+            // Back at the start. Try a new direction.
+            this.currentDirectionLockSideIndeterminate = true;
+        } else if (this.currentDirectionLockSideIndeterminate) {
+            this.currentDirectionLockSideIndeterminate = false;
+            this.currentDirectionLockSide = dx <= dy ? 0 : 1;
+        }
 
         if (this.currentDirectionLockSide === 0) {
             return new Vector(this.lastDragTile.x, mouseTile.y);


### PR DESCRIPTION
The orientation of the planner is now considered indeterminate initially. As soon as the cursor is moved at least one tile, the direction gets set based on the direction of movement.

This makes the planner more intuitive, and would lead to less need to flip it with <kbd>R</kbd>.

I was not sure where to place the code, so it ended up in `get currentDirectionLockCorner()`. If you have a better suggestion, I will move it.

Does this need a new option in game settings?