### PR TITLE
Fixed an issue that caused an error when pressing the tab key

### DIFF
--- a/src/js/game/hud/parts/base_toolbar.js
+++ b/src/js/game/hud/parts/base_toolbar.js
@@ -103,14 +103,24 @@ export class HUDBaseToolbar extends BaseHUDPart {
      * Cycles through all buildings
      */
     cycleBuildings() {
+        const visible = this.visibilityCondition();
+        if (!visible) {
+            return;
+        }
+
+        let process = false;
         let newIndex = this.lastSelectedIndex;
         for (let i = 0; i < this.supportedBuildings.length; ++i, ++newIndex) {
             newIndex %= this.supportedBuildings.length;
             const metaBuilding = gMetaBuildingRegistry.findByClass(this.supportedBuildings[newIndex]);
             const handle = this.buildingHandles[metaBuilding.id];
             if (!handle.selected && handle.unlocked) {
+                process = true;
                 break;
             }
+        }
+        if (!process) {
+            return;
         }
         const metaBuildingClass = this.supportedBuildings[newIndex];
         const metaBuilding = gMetaBuildingRegistry.findByClass(metaBuildingClass);

--- a/src/js/game/hud/parts/base_toolbar.js
+++ b/src/js/game/hud/parts/base_toolbar.js
@@ -108,18 +108,18 @@ export class HUDBaseToolbar extends BaseHUDPart {
             return;
         }
 
-        let process = false;
+        let newBuildingFound = false;
         let newIndex = this.lastSelectedIndex;
         for (let i = 0; i < this.supportedBuildings.length; ++i, ++newIndex) {
             newIndex %= this.supportedBuildings.length;
             const metaBuilding = gMetaBuildingRegistry.findByClass(this.supportedBuildings[newIndex]);
             const handle = this.buildingHandles[metaBuilding.id];
             if (!handle.selected && handle.unlocked) {
-                process = true;
+                newBuildingFound = true;
                 break;
             }
         }
-        if (!process) {
+        if (!newBuildingFound) {
             return;
         }
         const metaBuildingClass = this.supportedBuildings[newIndex];


### PR DESCRIPTION
Fixed an issue that caused an error when pressing the tab key

It was a combination of the following issues.
* Toolbars on hidden layers are also affected by the tab key.
* If the toolbar has only one item registered, the tab key does not work properly.
