### PR TITLE
Facilitate Launch Options in ./play.sh

### DIFF
--- a/gulp/standalone.js
+++ b/gulp/standalone.js
@@ -159,7 +159,7 @@ function gulptasksStandalone($, gulp, buildFolder) {
                     fs.writeFileSync(path.join(appPath, ".itch.toml"), tomlFile);
 
                     if (platform === "linux" || platform === "darwin") {
-                        fs.writeFileSync(path.join(appPath, "play.sh"), "#!/usr/bin/env bash\n./shapezio\n");
+                        fs.writeFileSync(path.join(appPath, "play.sh"), "#!/usr/bin/env bash\n./shapezio "$@"\n");
                         fs.chmodSync(path.join(appPath, "play.sh"), 0o775);
                     } else if (platform === "win32") {
                         // Optional: Create a playable copy. Shouldn't be required


### PR DESCRIPTION
Small modification to play.sh that allows launch options to be passed, i.e. --no-sandbox. This enables the game to work with Steam in a Flatpak or other nosuid environments.