### PR TITLE
Allow TAB to be keybinded

### DIFF
--- a/src/js/states/keybindings.js
+++ b/src/js/states/keybindings.js
@@ -111,9 +111,7 @@ export class KeybindingsState extends TextualGameState {
 
             if (
                 // Enter
-                keyCode === 13 ||
-                // TAB
-                keyCode === 9
+                keyCode === 13
             ) {
                 // Ignore builtins
                 return;


### PR DESCRIPTION
It seems to be intended, but I think there seems to be no problems.
Personally, I want to swap the keybinds of `Cycle Variants` and `Cycle Buildings`.