### PR TITLE
Explicitly list yarn as a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "sass-unused": "^0.3.0",
         "speed-measure-webpack-plugin": "^1.3.1",
         "strip-json-comments": "^3.0.1",
-        "trim": "^0.0.1"
+        "trim": "^0.0.1",
+        "yarn": "^1.22.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9082,6 +9082,11 @@ yargs@^15.3.1:
     y18n "^4.0.0"
     yargs-parser "^18.1.1"
 
+yarn@^1.22.4:
+  version "1.22.4"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.4.tgz#01c1197ca5b27f21edc8bc472cd4c8ce0e5a470e"
+  integrity sha512-oYM7hi/lIWm9bCoDMEWgffW8aiNZXCWeZ1/tGy0DWrN6vmzjCXIKu2Y21o8DYVBUtiktwKcNoxyGl/2iKLUNGA==
+
 yauzl@^2.4.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"


### PR DESCRIPTION
This way, if people aren't using `yarn`, most commands will still work.