### PR TITLE
added debug flag 'rewardsSingleShape' - change goal to 1x shape after level 18

### DIFF
--- a/src/js/core/config.local.js
+++ b/src/js/core/config.local.js
@@ -32,6 +32,9 @@ export default {
     // All rewards can be unlocked by passing just 1 of any shape
     // rewardsInstant: true,
     // -----------------------------------------------------------------------------------
+    // Rewards after level 18 can be unlocked by passing just 1 of required shape
+    // rewardsSingleShape: true,
+    // -----------------------------------------------------------------------------------
     // Unlocks all buildings
     // allBuildingsUnlocked: true,
     // -----------------------------------------------------------------------------------

--- a/src/js/game/hub_goals.js
+++ b/src/js/game/hub_goals.js
@@ -210,12 +210,21 @@ export class HubGoals extends BasicSerializableObject {
             return;
         }
 
-        this.currentGoal = {
-            /** @type {ShapeDefinition} */
-            definition: this.createRandomShape(),
-            required: 10000 + findNiceIntegerValue(this.level * 2000),
-            reward: enumHubGoalRewards.no_reward_freeplay,
-        };
+        if (globalConfig.debug.rewardsSingleShape) {
+            this.currentGoal = {
+                /** @type {ShapeDefinition} */
+                definition: this.createRandomShape(),
+                required: 1,
+                reward: enumHubGoalRewards.no_reward_freeplay,
+            };
+        } else {
+            this.currentGoal = {
+                /** @type {ShapeDefinition} */
+                definition: this.createRandomShape(),
+                required: 10000 + findNiceIntegerValue(this.level * 2000),
+                reward: enumHubGoalRewards.no_reward_freeplay,
+            };
+        }
     }
 
     /**

--- a/src/js/game/hub_goals.js
+++ b/src/js/game/hub_goals.js
@@ -217,14 +217,15 @@ export class HubGoals extends BasicSerializableObject {
                 required: 1,
                 reward: enumHubGoalRewards.no_reward_freeplay,
             };
-        } else {
-            this.currentGoal = {
-                /** @type {ShapeDefinition} */
-                definition: this.createRandomShape(),
-                required: 10000 + findNiceIntegerValue(this.level * 2000),
-                reward: enumHubGoalRewards.no_reward_freeplay,
-            };
+            return;
         }
+        this.currentGoal = {
+            /** @type {ShapeDefinition} */
+            definition: this.createRandomShape(),
+            required: 10000 + findNiceIntegerValue(this.level * 2000),
+            reward: enumHubGoalRewards.no_reward_freeplay,
+        };
+        return;
     }
 
     /**


### PR DESCRIPTION
This debug flag changes the required goal to '1' after level 18. Instead of accepting any shape to level up (`rewardsInstant` -flag), you still need to provide the Hub with the specified shape.

![image](https://user-images.githubusercontent.com/14262612/87394946-d89b4280-c5f3-11ea-9dd0-d39749507389.png)
