### PR TITLE
Replace enumDirection with string literal Direction

### DIFF
--- a/src/js/core/draw_utils.js
+++ b/src/js/core/draw_utils.js
@@ -9,6 +9,8 @@ import { createLogger } from "./logging";
 
 const logger = createLogger("draw_utils");
 
+/** @typedef {import("./vector").Angle} Angle **/
+
 export function initDrawUtils() {
     CanvasRenderingContext2D.prototype.beginRoundedRect = function (x, y, w, h, r) {
         if (r < 0.05) {
@@ -284,7 +286,7 @@ export function wrapText(context, text, x, y, maxWidth, lineHeight, stroke = fal
  * @param {number} w
  * @param {number} h
  * @param {number} leftHeight
- * @param {number} angle
+ * @param {Angle} angle
  */
 export function rotateTrapezRightFaced(x, y, w, h, leftHeight, angle) {
     const halfY = y + h / 2;

--- a/src/js/core/rectangle.js
+++ b/src/js/core/rectangle.js
@@ -2,6 +2,8 @@ import { globalConfig } from "./config";
 import { clamp, epsilonCompare, round2Digits } from "./utils";
 import { Vector } from "./vector";
 
+/** @typedef {import("./vector").Angle} Angle **/
+
 export class Rectangle {
     constructor(x = 0, y = 0, w = 0, h = 0) {
         this.x = x;
@@ -56,7 +58,7 @@ export class Rectangle {
     /**
      * Returns a rectangle arround a rotated point
      * @param {Array<Vector>} points
-     * @param {number} angle
+     * @param {Angle} angle
      * @returns {Rectangle}
      */
     static getAroundPointsRotated(points, angle) {

--- a/src/js/game/blueprint.js
+++ b/src/js/game/blueprint.js
@@ -1,7 +1,7 @@
 import { DrawParameters } from "../core/draw_parameters";
 import { Loader } from "../core/loader";
 import { createLogger } from "../core/logging";
-import { Vector } from "../core/vector";
+import { clockwiseAngleMap, counterClockwiseAngleMap, Vector } from "../core/vector";
 import { Entity } from "./entity";
 import { GameRoot, enumLayer } from "./root";
 import { findNiceIntegerValue } from "../core/utils";
@@ -111,19 +111,23 @@ export class Blueprint {
             const entity = this.entities[i];
             const staticComp = entity.components.StaticMapEntity;
 
-            staticComp.rotation = (staticComp.rotation + 90) % 360;
-            staticComp.originalRotation = (staticComp.originalRotation + 90) % 360;
+            staticComp.rotation = clockwiseAngleMap[staticComp.rotation];
+            staticComp.originalRotation = clockwiseAngleMap[staticComp.originalRotation];
             staticComp.origin = staticComp.origin.rotateFastMultipleOf90(90);
         }
     }
 
     /**
-     * Rotates the blueprint counter clock wise
+     * Rotates the blueprint counter-clockwise
      */
     rotateCcw() {
-        // Well ...
-        for (let i = 0; i < 3; ++i) {
-            this.rotateCw();
+        for (let i = 0; i < this.entities.length; ++i) {
+            const entity = this.entities[i];
+            const staticComp = entity.components.StaticMapEntity;
+
+            staticComp.rotation = counterClockwiseAngleMap[staticComp.rotation];
+            staticComp.originalRotation = counterClockwiseAngleMap[staticComp.originalRotation];
+            staticComp.origin = staticComp.origin.rotateFastMultipleOf90(270);
         }
     }
 

--- a/src/js/game/buildings/advanced_processor.js
+++ b/src/js/game/buildings/advanced_processor.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { enumItemType } from "../base_item";
 import { EnergyConsumerComponent } from "../components/energy_consumer";
@@ -57,8 +57,8 @@ export class MetaAdvancedProcessorBuilding extends MetaBuilding {
         entity.addComponent(
             new ItemEjectorComponent({
                 slots: [
-                    { pos: new Vector(1, 0), direction: enumDirection.right },
-                    { pos: new Vector(1, 0), direction: enumDirection.top, layer: enumLayer.wires },
+                    { pos: new Vector(1, 0), direction: "right" },
+                    { pos: new Vector(1, 0), direction: "top", layer: enumLayer.wires },
                 ],
             })
         );
@@ -77,12 +77,12 @@ export class MetaAdvancedProcessorBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                         type: enumPinSlotType.positiveEnergyAcceptor,
                     },
                     {
                         pos: new Vector(1, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                         type: enumPinSlotType.negativeEnergyEjector,
                     },
                 ],
@@ -93,11 +93,11 @@ export class MetaAdvancedProcessorBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 1),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                     },
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: enumItemType.positiveEnergy,
                         layer: enumLayer.wires,
                     },

--- a/src/js/game/buildings/belt.js
+++ b/src/js/game/buildings/belt.js
@@ -1,5 +1,4 @@
 import { Loader } from "../../core/loader";
-import { enumDirection } from "../../core/vector";
 import { SOUNDS } from "../../platform/sound";
 import { arrayBeltVariantToRotation, MetaBeltBaseBuilding } from "./belt_base";
 
@@ -18,13 +17,13 @@ export class MetaBeltBuilding extends MetaBeltBaseBuilding {
 
     getPreviewSprite(rotationVariant) {
         switch (arrayBeltVariantToRotation[rotationVariant]) {
-            case enumDirection.top: {
+            case "top": {
                 return Loader.getSprite("sprites/buildings/belt_top.png");
             }
-            case enumDirection.left: {
+            case "left": {
                 return Loader.getSprite("sprites/buildings/belt_left.png");
             }
-            case enumDirection.right: {
+            case "right": {
                 return Loader.getSprite("sprites/buildings/belt_right.png");
             }
             default: {
@@ -35,13 +34,13 @@ export class MetaBeltBuilding extends MetaBeltBaseBuilding {
 
     getBlueprintSprite(rotationVariant) {
         switch (arrayBeltVariantToRotation[rotationVariant]) {
-            case enumDirection.top: {
+            case "top": {
                 return Loader.getSprite("sprites/blueprints/belt_top.png");
             }
-            case enumDirection.left: {
+            case "left": {
                 return Loader.getSprite("sprites/blueprints/belt_left.png");
             }
-            case enumDirection.right: {
+            case "right": {
                 return Loader.getSprite("sprites/blueprints/belt_right.png");
             }
             default: {

--- a/src/js/game/buildings/belt_base.js
+++ b/src/js/game/buildings/belt_base.js
@@ -1,5 +1,11 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumAngleToDirection, enumDirection, Vector } from "../../core/vector";
+import {
+    angleDirectionMap,
+    clockwiseAngleMap,
+    counterClockwiseAngleMap,
+    inverseAngleMap,
+    Vector,
+} from "../../core/vector";
 import { SOUNDS } from "../../platform/sound";
 import { T } from "../../translations";
 import { BeltComponent } from "../components/belt";
@@ -10,7 +16,13 @@ import { Entity } from "../entity";
 import { MetaBuilding } from "../meta_building";
 import { GameRoot, enumLayer } from "../root";
 
-export const arrayBeltVariantToRotation = [enumDirection.top, enumDirection.left, enumDirection.right];
+/**
+ * @typedef {import("../../core/vector").Angle} Angle
+ * @typedef {import("../../core/vector").Direction} Direction
+ */
+
+/** @type {Direction[]} **/
+export const arrayBeltVariantToRotation = ["top", "left", "right"];
 
 export class MetaBeltBaseBuilding extends MetaBuilding {
     getHasDirectionLockAvailable() {
@@ -50,7 +62,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
     setupEntityComponents(entity) {
         entity.addComponent(
             new BeltComponent({
-                direction: enumDirection.top, // updated later
+                direction: "top", // updated later
             })
         );
         // Make this entity replaceabel
@@ -61,7 +73,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         layer: this.getLayer(),
                     },
                 ],
@@ -74,7 +86,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top, // updated later
+                        direction: "top", // updated later
                         layer: this.getLayer(),
                     },
                 ],
@@ -98,16 +110,16 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
      * @param {object} param0
      * @param {GameRoot} param0.root
      * @param {Vector} param0.tile
-     * @param {number} param0.rotation
+     * @param {Angle} param0.rotation
      * @param {string} param0.variant
      * @param {string} param0.layer
-     * @return {{ rotation: number, rotationVariant: number, connectedEntities?: Array<Entity> }}
+     * @return {{ rotation: Angle, rotationVariant: number, connectedEntities?: Array<Entity> }}
      */
     computeOptimalDirectionAndRotationVariantAtTile({ root, tile, rotation, variant, layer }) {
-        const topDirection = enumAngleToDirection[rotation];
-        const rightDirection = enumAngleToDirection[(rotation + 90) % 360];
-        const bottomDirection = enumAngleToDirection[(rotation + 180) % 360];
-        const leftDirection = enumAngleToDirection[(rotation + 270) % 360];
+        const topDirection = angleDirectionMap[rotation];
+        const rightDirection = angleDirectionMap[clockwiseAngleMap[rotation]];
+        const bottomDirection = angleDirectionMap[inverseAngleMap[rotation]];
+        const leftDirection = angleDirectionMap[counterClockwiseAngleMap[rotation]];
 
         const { ejectors, acceptors } = root.logic.getEjectorsAndAcceptorsAtTile(tile, layer);
 
@@ -152,7 +164,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
 
             if (hasRightEjector && !hasLeftEjector) {
                 return {
-                    rotation: (rotation + 270) % 360,
+                    rotation: counterClockwiseAngleMap[rotation],
                     rotationVariant: 2,
                 };
             }
@@ -161,7 +173,7 @@ export class MetaBeltBaseBuilding extends MetaBuilding {
             // do a curve from the right to the top
             if (hasLeftEjector && !hasRightEjector) {
                 return {
-                    rotation: (rotation + 90) % 360,
+                    rotation: clockwiseAngleMap[rotation],
                     rotationVariant: 1,
                 };
             }

--- a/src/js/game/buildings/cutter.js
+++ b/src/js/game/buildings/cutter.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -81,7 +81,7 @@ export class MetaCutterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.shape,
                     },
                 ],
@@ -99,18 +99,18 @@ export class MetaCutterBuilding extends MetaBuilding {
         switch (variant) {
             case defaultBuildingVariant: {
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                    { pos: new Vector(1, 0), direction: enumDirection.top },
+                    { pos: new Vector(0, 0), direction: "top" },
+                    { pos: new Vector(1, 0), direction: "top" },
                 ]);
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.cutter;
                 break;
             }
             case enumCutterVariants.quad: {
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                    { pos: new Vector(1, 0), direction: enumDirection.top },
-                    { pos: new Vector(2, 0), direction: enumDirection.top },
-                    { pos: new Vector(3, 0), direction: enumDirection.top },
+                    { pos: new Vector(0, 0), direction: "top" },
+                    { pos: new Vector(1, 0), direction: "top" },
+                    { pos: new Vector(2, 0), direction: "top" },
+                    { pos: new Vector(3, 0), direction: "top" },
                 ]);
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.cutterQuad;
                 break;

--- a/src/js/game/buildings/energy_generator.js
+++ b/src/js/game/buildings/energy_generator.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { enumItemType } from "../base_item";
 import { EnergyGeneratorComponent } from "../components/energy_generator";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
@@ -50,17 +50,17 @@ export class MetaEnergyGenerator extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 1),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(1, 1),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         layer: enumLayer.wires,
                         filter: enumItemType.negativeEnergy,
                     },
@@ -73,7 +73,7 @@ export class MetaEnergyGenerator extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                         layer: enumLayer.wires,
                     },
                 ],
@@ -95,12 +95,12 @@ export class MetaEnergyGenerator extends MetaBuilding {
                     {
                         pos: new Vector(0, 0),
                         type: enumPinSlotType.positiveEnergyEjector,
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                     {
                         pos: new Vector(1, 0),
                         type: enumPinSlotType.negativeEnergyAcceptor,
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                 ],
             })

--- a/src/js/game/buildings/hub.js
+++ b/src/js/game/buildings/hub.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { enumItemType } from "../base_item";
 import { HubComponent } from "../components/hub";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
@@ -52,72 +52,72 @@ export class MetaHubBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.top, enumDirection.left],
+                        directions: ["top", "left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(2, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(3, 0),
-                        directions: [enumDirection.top, enumDirection.right],
+                        directions: ["top", "right"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(0, 3),
-                        directions: [enumDirection.bottom, enumDirection.left],
+                        directions: ["bottom", "left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(1, 3),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(2, 3),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(3, 3),
-                        directions: [enumDirection.bottom, enumDirection.right],
+                        directions: ["bottom", "right"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(0, 1),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(0, 2),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(0, 3),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(3, 1),
-                        directions: [enumDirection.right],
+                        directions: ["right"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(3, 2),
-                        directions: [enumDirection.right],
+                        directions: ["right"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(3, 3),
-                        directions: [enumDirection.right],
+                        directions: ["right"],
                         filter: enumItemType.shape,
                     },
                 ],

--- a/src/js/game/buildings/miner.js
+++ b/src/js/game/buildings/miner.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { MinerComponent } from "../components/miner";
 import { Entity } from "../entity";
@@ -49,7 +49,7 @@ export class MetaMinerBuilding extends MetaBuilding {
         entity.addComponent(new MinerComponent({}));
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(0, 0), direction: enumDirection.top }],
+                slots: [{ pos: new Vector(0, 0), direction: "top" }],
             })
         );
     }

--- a/src/js/game/buildings/mixer.js
+++ b/src/js/game/buildings/mixer.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { enumItemType } from "../base_item";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
@@ -54,7 +54,7 @@ export class MetaMixerBuilding extends MetaBuilding {
 
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(0, 0), direction: enumDirection.top }],
+                slots: [{ pos: new Vector(0, 0), direction: "top" }],
             })
         );
         entity.addComponent(
@@ -62,12 +62,12 @@ export class MetaMixerBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.color,
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.color,
                     },
                 ],

--- a/src/js/game/buildings/painter.js
+++ b/src/js/game/buildings/painter.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -89,7 +89,7 @@ export class MetaPainterBuilding extends MetaBuilding {
 
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(1, 0), direction: enumDirection.right }],
+                slots: [{ pos: new Vector(1, 0), direction: "right" }],
             })
         );
         entity.addComponent(
@@ -97,12 +97,12 @@ export class MetaPainterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: enumItemType.color,
                     },
                 ],
@@ -123,87 +123,77 @@ export class MetaPainterBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [
-                            variant === defaultBuildingVariant ? enumDirection.top : enumDirection.bottom,
-                        ],
+                        directions: [variant === defaultBuildingVariant ? "top" : "bottom"],
                         filter: enumItemType.color,
                     },
                 ]);
 
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.painter;
                 entity.components.ItemProcessor.inputsPerCharge = 2;
-                entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(1, 0), direction: enumDirection.right },
-                ]);
+                entity.components.ItemEjector.setSlots([{ pos: new Vector(1, 0), direction: "right" }]);
                 break;
             }
             case enumPainterVariants.double: {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(0, 1),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: enumItemType.color,
                     },
                 ]);
 
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.painterDouble;
                 entity.components.ItemProcessor.inputsPerCharge = 3;
-
-                entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(1, 0), direction: enumDirection.right },
-                ]);
+                entity.components.ItemEjector.setSlots([{ pos: new Vector(1, 0), direction: "right" }]);
                 break;
             }
             case enumPainterVariants.quad: {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.color,
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.color,
                     },
                     {
                         pos: new Vector(2, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.color,
                     },
                     {
                         pos: new Vector(3, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.color,
                     },
                 ]);
 
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.painterQuad;
                 entity.components.ItemProcessor.inputsPerCharge = 5;
-
-                entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                ]);
+                entity.components.ItemEjector.setSlots([{ pos: new Vector(0, 0), direction: "top" }]);
                 break;
             }
             default:

--- a/src/js/game/buildings/rotater.js
+++ b/src/js/game/buildings/rotater.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -80,7 +80,7 @@ export class MetaRotaterBuilding extends MetaBuilding {
 
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(0, 0), direction: enumDirection.top }],
+                slots: [{ pos: new Vector(0, 0), direction: "top" }],
             })
         );
         entity.addComponent(
@@ -88,7 +88,7 @@ export class MetaRotaterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.shape,
                     },
                 ],

--- a/src/js/game/buildings/splitter.js
+++ b/src/js/game/buildings/splitter.js
@@ -1,5 +1,5 @@
 import { globalConfig } from "../../core/config";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { enumItemProcessorTypes, ItemProcessorComponent } from "../components/item_processor";
@@ -102,22 +102,22 @@ export class MetaSplitterBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                 ]);
 
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                    { pos: new Vector(1, 0), direction: enumDirection.top },
+                    { pos: new Vector(0, 0), direction: "top" },
+                    { pos: new Vector(1, 0), direction: "top" },
                 ]);
 
                 entity.components.ItemAcceptor.beltUnderlays = [
-                    { pos: new Vector(0, 0), direction: enumDirection.top, layer: enumLayer.regular },
-                    { pos: new Vector(1, 0), direction: enumDirection.top, layer: enumLayer.regular },
+                    { pos: new Vector(0, 0), direction: "top", layer: enumLayer.regular },
+                    { pos: new Vector(1, 0), direction: "top", layer: enumLayer.regular },
                 ];
 
                 break;
@@ -127,24 +127,18 @@ export class MetaSplitterBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                     {
                         pos: new Vector(0, 0),
-                        directions: [
-                            variant === enumSplitterVariants.compactInverse
-                                ? enumDirection.left
-                                : enumDirection.right,
-                        ],
+                        directions: [variant === enumSplitterVariants.compactInverse ? "left" : "right"],
                     },
                 ]);
 
-                entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                ]);
+                entity.components.ItemEjector.setSlots([{ pos: new Vector(0, 0), direction: "top" }]);
 
                 entity.components.ItemAcceptor.beltUnderlays = [
-                    { pos: new Vector(0, 0), direction: enumDirection.top, layer: enumLayer.regular },
+                    { pos: new Vector(0, 0), direction: "top", layer: enumLayer.regular },
                 ];
 
                 break;

--- a/src/js/game/buildings/stacker.js
+++ b/src/js/game/buildings/stacker.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -54,7 +54,7 @@ export class MetaStackerBuilding extends MetaBuilding {
 
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(0, 0), direction: enumDirection.top }],
+                slots: [{ pos: new Vector(0, 0), direction: "top" }],
             })
         );
         entity.addComponent(
@@ -62,12 +62,12 @@ export class MetaStackerBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.shape,
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: enumItemType.shape,
                     },
                 ],

--- a/src/js/game/buildings/trash.js
+++ b/src/js/game/buildings/trash.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { enumItemProcessorTypes, ItemProcessorComponent } from "../components/item_processor";
@@ -85,12 +85,7 @@ export class MetaTrashBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [
-                            enumDirection.top,
-                            enumDirection.right,
-                            enumDirection.bottom,
-                            enumDirection.left,
-                        ],
+                        directions: ["top", "right", "bottom", "left"],
                     },
                 ],
             })
@@ -121,12 +116,7 @@ export class MetaTrashBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [
-                            enumDirection.top,
-                            enumDirection.right,
-                            enumDirection.bottom,
-                            enumDirection.left,
-                        ],
+                        directions: ["top", "right", "bottom", "left"],
                     },
                 ]);
                 entity.components.ItemEjector.setSlots([]);
@@ -145,22 +135,22 @@ export class MetaTrashBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 1),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                     {
                         pos: new Vector(1, 1),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                 ]);
 
                 entity.components.ItemEjector.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                     {
                         pos: new Vector(1, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                 ]);
                 break;

--- a/src/js/game/buildings/underground_belt.js
+++ b/src/js/game/buildings/underground_belt.js
@@ -1,5 +1,5 @@
 import { Loader } from "../../core/loader";
-import { enumDirection, Vector, enumAngleToDirection, enumDirectionToVector } from "../../core/vector";
+import { Vector, angleDirectionMap, directionVectorMap, inverseAngleMap } from "../../core/vector";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { enumUndergroundBeltMode, UndergroundBeltComponent } from "../components/underground_belt";
@@ -10,6 +10,8 @@ import { globalConfig } from "../../core/config";
 import { enumHubGoalRewards } from "../tutorial_goals";
 import { formatItemsPerSecond } from "../../core/utils";
 import { T } from "../../translations";
+
+/** @typedef {import("../../core/vector").Angle} Angle **/
 
 /** @enum {string} */
 export const arrayUndergroundRotationVariantToMode = [
@@ -151,17 +153,17 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
      * @param {object} param0
      * @param {GameRoot} param0.root
      * @param {Vector} param0.tile
-     * @param {number} param0.rotation
+     * @param {Angle} param0.rotation
      * @param {string} param0.variant
      * @param {string} param0.layer
-     * @return {{ rotation: number, rotationVariant: number, connectedEntities?: Array<Entity> }}
+     * @return {{ rotation: Angle, rotationVariant: number, connectedEntities?: Array<Entity> }}
      */
     computeOptimalDirectionAndRotationVariantAtTile({ root, tile, rotation, variant, layer }) {
-        const searchDirection = enumAngleToDirection[rotation];
-        const searchVector = enumDirectionToVector[searchDirection];
+        const searchDirection = angleDirectionMap[rotation];
+        const searchVector = directionVectorMap[searchDirection];
         const tier = enumUndergroundBeltVariantToTier[variant];
 
-        const targetRotation = (rotation + 180) % 360;
+        const targetRotation = inverseAngleMap[rotation];
         const targetSenderRotation = rotation;
 
         for (
@@ -191,7 +193,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                         // Draw connections to receivers
                         if (undergroundComp.mode === enumUndergroundBeltMode.receiver) {
                             return {
-                                rotation: rotation,
+                                rotation,
                                 rotationVariant: 0,
                                 connectedEntities: [contents],
                             };
@@ -225,7 +227,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                 ]);
                 return;
@@ -236,7 +238,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                 entity.components.ItemEjector.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                 ]);
                 return;

--- a/src/js/game/buildings/wire_base.js
+++ b/src/js/game/buildings/wire_base.js
@@ -1,5 +1,4 @@
 import { Loader } from "../../core/loader";
-import { enumDirection } from "../../core/vector";
 import { enumLayer } from "../root";
 import { arrayBeltVariantToRotation, MetaBeltBaseBuilding } from "./belt_base";
 
@@ -18,13 +17,13 @@ export class MetaWireBaseBuilding extends MetaBeltBaseBuilding {
 
     getPreviewSprite(rotationVariant) {
         switch (arrayBeltVariantToRotation[rotationVariant]) {
-            case enumDirection.top: {
+            case "top": {
                 return Loader.getSprite("sprites/buildings/wire_top.png");
             }
-            case enumDirection.left: {
+            case "left": {
                 return Loader.getSprite("sprites/buildings/wire_left.png");
             }
-            case enumDirection.right: {
+            case "right": {
                 return Loader.getSprite("sprites/buildings/wire_right.png");
             }
             default: {
@@ -35,13 +34,13 @@ export class MetaWireBaseBuilding extends MetaBeltBaseBuilding {
 
     getBlueprintSprite(rotationVariant) {
         switch (arrayBeltVariantToRotation[rotationVariant]) {
-            case enumDirection.top: {
+            case "top": {
                 return Loader.getSprite("sprites/blueprints/wire_top.png");
             }
-            case enumDirection.left: {
+            case "left": {
                 return Loader.getSprite("sprites/blueprints/wire_left.png");
             }
-            case enumDirection.right: {
+            case "right": {
                 return Loader.getSprite("sprites/blueprints/wire_right.png");
             }
             default: {

--- a/src/js/game/buildings/wire_crossings.js
+++ b/src/js/game/buildings/wire_crossings.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { enumItemType } from "../base_item";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -82,14 +82,14 @@ export class MetaWireCrossingsBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         layer: enumLayer.wires,
                     },
                 ]);
 
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top, layer: enumLayer.wires },
-                    { pos: new Vector(0, 0), direction: enumDirection.right, layer: enumLayer.wires },
+                    { pos: new Vector(0, 0), direction: "top", layer: enumLayer.wires },
+                    { pos: new Vector(0, 0), direction: "right", layer: enumLayer.wires },
                 ]);
 
                 break;
@@ -98,18 +98,18 @@ export class MetaWireCrossingsBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         layer: enumLayer.wires,
                     },
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.right],
+                        directions: ["right"],
                         layer: enumLayer.wires,
                     },
                 ]);
 
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.bottom, layer: enumLayer.wires },
+                    { pos: new Vector(0, 0), direction: "bottom", layer: enumLayer.wires },
                 ]);
                 break;
             }

--- a/src/js/game/components/belt.js
+++ b/src/js/game/components/belt.js
@@ -1,9 +1,11 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { types } from "../../savegame/serialization";
 import { BeltPath } from "../belt_path";
 import { Component } from "../component";
 import { Entity } from "../entity";
 import { enumLayer } from "../root";
+
+/** @typedef {import("../../core/vector").Direction} Direction **/
 
 export const curvedBeltLength = /* Math.PI / 4 */ 0.78;
 
@@ -26,9 +28,9 @@ export class BeltComponent extends Component {
     /**
      *
      * @param {object} param0
-     * @param {enumDirection=} param0.direction The direction of the belt
+     * @param {Direction=} param0.direction The direction of the belt
      */
-    constructor({ direction = enumDirection.top }) {
+    constructor({ direction = "top" }) {
         super();
 
         this.direction = direction;
@@ -53,7 +55,7 @@ export class BeltComponent extends Component {
         if (layer === enumLayer.wires) {
             return 1.0;
         }
-        return this.direction === enumDirection.top ? 1.0 : curvedBeltLength;
+        return this.direction === "top" ? 1.0 : curvedBeltLength;
     }
 
     /**
@@ -69,11 +71,11 @@ export class BeltComponent extends Component {
         switch (layer) {
             case enumLayer.regular: {
                 switch (this.direction) {
-                    case enumDirection.top:
+                    case "top":
                         assert(progress <= 1.02, "Invalid progress: " + progress);
                         return new Vector(0, 0.5 - progress);
 
-                    case enumDirection.right: {
+                    case "right": {
                         assert(progress <= curvedBeltLength + 0.02, "Invalid progress 2: " + progress);
                         const arcProgress = (progress / curvedBeltLength) * 0.5 * Math.PI;
                         return new Vector(
@@ -81,7 +83,7 @@ export class BeltComponent extends Component {
                             0.5 - 0.5 * Math.sin(arcProgress)
                         );
                     }
-                    case enumDirection.left: {
+                    case "left": {
                         assert(progress <= curvedBeltLength + 0.02, "Invalid progress 3: " + progress);
                         const arcProgress = (progress / curvedBeltLength) * 0.5 * Math.PI;
                         return new Vector(
@@ -97,15 +99,15 @@ export class BeltComponent extends Component {
             case enumLayer.wires: {
                 const pow = 0.5;
                 switch (this.direction) {
-                    case enumDirection.top:
+                    case "top":
                         assert(progress <= 1.02, "Invalid progress: " + progress);
                         return new Vector(0, 0.5 - progress);
 
-                    case enumDirection.right: {
+                    case "right": {
                         assert(progress <= 1.02, "Invalid progress 2: " + progress);
                         return progress > 0.5 ? new Vector(progress - 0.5, 0) : new Vector(0, 0.5 - progress);
                     }
-                    case enumDirection.left: {
+                    case "left": {
                         assert(progress <= 1.02, "Invalid progress 3: " + progress);
                         return progress > 0.5
                             ? new Vector(-progress + 0.5, 0)

--- a/src/js/game/components/item_acceptor.js
+++ b/src/js/game/components/item_acceptor.js
@@ -1,30 +1,34 @@
-import { enumDirection, enumInvertedDirections, Vector } from "../../core/vector";
+import { directions, invertedDirectionMap } from "../../core/vector";
 import { types } from "../../savegame/serialization";
 import { BaseItem, enumItemType } from "../base_item";
 import { Component } from "../component";
 import { enumLayer } from "../root";
 
-/** @typedef {{
- * pos: Vector,
- * directions: enumDirection[],
- * layer: enumLayer,
- * filter?: enumItemType
- * }} ItemAcceptorSlot */
-
 /**
+ * @typedef {import("../../core/vector").Direction} Direction
+ * @typedef {import("../../core/vector").Vector} Vector
+ *
+ * @typedef {{
+ *   pos: Vector,
+ *   directions: Direction[],
+ *   layer: enumLayer,
+ *   filter?: enumItemType
+ * }} ItemAcceptorSlot
+ *
  * Contains information about a slot plus its location
  * @typedef {{
- *  slot: ItemAcceptorSlot,
- *  index: number,
- *  acceptedDirection: enumDirection
- * }} ItemAcceptorLocatedSlot */
-
-/** @typedef {{
- * pos: Vector,
- * directions: enumDirection[],
- * layer?: enumLayer,
- * filter?: enumItemType
- * }} ItemAcceptorSlotConfig */
+ *   slot: ItemAcceptorSlot,
+ *   index: number,
+ *   acceptedDirection: Direction
+ * }} ItemAcceptorLocatedSlot
+ *
+ * @typedef {{
+ *   pos: Vector,
+ *   directions: Direction[],
+ *   layer?: enumLayer,
+ *  filter?: enumItemType
+ * }} ItemAcceptorSlotConfig
+ */
 
 export class ItemAcceptorComponent extends Component {
     static getId() {
@@ -36,7 +40,7 @@ export class ItemAcceptorComponent extends Component {
             slots: types.array(
                 types.structured({
                     pos: types.vector,
-                    directions: types.array(types.enum(enumDirection)),
+                    directions: types.array(types.enum(directions)),
                     filter: types.nullable(types.enum(enumItemType)),
 
                     // TODO: MIGRATE
@@ -47,7 +51,7 @@ export class ItemAcceptorComponent extends Component {
             beltUnderlays: types.array(
                 types.structured({
                     pos: types.vector,
-                    direction: types.enum(enumDirection),
+                    direction: types.enum(directions),
 
                     // TODO: MIGRATE
                     layer: types.enum(enumLayer),
@@ -90,7 +94,7 @@ export class ItemAcceptorComponent extends Component {
      * @param {object} param0
      * @param {Array<ItemAcceptorSlotConfig>} param0.slots The slots from which we accept items
      * @param {boolean=} param0.animated Whether to animate item consumption
-     * @param {Array<{pos: Vector, direction: enumDirection, layer: enumLayer}>=} param0.beltUnderlays Where to render belt underlays
+     * @param {Array<{pos: Vector, direction: Direction, layer: enumLayer}>=} param0.beltUnderlays Where to render belt underlays
      */
     constructor({ slots = [], beltUnderlays = [], animated = true }) {
         super();
@@ -99,7 +103,7 @@ export class ItemAcceptorComponent extends Component {
 
         /**
          * Fixes belt animations
-         * @type {Array<{ item: BaseItem, slotIndex: number, animProgress: number, direction: enumDirection }>}
+         * @type {Array<{ item: BaseItem, slotIndex: number, animProgress: number, direction: Direction }>}
          */
         this.itemConsumptionAnimations = [];
 
@@ -160,7 +164,7 @@ export class ItemAcceptorComponent extends Component {
     /**
      * Called when an item has been accepted so that
      * @param {number} slotIndex
-     * @param {enumDirection} direction
+     * @param {Direction} direction
      * @param {BaseItem} item
      */
     onItemAccepted(slotIndex, direction, item) {
@@ -177,7 +181,7 @@ export class ItemAcceptorComponent extends Component {
     /**
      * Tries to find a slot which accepts the current item
      * @param {Vector} targetLocalTile
-     * @param {enumDirection} fromLocalDirection
+     * @param {Direction} fromLocalDirection
      * @param {enumLayer} layer
      * @returns {ItemAcceptorLocatedSlot|null}
      */
@@ -185,7 +189,7 @@ export class ItemAcceptorComponent extends Component {
         // We need to invert our direction since the acceptor specifies *from* which direction
         // it accepts items, but the ejector specifies *into* which direction it ejects items.
         // E.g.: Ejector ejects into "right" direction but acceptor accepts from "left" direction.
-        const desiredDirection = enumInvertedDirections[fromLocalDirection];
+        const desiredDirection = invertedDirectionMap[fromLocalDirection];
 
         // Go over all slots and try to find a target slot
         for (let slotIndex = 0; slotIndex < this.slots.length; ++slotIndex) {

--- a/src/js/game/components/item_ejector.js
+++ b/src/js/game/components/item_ejector.js
@@ -1,4 +1,4 @@
-import { Vector, enumDirection, enumDirectionToVector } from "../../core/vector";
+import { directions, directionVectorMap, Vector } from "../../core/vector";
 import { BaseItem } from "../base_item";
 import { Component } from "../component";
 import { types } from "../../savegame/serialization";
@@ -7,13 +7,15 @@ import { Entity } from "../entity";
 import { enumLayer } from "../root";
 
 /**
+ * @typedef {import("../../core/vector").Direction} Direction
+ * @typedef {import("./item_acceptor").ItemAcceptorLocatedSlot} ItemAcceptorLocatedSlot
  * @typedef {{
  *    pos: Vector,
- *    direction: enumDirection,
+ *    direction: Direction,
  *    item: BaseItem,
  *    layer: enumLayer,
  *    progress: number?,
- *    cachedDestSlot?: import("./item_acceptor").ItemAcceptorLocatedSlot,
+ *    cachedDestSlot?: ItemAcceptorLocatedSlot,
  *    cachedTargetEntity?: Entity
  * }} ItemEjectorSlot
  */
@@ -31,7 +33,7 @@ export class ItemEjectorComponent extends Component {
             slots: types.array(
                 types.structured({
                     pos: types.vector,
-                    direction: types.enum(enumDirection),
+                    direction: types.enum(directions),
                     item: types.nullable(types.obj(gItemRegistry)),
                     progress: types.float,
 
@@ -62,7 +64,7 @@ export class ItemEjectorComponent extends Component {
     /**
      *
      * @param {object} param0
-     * @param {Array<{pos: Vector, direction: enumDirection, layer?: enumLayer}>=} param0.slots The slots to eject on
+     * @param {Array<{pos: Vector, direction: Direction, layer?: enumLayer}>=} param0.slots The slots to eject on
      * @param {boolean=} param0.instantEject If the ejection is instant
      */
     constructor({ slots = [], instantEject = false }) {
@@ -83,7 +85,7 @@ export class ItemEjectorComponent extends Component {
     }
 
     /**
-     * @param {Array<{pos: Vector, direction: enumDirection, layer?: enumLayer}>} slots The slots to eject on
+     * @param {Array<{pos: Vector, direction: Direction, layer?: enumLayer}>} slots The slots to eject on
      */
     setSlots(slots) {
         /** @type {Array<ItemEjectorSlot>} */
@@ -109,7 +111,7 @@ export class ItemEjectorComponent extends Component {
      */
     getSlotTargetLocalTile(index) {
         const slot = this.slots[index];
-        const directionVector = enumDirectionToVector[slot.direction];
+        const directionVector = directionVectorMap[slot.direction];
         return slot.pos.add(directionVector);
     }
 

--- a/src/js/game/components/static_map_entity.js
+++ b/src/js/game/components/static_map_entity.js
@@ -2,10 +2,15 @@ import { globalConfig } from "../../core/config";
 import { DrawParameters } from "../../core/draw_parameters";
 import { Rectangle } from "../../core/rectangle";
 import { AtlasSprite } from "../../core/sprites";
-import { enumDirection, Vector } from "../../core/vector";
+import { directionRotationMap, inverseAngleMap, Vector } from "../../core/vector";
 import { types } from "../../savegame/serialization";
 import { Component } from "../component";
 import { getBuildingDataFromCode } from "../building_codes";
+
+/**
+ * @typedef {import("../../core/vector").Angle} Angle
+ * @typedef {import("../../core/vector").Direction} Direction
+ */
 
 export class StaticMapEntityComponent extends Component {
     static getId() {
@@ -63,8 +68,8 @@ export class StaticMapEntityComponent extends Component {
      * @param {object} param0
      * @param {Vector=} param0.origin Origin (Top Left corner) of the entity
      * @param {Vector=} param0.tileSize Size of the entity in tiles
-     * @param {number=} param0.rotation Rotation in degrees. Must be multiple of 90
-     * @param {number=} param0.originalRotation Original Rotation in degrees. Must be multiple of 90
+     * @param {Angle} param0.rotation Rotation in degrees. Must be multiple of 90
+     * @param {Angle=} param0.originalRotation Original Rotation in degrees. Must be multiple of 90
      * @param {number=} param0.code Building code
      */
     constructor({
@@ -136,25 +141,25 @@ export class StaticMapEntityComponent extends Component {
      * @returns {Vector}
      */
     unapplyRotationToVector(vector) {
-        return vector.rotateFastMultipleOf90(360 - this.rotation);
+        return vector.rotateFastMultipleOf90(inverseAngleMap[this.rotation]);
     }
 
     /**
      * Transforms the given direction from local space
-     * @param {enumDirection} direction
-     * @returns {enumDirection}
+     * @param {Direction} direction
+     * @returns {Direction}
      */
     localDirectionToWorld(direction) {
-        return Vector.transformDirectionFromMultipleOf90(direction, this.rotation);
+        return directionRotationMap[direction][this.rotation];
     }
 
     /**
      * Transforms the given direction from world to local space
-     * @param {enumDirection} direction
-     * @returns {enumDirection}
+     * @param {Direction} direction
+     * @returns {Direction}
      */
     worldDirectionToLocal(direction) {
-        return Vector.transformDirectionFromMultipleOf90(direction, 360 - this.rotation);
+        return directionRotationMap[direction][inverseAngleMap[this.rotation]];
     }
 
     /**

--- a/src/js/game/components/wired_pins.js
+++ b/src/js/game/components/wired_pins.js
@@ -1,6 +1,21 @@
 import { Component } from "../component";
-import { Vector, enumDirection } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { types } from "../../savegame/serialization";
+
+/**
+ * @typedef {import("../../core/vector").Direction} Direction
+ *
+ * @typedef {{
+ *   pos: Vector,
+ *   type: enumPinSlotType,
+ *   direction: Direction
+ * }} WirePinSlotDefinition
+ *
+ * @typedef {{
+ *   pos: Vector,
+ *   type: enumPinSlotType,
+ *   direction: Direction
+ * }} WirePinSlot */
 
 /** @enum {string} */
 export const enumPinSlotType = {
@@ -9,18 +24,6 @@ export const enumPinSlotType = {
     positiveEnergyAcceptor: "positiveEnergyAcceptor",
     negativeEnergyAcceptor: "negativeEnergyAcceptor",
 };
-
-/** @typedef {{
- *   pos: Vector,
- *   type: enumPinSlotType,
- *   direction: enumDirection
- * }} WirePinSlotDefinition */
-
-/** @typedef {{
- *   pos: Vector,
- *   type: enumPinSlotType,
- *   direction: enumDirection
- * }} WirePinSlot */
 
 export class WiredPinsComponent extends Component {
     static getId() {

--- a/src/js/game/entity.js
+++ b/src/js/game/entity.js
@@ -5,7 +5,7 @@ import { Component } from "./component";
 
 import { GameRoot, enumLayer } from "./root";
 import { globalConfig } from "../core/config";
-import { enumDirectionToVector, enumDirectionToAngle } from "../core/vector";
+import { directionAngleMap, directionVectorMap } from "../core/vector";
 import { BasicSerializableObject, types } from "../savegame/serialization";
 import { EntityComponentStorage } from "./entity_components";
 import { Loader } from "../core/loader";
@@ -174,8 +174,8 @@ export class Entity extends BasicSerializableObject {
                     }
                     const slotTile = staticComp.localTileToWorld(slot.pos);
                     const direction = staticComp.localDirectionToWorld(slot.direction);
-                    const directionVector = enumDirectionToVector[direction];
-                    const angle = Math.radians(enumDirectionToAngle[direction]);
+                    const directionVector = directionVectorMap[direction];
+                    const angle = Math.radians(directionAngleMap[direction]);
 
                     context.globalAlpha = slot.item ? 1 : 0.2;
                     drawRotatedSprite({
@@ -200,8 +200,8 @@ export class Entity extends BasicSerializableObject {
                     const slotTile = staticComp.localTileToWorld(slot.pos);
                     for (let k = 0; k < slot.directions.length; ++k) {
                         const direction = staticComp.localDirectionToWorld(slot.directions[k]);
-                        const directionVector = enumDirectionToVector[direction];
-                        const angle = Math.radians(enumDirectionToAngle[direction] + 180);
+                        const directionVector = directionVectorMap[direction];
+                        const angle = Math.radians(directionAngleMap[direction] + 180);
                         context.globalAlpha = 0.4;
                         drawRotatedSprite({
                             parameters,

--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -4,12 +4,7 @@ import { DrawParameters } from "../../../core/draw_parameters";
 import { drawRotatedSprite, rotateTrapezRightFaced } from "../../../core/draw_utils";
 import { Loader } from "../../../core/loader";
 import { clamp, makeDiv, removeAllChildren } from "../../../core/utils";
-import {
-    enumDirectionToAngle,
-    enumDirectionToVector,
-    enumInvertedDirections,
-    Vector,
-} from "../../../core/vector";
+import { directionVectorMap, directionAngleMap, invertedDirectionMap, Vector } from "../../../core/vector";
 import { T } from "../../../translations";
 import { KEYMAPPINGS } from "../../key_action_mapper";
 import { defaultBuildingVariant } from "../../meta_building";
@@ -459,7 +454,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                     const worldDirection = staticComp.localDirectionToWorld(direction);
 
                     // Figure out which tile ejects to this slot
-                    const sourceTile = acceptorSlotWsTile.add(enumDirectionToVector[worldDirection]);
+                    const sourceTile = acceptorSlotWsTile.add(directionVectorMap[worldDirection]);
 
                     let isBlocked = false;
                     let isConnected = false;
@@ -505,7 +500,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                         sprite,
                         x: acceptorSlotWsPos.x,
                         y: acceptorSlotWsPos.y,
-                        angle: Math.radians(enumDirectionToAngle[enumInvertedDirections[worldDirection]]),
+                        angle: Math.radians(directionAngleMap[invertedDirectionMap[worldDirection]]),
                         size: 13,
                         offsetY: offsetShift + 13,
                     });
@@ -574,7 +569,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                     sprite,
                     x: ejectorSLotWsPos.x,
                     y: ejectorSLotWsPos.y,
-                    angle: Math.radians(enumDirectionToAngle[ejectorSlotWsDirection]),
+                    angle: Math.radians(directionAngleMap[ejectorSlotWsDirection]),
                     size: 13,
                     offsetY: offsetShift,
                 });

--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -1,6 +1,6 @@
 import { createLogger } from "../core/logging";
 import { round2Digits } from "../core/utils";
-import { enumDirection, enumDirectionToVector, Vector } from "../core/vector";
+import { directionVectorMap, Vector } from "../core/vector";
 import { Entity } from "./entity";
 import { MetaBuilding } from "./meta_building";
 import { enumLayer, GameRoot } from "./root";
@@ -9,26 +9,25 @@ import { STOP_PROPAGATION } from "../core/signal";
 const logger = createLogger("ingame/logic");
 
 /**
- * Typing helper
+ * @typedef {import("./components/item_ejector").ItemEjectorSlot} ItemEjectorSlot
+ * @typedef {import("./components/item_acceptor").ItemAcceptorSlot} ItemAcceptorSlot
+ * @typedef {import("../core/vector").Angle} Angle
+ * @typedef {import("../core/vector").Direction} Direction
+ *
  * @typedef {Array<{
  *  entity: Entity,
- *  slot: import("./components/item_ejector").ItemEjectorSlot,
+ *  slot: ItemEjectorSlot,
  *  fromTile: Vector,
- *  toDirection: enumDirection
+ *  toDirection: Direction
  * }>} EjectorsAffectingTile
- */
-
-/**
- * Typing helper
+ *
  * @typedef {Array<{
  *  entity: Entity,
- *  slot: import("./components/item_acceptor").ItemAcceptorSlot,
+ *  slot: ItemAcceptorSlot,
  *  toTile: Vector,
- *  fromDirection: enumDirection
+ *  fromDirection: Direction
  * }>} AcceptorsAffectingTile
- */
-
-/**
+ *
  * @typedef {{
  *     acceptors: AcceptorsAffectingTile,
  *     ejectors: EjectorsAffectingTile
@@ -82,8 +81,8 @@ export class GameLogic {
      * Attempts to place the given building
      * @param {object} param0
      * @param {Vector} param0.origin
-     * @param {number} param0.rotation
-     * @param {number} param0.originalRotation
+     * @param {Angle} param0.rotation
+     * @param {Angle} param0.originalRotation
      * @param {number} param0.rotationVariant
      * @param {string} param0.variant
      * @param {MetaBuilding} param0.building
@@ -183,9 +182,9 @@ export class GameLogic {
      */
     getEjectorsAndAcceptorsAtTile(tile, layer) {
         /** @type {EjectorsAffectingTile} */
-        let ejectors = [];
+        const ejectors = [];
         /** @type {AcceptorsAffectingTile} */
-        let acceptors = [];
+        const acceptors = [];
 
         // Well .. please ignore this code! :D
         for (let dx = -1; dx <= 1; ++dx) {
@@ -208,7 +207,7 @@ export class GameLogic {
                             }
                             const wsTile = staticComp.localTileToWorld(slot.pos);
                             const wsDirection = staticComp.localDirectionToWorld(slot.direction);
-                            const targetTile = wsTile.add(enumDirectionToVector[wsDirection]);
+                            const targetTile = wsTile.add(directionVectorMap[wsDirection]);
                             if (targetTile.equals(tile)) {
                                 ejectors.push({
                                     entity,
@@ -233,7 +232,7 @@ export class GameLogic {
                                 const direction = slot.directions[k];
                                 const wsDirection = staticComp.localDirectionToWorld(direction);
 
-                                const sourceTile = wsTile.add(enumDirectionToVector[wsDirection]);
+                                const sourceTile = wsTile.add(directionVectorMap[wsDirection]);
                                 if (sourceTile.equals(tile)) {
                                     acceptors.push({
                                         entity,

--- a/src/js/game/meta_building.js
+++ b/src/js/game/meta_building.js
@@ -7,6 +7,8 @@ import { Entity } from "./entity";
 import { enumLayer, GameRoot } from "./root";
 import { getCodeFromBuildingData } from "./building_codes";
 
+/** @typedef {import("../core/vector").Angle} Angle **/
+
 export const defaultBuildingVariant = "default";
 
 export class MetaBuilding {
@@ -150,8 +152,8 @@ export class MetaBuilding {
      * @param {object} param0
      * @param {GameRoot} param0.root
      * @param {Vector} param0.origin Origin tile
-     * @param {number=} param0.rotation Rotation
-     * @param {number} param0.originalRotation Original Rotation
+     * @param {Angle=} param0.rotation Rotation
+     * @param {Angle} param0.originalRotation Original Rotation
      * @param {number} param0.rotationVariant Rotation variant
      * @param {string} param0.variant
      */
@@ -192,10 +194,10 @@ export class MetaBuilding {
      * @param {object} param0
      * @param {GameRoot} param0.root
      * @param {Vector} param0.tile
-     * @param {number} param0.rotation
+     * @param {Angle} param0.rotation
      * @param {string} param0.variant
      * @param {string} param0.layer
-     * @return {{ rotation: number, rotationVariant: number, connectedEntities?: Array<Entity> }}
+     * @return {{ rotation: Angle, rotationVariant: number, connectedEntities?: Array<Entity> }}
      */
     computeOptimalDirectionAndRotationVariantAtTile({ root, tile, rotation, variant, layer }) {
         if (!this.isRotateable(variant)) {

--- a/src/js/game/systems/belt.js
+++ b/src/js/game/systems/belt.js
@@ -5,7 +5,7 @@ import { Loader } from "../../core/loader";
 import { createLogger } from "../../core/logging";
 import { AtlasSprite } from "../../core/sprites";
 import { fastArrayDeleteValue } from "../../core/utils";
-import { enumDirection, enumDirectionToVector, enumInvertedDirections, Vector } from "../../core/vector";
+import { directionVectorMap, invertedDirectionMap, Vector } from "../../core/vector";
 import { BeltPath } from "../belt_path";
 import { arrayBeltVariantToRotation, MetaBeltBaseBuilding } from "../buildings/belt_base";
 import { BeltComponent } from "../components/belt";
@@ -22,46 +22,46 @@ export const BELT_ANIM_COUNT = 28;
 const logger = createLogger("belt");
 
 /**
+ * @typedef {import("../../core/vector").Direction} Direction
+ */
+
+/**
  * Manages all belts
  */
 export class BeltSystem extends GameSystemWithFilter {
     constructor(root) {
         super(root, [BeltComponent]);
         /**
-         * @type {Object.<enumDirection, Array<AtlasSprite>>}
+         * @type {Object.<Direction, Array<AtlasSprite>>}
          */
         this.beltSprites = {
-            [enumDirection.top]: Loader.getSprite("sprites/belt/forward_0.png"),
-            [enumDirection.left]: Loader.getSprite("sprites/belt/left_0.png"),
-            [enumDirection.right]: Loader.getSprite("sprites/belt/right_0.png"),
+            top: Loader.getSprite("sprites/belt/forward_0.png"),
+            left: Loader.getSprite("sprites/belt/left_0.png"),
+            right: Loader.getSprite("sprites/belt/right_0.png"),
         };
 
         /**
-         * @type {Object.<enumDirection, Array<AtlasSprite>>}
+         * @type {Object.<Direction, Array<AtlasSprite>>}
          */
         this.wireSprites = {
-            [enumDirection.top]: Loader.getSprite("sprites/buildings/wire_top.png"),
-            [enumDirection.left]: Loader.getSprite("sprites/buildings/wire_left.png"),
-            [enumDirection.right]: Loader.getSprite("sprites/buildings/wire_right.png"),
+            top: Loader.getSprite("sprites/buildings/wire_top.png"),
+            left: Loader.getSprite("sprites/buildings/wire_left.png"),
+            right: Loader.getSprite("sprites/buildings/wire_right.png"),
         };
 
         /**
-         * @type {Object.<enumDirection, Array<AtlasSprite>>}
+         * @type {Object.<Direction, Array<AtlasSprite>>}
          */
         this.beltAnimations = {
-            [enumDirection.top]: [],
-            [enumDirection.left]: [],
-            [enumDirection.right]: [],
+            top: [],
+            left: [],
+            right: [],
         };
 
         for (let i = 0; i < BELT_ANIM_COUNT; ++i) {
-            this.beltAnimations[enumDirection.top].push(
-                Loader.getSprite("sprites/belt/forward_" + i + ".png")
-            );
-            this.beltAnimations[enumDirection.left].push(Loader.getSprite("sprites/belt/left_" + i + ".png"));
-            this.beltAnimations[enumDirection.right].push(
-                Loader.getSprite("sprites/belt/right_" + i + ".png")
-            );
+            this.beltAnimations.top.push(Loader.getSprite(`sprites/belt/forward_${i}.png`));
+            this.beltAnimations.left.push(Loader.getSprite(`sprites/belt/left_${i}.png`));
+            this.beltAnimations.right.push(Loader.getSprite(`sprites/belt/right_${i}.png`));
         }
 
         this.root.signals.entityDestroyed.add(this.onEntityDestroyed, this);
@@ -351,7 +351,7 @@ export class BeltSystem extends GameSystemWithFilter {
         const beltComp = entity.components.Belt;
 
         const followUpDirection = staticComp.localDirectionToWorld(beltComp.direction);
-        const followUpVector = enumDirectionToVector[followUpDirection];
+        const followUpVector = directionVectorMap[followUpDirection];
 
         const followUpTile = staticComp.origin.add(followUpVector);
         const followUpEntity = this.root.map.getLayerContentXY(followUpTile.x, followUpTile.y, entity.layer);
@@ -375,7 +375,7 @@ export class BeltSystem extends GameSystemWithFilter {
 
                     for (let k = 0; k < slot.directions.length; ++k) {
                         const localDirection = followUpStatic.localDirectionToWorld(slot.directions[k]);
-                        if (enumInvertedDirections[localDirection] === followUpDirection) {
+                        if (invertedDirectionMap[localDirection] === followUpDirection) {
                             return followUpEntity;
                         }
                     }
@@ -394,8 +394,8 @@ export class BeltSystem extends GameSystemWithFilter {
     findSupplyingEntity(entity) {
         const staticComp = entity.components.StaticMapEntity;
 
-        const supplyDirection = staticComp.localDirectionToWorld(enumDirection.bottom);
-        const supplyVector = enumDirectionToVector[supplyDirection];
+        const supplyDirection = staticComp.localDirectionToWorld("bottom");
+        const supplyVector = directionVectorMap[supplyDirection];
 
         const supplyTile = staticComp.origin.add(supplyVector);
         const supplyEntity = this.root.map.getLayerContentXY(supplyTile.x, supplyTile.y, entity.layer);
@@ -417,7 +417,7 @@ export class BeltSystem extends GameSystemWithFilter {
                         continue;
                     }
                     const localDirection = supplyStatic.localDirectionToWorld(slot.direction);
-                    if (enumInvertedDirections[localDirection] === supplyDirection) {
+                    if (invertedDirectionMap[localDirection] === supplyDirection) {
                         return supplyEntity;
                     }
                 }

--- a/src/js/game/systems/item_acceptor.js
+++ b/src/js/game/systems/item_acceptor.js
@@ -2,7 +2,7 @@ import { GameSystemWithFilter } from "../game_system_with_filter";
 import { globalConfig } from "../../core/config";
 import { DrawParameters } from "../../core/draw_parameters";
 import { Entity } from "../entity";
-import { enumDirectionToVector, enumDirectionToAngle } from "../../core/vector";
+import { directionAngleMap, directionVectorMap } from "../../core/vector";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { Loader } from "../../core/loader";
 import { drawRotatedSprite } from "../../core/draw_utils";
@@ -93,7 +93,7 @@ export class ItemAcceptorSystem extends GameSystemWithFilter {
             }
 
             const slotWorldPos = staticComp.applyRotationToVector(slotData.pos).add(staticComp.origin);
-            const fadeOutDirection = enumDirectionToVector[staticComp.localDirectionToWorld(direction)];
+            const fadeOutDirection = directionVectorMap[staticComp.localDirectionToWorld(direction)];
             const finalTile = slotWorldPos.subScalars(
                 fadeOutDirection.x * (animProgress / 2 - 0.5),
                 fadeOutDirection.y * (animProgress / 2 - 0.5)
@@ -131,7 +131,7 @@ export class ItemAcceptorSystem extends GameSystemWithFilter {
             }
 
             const transformedPos = staticComp.localTileToWorld(pos);
-            const angle = enumDirectionToAngle[staticComp.localDirectionToWorld(direction)];
+            const angle = directionAngleMap[staticComp.localDirectionToWorld(direction)];
 
             // SYNC with systems/belt.js:drawSingleEntity!
             const animationIndex = Math.floor(

--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -2,7 +2,7 @@ import { globalConfig } from "../../core/config";
 import { DrawParameters } from "../../core/draw_parameters";
 import { createLogger } from "../../core/logging";
 import { Rectangle } from "../../core/rectangle";
-import { enumDirectionToVector, Vector } from "../../core/vector";
+import { directionRotationMap, directionVectorMap } from "../../core/vector";
 import { BaseItem, enumItemType, enumItemTypeToLayer } from "../base_item";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { Entity } from "../entity";
@@ -133,7 +133,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
             // Figure out where and into which direction we eject items
             const ejectSlotWsTile = staticComp.localTileToWorld(ejectorSlot.pos);
             const ejectSlotWsDirection = staticComp.localDirectionToWorld(ejectorSlot.direction);
-            const ejectSlotWsDirectionVector = enumDirectionToVector[ejectSlotWsDirection];
+            const ejectSlotWsDirectionVector = directionVectorMap[ejectSlotWsDirection];
             const ejectSlotTargetWsTile = ejectSlotWsTile.add(ejectSlotWsDirectionVector);
 
             // Try to find the given acceptor component to take the item
@@ -372,11 +372,8 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
             }
 
             const realPosition = slot.pos.rotateFastMultipleOf90(staticComp.rotation);
-            const realDirection = Vector.transformDirectionFromMultipleOf90(
-                slot.direction,
-                staticComp.rotation
-            );
-            const realDirectionVector = enumDirectionToVector[realDirection];
+            const realDirection = directionRotationMap[slot.direction][staticComp.rotation];
+            const realDirectionVector = directionVectorMap[realDirection];
 
             const tileX =
                 staticComp.origin.x + realPosition.x + 0.5 + realDirectionVector.x * 0.5 * slot.progress;

--- a/src/js/game/systems/miner.js
+++ b/src/js/game/systems/miner.js
@@ -1,6 +1,6 @@
 import { globalConfig } from "../../core/config";
 import { DrawParameters } from "../../core/draw_parameters";
-import { enumDirectionToVector } from "../../core/vector";
+import { directionVectorMap } from "../../core/vector";
 import { BaseItem } from "../base_item";
 import { MinerComponent } from "../components/miner";
 import { Entity } from "../entity";
@@ -74,7 +74,7 @@ export class MinerSystem extends GameSystemWithFilter {
             const ejectingPos = staticComp.localTileToWorld(ejectingSlot.pos);
             const ejectingDirection = staticComp.localDirectionToWorld(ejectingSlot.direction);
 
-            const targetTile = ejectingPos.add(enumDirectionToVector[ejectingDirection]);
+            const targetTile = ejectingPos.add(directionVectorMap[ejectingDirection]);
             const targetContents = this.root.map.getTileContent(targetTile, enumLayer.regular);
 
             // Check if we are connected to another miner and thus do not eject directly

--- a/src/js/game/systems/static_map_entity.js
+++ b/src/js/game/systems/static_map_entity.js
@@ -3,7 +3,6 @@ import { DrawParameters } from "../../core/draw_parameters";
 import { globalConfig } from "../../core/config";
 import { MapChunkView } from "../map_chunk_view";
 import { Loader } from "../../core/loader";
-import { enumDirection } from "../../core/vector";
 import { enumLayer } from "../root";
 
 export class StaticMapEntitySystem extends GameSystem {
@@ -11,9 +10,9 @@ export class StaticMapEntitySystem extends GameSystem {
         super(root);
 
         this.beltOverviewSprites = {
-            [enumDirection.top]: Loader.getSprite("sprites/map_overview/belt_forward.png"),
-            [enumDirection.right]: Loader.getSprite("sprites/map_overview/belt_right.png"),
-            [enumDirection.left]: Loader.getSprite("sprites/map_overview/belt_left.png"),
+            top: Loader.getSprite("sprites/map_overview/belt_forward.png"),
+            right: Loader.getSprite("sprites/map_overview/belt_right.png"),
+            left: Loader.getSprite("sprites/map_overview/belt_left.png"),
         };
     }
 

--- a/src/js/game/systems/underground_belt.js
+++ b/src/js/game/systems/underground_belt.js
@@ -3,11 +3,10 @@ import { Loader } from "../../core/loader";
 import { createLogger } from "../../core/logging";
 import { Rectangle } from "../../core/rectangle";
 import {
-    enumAngleToDirection,
-    enumDirection,
-    enumDirectionToAngle,
-    enumDirectionToVector,
-    enumInvertedDirections,
+    angleDirectionMap,
+    directionAngleMap,
+    directionVectorMap,
+    invertedDirectionMap,
 } from "../../core/vector";
 import { enumUndergroundBeltMode, UndergroundBeltComponent } from "../components/underground_belt";
 import { Entity } from "../entity";
@@ -82,9 +81,9 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
             const staticComp = entity.components.StaticMapEntity;
             const tile = staticComp.origin;
 
-            const direction = enumAngleToDirection[staticComp.rotation];
-            const inverseDirection = enumInvertedDirections[direction];
-            const offset = enumDirectionToVector[inverseDirection];
+            const direction = angleDirectionMap[staticComp.rotation];
+            const inverseDirection = invertedDirectionMap[direction];
+            const offset = directionVectorMap[inverseDirection];
 
             let currentPos = tile.copy();
 
@@ -107,7 +106,7 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
                     contentsUndergroundComp &&
                     contentsUndergroundComp.tier === undergroundComp.tier &&
                     contentsUndergroundComp.mode === enumUndergroundBeltMode.sender &&
-                    enumAngleToDirection[contentsStaticComp.rotation] === direction
+                    angleDirectionMap[contentsStaticComp.rotation] === direction
                 ) {
                     matchingEntrance = {
                         entity: contents,
@@ -144,8 +143,8 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
 
                 // It's a belt
                 if (
-                    contentsBeltComp.direction !== enumDirection.top ||
-                    enumAngleToDirection[contentsStaticComp.rotation] !== direction
+                    contentsBeltComp.direction !== "top" ||
+                    angleDirectionMap[contentsStaticComp.rotation] !== direction
                 ) {
                     allBeltsMatch = false;
                     break;
@@ -208,8 +207,8 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
                 const staticAfter = entityAfter.components.StaticMapEntity;
 
                 if (
-                    enumAngleToDirection[staticBefore.rotation] !== direction ||
-                    enumAngleToDirection[staticAfter.rotation] !== direction
+                    angleDirectionMap[staticBefore.rotation] !== direction ||
+                    angleDirectionMap[staticAfter.rotation] !== direction
                 ) {
                     // Wrong rotation
                     continue;
@@ -285,9 +284,9 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
     findRecieverForSender(entity) {
         const staticComp = entity.components.StaticMapEntity;
         const undergroundComp = entity.components.UndergroundBelt;
-        const searchDirection = staticComp.localDirectionToWorld(enumDirection.top);
-        const searchVector = enumDirectionToVector[searchDirection];
-        const targetRotation = enumDirectionToAngle[searchDirection];
+        const searchDirection = staticComp.localDirectionToWorld("top");
+        const searchVector = directionVectorMap[searchDirection];
+        const targetRotation = directionAngleMap[searchDirection];
         let currentTile = staticComp.origin;
 
         // Search in the direction of the tunnel

--- a/src/js/savegame/serialization_data_types.js
+++ b/src/js/savegame/serialization_data_types.js
@@ -460,7 +460,7 @@ export class TypeEnum extends BaseDataType {
      */
     constructor(enumeration = {}) {
         super();
-        this.availableValues = Object.keys(enumeration);
+        this.availableValues = Object.values(enumeration);
     }
 
     serialize(value) {
@@ -488,7 +488,7 @@ export class TypeEnum extends BaseDataType {
     }
 
     verifySerializedValue(value) {
-        if (this.availableValues.indexOf(value) < 0) {
+        if (!this.availableValues.includes(value)) {
             return "Unknown enum value: " + value;
         }
     }


### PR DESCRIPTION
In practice, TypeScript's string enums end up making code more bloated without any of the benefits.

We can replace the string enum type `enumDirection` with a string literal type `Direction` without much hassle.

I also went ahead and created an `Angle` type to enforce consistent usage throughout the codebase. All of the math used for rotating and inverting are implemented using maps.

I've done the colors as well on a separate branch. If you're okay with this approach I'll apply it for the rest of the enums.
