### PR TITLE
Extend the pipette hack to work with belts and wires.

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -416,6 +416,14 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
                 ) {
                     continue checkVariant;
                 }
+
+                if (metaBuilding.id === "wire" && entity.layer !== enumLayer.wires) {
+                    continue checkVariant;
+                }
+
+                if (metaBuilding.id === "belt" && entity.layer !== enumLayer.regular) {
+                    continue checkVariant;
+                }
                 matches.push({ metaBuilding, variant });
             }
         }


### PR DESCRIPTION
Extended the pipette building check hack to understand the difference between belts and wires. Ideally, we would replace the hack with a proper implementation but that's going to require a re-work of some core code. Outside the scope of a bug fix.

Fixes Bug: https://trello.com/c/oN4qFsiK/263-q-on-belts-doesnt-work-anymore