### PR TITLE
Change the suffix for large numbers to use SI in Dutch

### DIFF
--- a/translations/base-nl.yaml
+++ b/translations/base-nl.yaml
@@ -76,9 +76,9 @@ global:
 
     # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
     suffix:
-        thousands: k
+        thousands: K
         millions: M
-        billions: B
+        billions: G
         trillions: T
 
     # Shown for infinitely big numbers


### PR DESCRIPTION
Changes made:
 - change 'k' to uppercase 'K' ([source](https://taaladvies.net/taal/advies/vraag/1818/))
 - change 'B' to 'G'

This PR has been made because the English system does not work for Dutch. As `mln.`, `mlj.`, and `bln.` are too long for the game, I suggest using the SI suffixes instead of the English ones.