### PR TITLE
Change the processing time of ItemProcessor so that it only affects the interval and not the speed.

### DIFF
--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -185,7 +185,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
         }
 
         // Precompute effective belt speed
-        let progressGrowth = 2 * this.root.dynamicTickrate.deltaSeconds;
+        let progressGrowth = this.root.dynamicTickrate.deltaSeconds;
 
         if (G_IS_DEV && globalConfig.debug.instantBelts) {
             progressGrowth = 1;

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -29,9 +29,26 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
                 processorComp.secondsUntilEject = 0;
             }
 
-            // Check if we have any finished items we can eject
             if (
                 processorComp.secondsUntilEject === 0 && // it was processed in time
+                processorComp.itemsToEject.length === 0 // Check if we have an empty queue and can start a new charge
+            ) {
+                if (processorComp.inputSlots.length >= processorComp.inputsPerCharge) {
+                    const energyConsumerComp = entity.components.EnergyConsumer;
+                    if (energyConsumerComp) {
+                        // Check if we have enough energy
+                        if (energyConsumerComp.tryStartNextCharge()) {
+                            this.startNewCharge(entity);
+                        }
+                    } else {
+                        // No further checks required
+                        this.startNewCharge(entity);
+                    }
+                }
+            }
+
+            // Check if we have any finished items we can eject
+            if (
                 processorComp.itemsToEject.length > 0 // we have some items left to eject
             ) {
                 for (let itemIndex = 0; itemIndex < processorComp.itemsToEject.length; ++itemIndex) {
@@ -63,22 +80,6 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
                             processorComp.itemsToEject.splice(itemIndex, 1);
                             itemIndex -= 1;
                         }
-                    }
-                }
-            }
-
-            // Check if we have an empty queue and can start a new charge
-            if (processorComp.itemsToEject.length === 0) {
-                if (processorComp.inputSlots.length >= processorComp.inputsPerCharge) {
-                    const energyConsumerComp = entity.components.EnergyConsumer;
-                    if (energyConsumerComp) {
-                        // Check if we have enough energy
-                        if (energyConsumerComp.tryStartNextCharge()) {
-                            this.startNewCharge(entity);
-                        }
-                    } else {
-                        // No further checks required
-                        this.startNewCharge(entity);
                     }
                 }
             }

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -19,21 +19,21 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
             const processorComp = entity.components.ItemProcessor;
             const ejectorComp = entity.components.ItemEjector;
 
-            // First of all, process the current recipe
-            processorComp.secondsUntilEject = Math.max(
-                0,
-                processorComp.secondsUntilEject - this.root.dynamicTickrate.deltaSeconds
-            );
+            if (processorComp.inputSlots.length >= processorComp.inputsPerCharge) {
+                // First of all, process the current recipe
+                processorComp.secondsUntilEject = Math.max(
+                    0,
+                    processorComp.secondsUntilEject - this.root.dynamicTickrate.deltaSeconds
+                );
 
-            if (G_IS_DEV && globalConfig.debug.instantProcessors) {
-                processorComp.secondsUntilEject = 0;
-            }
+                if (G_IS_DEV && globalConfig.debug.instantProcessors) {
+                    processorComp.secondsUntilEject = 0;
+                }
 
-            if (
-                processorComp.secondsUntilEject === 0 && // it was processed in time
-                processorComp.itemsToEject.length === 0 // Check if we have an empty queue and can start a new charge
-            ) {
-                if (processorComp.inputSlots.length >= processorComp.inputsPerCharge) {
+                if (
+                    processorComp.secondsUntilEject === 0 && // it was processed in time
+                    processorComp.itemsToEject.length === 0 // Check if we have an empty queue and can start a new charge
+                ) {
                     const energyConsumerComp = entity.components.EnergyConsumer;
                     if (energyConsumerComp) {
                         // Check if we have enough energy


### PR DESCRIPTION
If ItemProcessor was faster than Belt, it was moving faster than the belt alone.
I think the speed of ItemProcessor is waiting time, not moving speed.

### ItemProcessor > Belt
Current
![PR_beltspeed1](https://user-images.githubusercontent.com/809200/87114339-4ae5ed00-c2ab-11ea-850e-b702d511c581.png)
New
![PR_beltspeed2](https://user-images.githubusercontent.com/809200/87114341-4c171a00-c2ab-11ea-9025-b33278d569ad.png)

### ItemProcessor < Belt
Current
![PR_beltspeed3](https://user-images.githubusercontent.com/809200/87114348-4de0dd80-c2ab-11ea-9bf5-bf2e82e41f3a.png)
New
![PR_beltspeed4](https://user-images.githubusercontent.com/809200/87114353-4faaa100-c2ab-11ea-8126-9e48cf53ea1b.png)
