### PR TITLE
[Perf] Avoid iterating over keys to generate assert message

### DIFF
--- a/src/js/core/sprites.js
+++ b/src/js/core/sprites.js
@@ -159,7 +159,7 @@ export class AtlasSprite extends BaseSprite {
         const link = this.linksByResolution[scale];
 
         if (!link) {
-            assert(false, "Link not known: " + scale + " (having " + Object.keys(this.linksByResolution) + ")");
+            assert(false, `Link not known: ${scale} (having ${Object.keys(this.linksByResolution)})`);
         }
 
         const scaleW = w / link.w;

--- a/src/js/core/sprites.js
+++ b/src/js/core/sprites.js
@@ -158,7 +158,9 @@ export class AtlasSprite extends BaseSprite {
         const scale = parameters.desiredAtlasScale;
         const link = this.linksByResolution[scale];
 
-        assert(link, "Link not known: " + scale);
+        if (!link) {
+            assert(false, "Link not known: " + scale + " (having " + Object.keys(this.linksByResolution) + ")");
+        }
 
         const scaleW = w / link.w;
         const scaleH = h / link.h;

--- a/src/js/core/sprites.js
+++ b/src/js/core/sprites.js
@@ -158,7 +158,7 @@ export class AtlasSprite extends BaseSprite {
         const scale = parameters.desiredAtlasScale;
         const link = this.linksByResolution[scale];
 
-        assert(link, "Link not known: " + scale + " (having " + Object.keys(this.linksByResolution) + ")");
+        assert(link, "Link not known: " + scale);
 
         const scaleW = w / link.w;
         const scaleH = h / link.h;


### PR DESCRIPTION
I did a quick perf check and this line stuck out. Even though the assert is not triggering, it is iterating over all the keys to build the string.

Before:
![shapez-perf-before](https://user-images.githubusercontent.com/20630/88247699-a7003680-ccd9-11ea-9ec0-89eb2302c9e8.png)

After:
![shapez-perf-after](https://user-images.githubusercontent.com/20630/88247709-ac5d8100-ccd9-11ea-9ce2-e0344ae026fe.png)

Profile duration was approximately 15 seconds realtime.

