### PR TITLE
Add support for a 75hz simulation target

### DIFF
--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -221,7 +221,7 @@ export const allApplicationSettings = [
     }),
 
     new EnumSetting("refreshRate", {
-        options: ["60", "100", "120", "144", "165", "250", G_IS_DEV ? "10" : "500"],
+        options: ["60", "75", "100", "120", "144", "165", "250", G_IS_DEV ? "10" : "500"],
         valueGetter: rate => rate,
         textGetter: rate => rate + " Hz",
         category: enumCategories.advanced,


### PR DESCRIPTION
Entirely untested, I just wanted to avoid having it sit as an issue forever and as such just quickly added it with the GitHub editor. Someone actually check it please. :sweat_smile: