### PR TITLE
Match belt/processor etc. level to upgrade tiers

### DIFF
--- a/src/js/game/hud/parts/sandbox_controller.js
+++ b/src/js/game/hud/parts/sandbox_controller.js
@@ -105,7 +105,7 @@ export class HUDSandboxController extends BaseHUDPart {
         this.root.hubGoals.upgradeImprovements[id] = improvement;
         this.root.signals.upgradePurchased.dispatch(id);
         this.root.hud.signals.notification.dispatch(
-            "Upgrade '" + id + "' is now at level " + (this.root.hubGoals.upgradeLevels[id] + 1),
+            "Upgrade '" + id + "' is now at tier " + (this.root.hubGoals.upgradeLevels[id] + 1),
             enumNotificationType.upgrade
         );
     }

--- a/src/js/game/hud/parts/sandbox_controller.js
+++ b/src/js/game/hud/parts/sandbox_controller.js
@@ -105,7 +105,7 @@ export class HUDSandboxController extends BaseHUDPart {
         this.root.hubGoals.upgradeImprovements[id] = improvement;
         this.root.signals.upgradePurchased.dispatch(id);
         this.root.hud.signals.notification.dispatch(
-            "Upgrade '" + id + "' is now at level " + this.root.hubGoals.upgradeLevels[id],
+            "Upgrade '" + id + "' is now at level " + (this.root.hubGoals.upgradeLevels[id] + 1),
             enumNotificationType.upgrade
         );
     }


### PR DESCRIPTION
Currently the belt (+ processor) levels do not match to the upgrade shop tiers. The tiers start from Tier 1, and once upgraded, they go to tier 2, 3, ... 7. So tier 7 is currently the highest.

However, the belt level starts from level 0, and increases to level 1 once upgraded. The maximum level is therefore 6.

This PR raises the start level of belts and other items to level 1, meaning the levels match the upgrade tiers in the shop. Makes it easier to talk about levels and tiers when they match.