### PR TITLE
Add TSLint to github actions, fix existing type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,7 @@ jobs:
 
             - name: TSLint
               run: |
+                  cd gulp
+                  yarn gulp translations.fullBuild
+                  cd ..
                   yarn tslint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,7 @@ jobs:
               uses: ibiqlik/action-yamllint@v1.0.0
               with:
                   file_or_dir: translations/*.yaml
+
+            - name: TSLint
+              run: |
+                  yarn tslint

--- a/src/css/states/main_menu.scss
+++ b/src/css/states/main_menu.scss
@@ -201,33 +201,6 @@
             flex-grow: 1;
             @include S(margin-bottom, 10px);
         }
-
-        .contest {
-            flex-grow: 1;
-            background: rgb(32, 187, 166);
-            @include S(padding, 15px);
-
-            h3 {
-                @include Heading;
-                color: #fff;
-                font-weight: bold;
-                text-transform: uppercase;
-                @include S(margin-bottom, 5px);
-            }
-            p {
-                color: #fff;
-                @include Text;
-                strong {
-                    font-weight: bold;
-                }
-                @include S(margin-bottom, 5px);
-            }
-
-            button {
-                background: #fff;
-                color: #333538;
-            }
-        }
     }
 
     .mainContainer {

--- a/src/js/application.js
+++ b/src/js/application.js
@@ -385,7 +385,7 @@ export class Application {
             }
 
             const scale = this.getEffectiveUiScale();
-            waitNextFrame().then(() => document.documentElement.style.setProperty("--ui-scale", scale));
+            waitNextFrame().then(() => document.documentElement.style.setProperty("--ui-scale", `${scale}`));
             window.focus();
         }
     }

--- a/src/js/game/hud/parts/entity_debugger.js
+++ b/src/js/game/hud/parts/entity_debugger.js
@@ -15,7 +15,9 @@ export class HUDEntityDebugger extends BaseHUDPart {
         `
         );
 
+        /** @type {HTMLElement} */
         this.mousePosElem = this.element.querySelector(".mousePos");
+        /** @type {HTMLElement} */
         this.chunkPosElem = this.element.querySelector(".chunkPos");
         this.entityInfoElem = this.element.querySelector(".entityInfo");
     }

--- a/src/js/game/hud/parts/settings_menu.js
+++ b/src/js/game/hud/parts/settings_menu.js
@@ -23,7 +23,7 @@ export class HUDSettingsMenu extends BaseHUDPart {
             <strong>${T.ingame.settingsMenu.beltsPlaced}</strong><span class="beltsPlaced"></span>
             <strong>${T.ingame.settingsMenu.buildingsPlaced}</strong><span class="buildingsPlaced"></span>
             <strong>${T.ingame.settingsMenu.playtime}</strong><span class="playtime"></span>
-            
+
             `
         );
 
@@ -106,16 +106,22 @@ export class HUDSettingsMenu extends BaseHUDPart {
         this.root.app.inputMgr.makeSureAttachedAndOnTop(this.inputReciever);
 
         const totalMinutesPlayed = Math.ceil(this.root.time.now() / 60);
-        this.statsElement.querySelector(".playtime").innerText = T.global.time.xMinutes.replace(
-            "<x>",
-            "" + totalMinutesPlayed
-        );
 
-        this.statsElement.querySelector(".buildingsPlaced").innerText = formatBigNumberFull(
+        /** @type {HTMLElement} */
+        const playtimeElement = this.statsElement.querySelector(".playtime");
+        /** @type {HTMLElement} */
+        const buildingsPlacedElement = this.statsElement.querySelector(".buildingsPlaced");
+        /** @type {HTMLElement} */
+        const beltsPlacedElement = this.statsElement.querySelector(".beltsPlaced");
+
+        playtimeElement.innerText = T.global.time.xMinutes.replace("<x>", `${totalMinutesPlayed}`);
+
+        buildingsPlacedElement.innerText = formatBigNumberFull(
             this.root.entityMgr.getAllWithComponent(StaticMapEntityComponent).length -
                 this.root.entityMgr.getAllWithComponent(BeltComponent).length
         );
-        this.statsElement.querySelector(".beltsPlaced").innerText = formatBigNumberFull(
+
+        beltsPlacedElement.innerText = formatBigNumberFull(
             this.root.entityMgr.getAllWithComponent(BeltComponent).length
         );
     }

--- a/src/js/globals.d.ts
+++ b/src/js/globals.d.ts
@@ -36,11 +36,6 @@ declare interface CanvasRenderingContext2D {
     webkitImageSmoothingEnabled: boolean;
 }
 
-declare interface HTMLCanvasElement {
-    opaque: boolean;
-    webkitOpaque: boolean;
-}
-
 // Just for compatibility with the shared code
 declare interface Logger {
     log(...args);
@@ -125,13 +120,6 @@ declare interface WebpackContext {
 
 declare interface NodeRequire {
     context(src: string, flag: boolean, regexp: RegExp): WebpackContext;
-}
-
-// HTML Element
-declare interface Element {
-    style: any;
-    innerText: string;
-    innerHTML: string;
 }
 
 declare interface Object {

--- a/src/js/platform/ad_providers/adinplay.js
+++ b/src/js/platform/ad_providers/adinplay.js
@@ -102,7 +102,10 @@ export class AdinplayAdProvider extends AdProviderInterface {
 
         // Add the player
         const videoElement = this.adContainerMainElement.querySelector(".videoInner");
-        this.adContainerMainElement.querySelector(".adInner").style.maxWidth = w + "px";
+        /** @type {HTMLElement} */
+        const adInnerElement = this.adContainerMainElement.querySelector(".adInner");
+
+        adInnerElement.style.maxWidth = w + "px";
 
         const self = this;
         window.aiptag.cmd.player.push(function () {

--- a/src/js/profile/setting_types.js
+++ b/src/js/profile/setting_types.js
@@ -40,7 +40,7 @@ export class BaseSetting {
 
     /**
      * @param {Application} app
-     * @param {Element} element
+     * @param {HTMLElement} element
      * @param {any} dialogs
      */
     bind(app, element, dialogs) {
@@ -188,7 +188,7 @@ export class BoolSetting extends BaseSetting {
         return `
         <div class="setting cardbox ${this.enabled ? "enabled" : "disabled"}">
             ${this.enabled ? "" : `<span class="standaloneOnlyHint">${T.demo.settingNotAvailable}</span>`}
-                
+
             <div class="row">
                 <label>${T.settings.labels[this.id].title}</label>
                 <div class="value checkbox checked" data-setting="${this.id}">

--- a/src/js/states/main_menu.js
+++ b/src/js/states/main_menu.js
@@ -46,7 +46,7 @@ export class MainMenuState extends GameState {
                     : ""
             }
             </div>
-            
+
             <video autoplay muted loop class="fullscreenBackgroundVideo">
                 <source src="${cachebust("res/bg_render.webm")}" type="video/webm">
             </video>
@@ -92,10 +92,10 @@ export class MainMenuState extends GameState {
                     <a class="redditLink">${T.mainMenu.subreddit}</a>
 
                     <a class="changelog">${T.changelog.title}</a>
-                
+
                     <a class="helpTranslate">${T.mainMenu.helpTranslate}</a>
                 </div>
-            
+
                 <div class="author">${T.mainMenu.madeBy.replace(
                     "<author-link>",
                     '<a class="producerLink" target="_blank">Tobias Springer</a>'
@@ -218,11 +218,6 @@ export class MainMenuState extends GameState {
         this.trackClicks(qs(".languageChoose"), this.onLanguageChooseClicked);
         this.trackClicks(qs(".helpTranslate"), this.onTranslationHelpLinkClicked);
 
-        const contestButton = qs(".participateContest");
-        if (contestButton) {
-            this.trackClicks(contestButton, this.onContestClicked);
-        }
-
         if (G_IS_STANDALONE) {
             this.trackClicks(qs(".exitAppButton"), this.onExitAppButtonClicked);
         }
@@ -310,15 +305,6 @@ export class MainMenuState extends GameState {
     onRedditClicked() {
         this.app.analytics.trackUiClick("main_menu_reddit_link");
         this.app.platformWrapper.openExternalLink(THIRDPARTY_URLS.reddit);
-    }
-
-    onContestClicked() {
-        this.app.analytics.trackUiClick("contest_click");
-
-        this.dialogs.showInfo(
-            T.mainMenu.contests.contest_01_03062020.title,
-            T.mainMenu.contests.contest_01_03062020.longDesc
-        );
     }
 
     onLanguageChooseClicked() {

--- a/src/js/states/preload.js
+++ b/src/js/states/preload.js
@@ -37,7 +37,7 @@ export class PreloadState extends GameState {
         return false;
     }
 
-    onEnter(payload) {
+    onEnter() {
         this.htmlElement.classList.add("prefab_LoadingState");
 
         const elementsToRemove = ["#loadingPreload", "#fontPreload"];
@@ -52,9 +52,13 @@ export class PreloadState extends GameState {
         const dialogsElement = document.body.querySelector(".modalDialogParent");
         this.dialogs.initializeToElement(dialogsElement);
 
+        /** @type {HTMLElement} */
         this.statusText = this.htmlElement.querySelector(".loadingStatus > .desc");
+        /** @type {HTMLElement} */
         this.statusBar = this.htmlElement.querySelector(".loadingStatus > .bar > .inner");
+        /** @type {HTMLElement} */
         this.statusBarText = this.htmlElement.querySelector(".loadingStatus > .bar > .status");
+
         this.currentStatus = "booting";
         this.currentIndex = 0;
 
@@ -251,12 +255,12 @@ export class PreloadState extends GameState {
                         ${this.currentStatus} failed:<br/>
                         ${text}
                     </div>
-                    
+
                     <div class="supportHelp">
                     Please send me an email with steps to reproduce and what you did before this happened:
                         <br /><a class="email" href="mailto:${email}?subject=App%20does%20not%20launch">${email}</a>
                     </div>
-                        
+
                     <div class="lower">
                         <button class="resetApp styledButton">Reset App</button>
                         <i>Build ${G_BUILD_VERSION} @ ${G_BUILD_COMMIT_HASH}</i>

--- a/src/js/states/settings.js
+++ b/src/js/states/settings.js
@@ -94,6 +94,7 @@ export class SettingsState extends TextualGameState {
 
     initSettings() {
         allApplicationSettings.forEach(setting => {
+            /** @type {HTMLElement} */
             const element = this.htmlElement.querySelector("[data-setting='" + setting.id + "']");
             setting.bind(this.app, element, this.dialogs);
             setting.syncValueToElement();

--- a/src/js/tsconfig.json
+++ b/src/js/tsconfig.json
@@ -3,7 +3,7 @@
         /* Basic Options */
         "target": "es6" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */,
         "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-        // "lib": [],                             /* Specify library files to be included in the compilation. */
+        "lib": ["DOM","ES2018"], /* Specify library files to be included in the compilation. */
         "allowJs": true /* Allow javascript files to be compiled. */,
         "checkJs": true /* Report errors in .js files. */,
         // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */

--- a/translations/base-zh-CN.yaml
+++ b/translations/base-zh-CN.yaml
@@ -181,7 +181,6 @@ mainMenu:
     savegameLevel: 第<x>关
     savegameLevelUnknown:
         未知关卡
-        # contestOver: This contest has ended - Join the discord to get noticed about new contests!
     continue: 继续游戏
     newGame: 新游戏
     madeBy: 作者：<author-link>


### PR DESCRIPTION
It looks like there is a `tslint` job which can be run by CI. Adding it to the Github CI Workflow was easy, fixing the existing type errors was fairly straightforward as well.

## Summary of type fixes
- Add the `DOM` and `ES2018` libs to `tsconfig.json`
- Remove references to the contest which is no longer implemented.
- `global.d.ts` had definitions for Element which conflicted with the typescript definition
- Some instances of querySelector needing to be cast are suboptimal, maybe there's a better approach here

