### PR TITLE
Update colors.js - Fix black + white = gray and not white

### DIFF
--- a/src/js/game/colors.js
+++ b/src/js/game/colors.js
@@ -155,6 +155,9 @@ for (const color in enumColors) {
 
     // Anything with white is white again
     enumColorMixingResults[color][c.white] = c.white;
+    
+    // Black mixed with white is gray
+    enumColorMixingResults[c.black][c.white] = c.uncolored;
 
     // Anything with uncolored is the same color
     enumColorMixingResults[color][c.uncolored] = color;

--- a/src/js/game/colors.js
+++ b/src/js/game/colors.js
@@ -155,7 +155,7 @@ for (const color in enumColors) {
 
     // Anything with white is white again
     enumColorMixingResults[color][c.white] = c.white;
-    
+
     // Black mixed with white is gray
     enumColorMixingResults[c.black][c.white] = c.uncolored;
 


### PR DESCRIPTION
Mixing black and white now correctly create gray paint, and not white anymore

![image](https://user-images.githubusercontent.com/14262612/86755388-f52ffb80-c084-11ea-9559-cc938d208beb.png)
