### PR TITLE
Danish translations

### DIFF
--- a/translations/base-da.yaml
+++ b/translations/base-da.yaml
@@ -21,7 +21,7 @@
 
 steamPage:
     # This is the short text appearing on the steam page
-    shortText: shapez.io is a game about building factories to automate the creation and combination of increasingly complex shapes within an infinite map.
+    shortText: shapez.io handler om at bygge fabrikker på en grænseløs spilleflade for automatisk at skabe og kombinere figurer, der i stigende grad bliver mere komplicerede.
 
     # This is the long description for the steam page - It is contained here so you can help to translate it, and I will regulary update the store page.
     # NOTICE:
@@ -30,97 +30,98 @@ steamPage:
     longText: >-
         [img]{STEAM_APP_IMAGE}/extras/store_page_gif.gif[/img]
 
-        shapez.io is a game about building factories to automate the creation and processing of increasingly complex shapes across an infinitely expanding map.
-        Upon delivering the requested shapes you will progress within the game and unlock upgrades to speed up your factory.
+        shapez.io handler om at bygge fabrikker over en grænseløs spilleflade for automatisk at skabe og kombinere figurer, der i stigende grad bliver mere komplicerede.
+        Når efterspurgte figurer bliver afleveret, vil du gøre fremskridt i spillet og modtage opgraderinger, der gør din fabrik hurtigere.
+        
+        Som efterspørgslen på figurer stiger, må du opskalere din fabrik for at holde trit - Glem dog ikke resurserne, du vil blive nødt til at udvide over hele den [b]uendelige flade[/b]!
 
-        As the demand for shapes increases, you will have to scale up your factory to meet the demand - Don't forget about resources though, you will have to expand across the [b]infinite map[/b]!
+        Der går ikke lang tid før du må mikse farver og male dine figurer med dem - Kombiner rød, grøn og blå farveresurser for at producere forskellige farver og mal derefter figurer med dem for at møde efterspørgslen.
+        
+        Dette spil indeholder 18 fremadskridende levels (Som allerede burde holde dig beskæftiget i timevis!) men jeg tilføjer hele tiden nyt - Der er en hel masse planlagt!
+        
+        Hvis du køber spillet, får du adgang til den selvstændige version, der har endnu flere ting, og du får også adgang til nyudviklet indhold.
 
-        Soon you will have to mix colors and paint your shapes with them - Combine red, green and blue color resources to produce different colors and paint shapes with it to satisfy the demand.
-
-        This game features 18 progressive levels (Which should keep you busy for hours already!) but I'm constantly adding new content - There is a lot planned!
-
-        Purchasing the game gives you access to the standalone version which has additional features and you'll also receive access to newly developed features.
-
-        [b]Standalone Advantages[/b]
+        [b]Fordele for køb[/b]
 
         [list]
-            [*] Dark Mode
-            [*] Unlimited Waypoints
-            [*] Unlimited Savegames
-            [*] Additional settings
-            [*] Coming soon: Wires & Energy! Aiming for (roughly) end of July 2020.
-            [*] Coming soon: More Levels
-            [*] Allows me to further develop shapez.io ❤️
+            [*] Mørk Tilstand
+            [*] Uendelige Markører
+            [*] Uendelige Gem
+            [*] Yderligere Indstillinger
+            [*] Kommer snart: Ledninger & Energi! Går efter at udgive (omkring) enden af juli 2020.
+            [*] Kommer snart: Flere levels
+            [*] Støtter mig i yderligere at udvikle shapez.io ❤️
         [/list]
 
-        [b]Future Updates[/b]
+        [b]Fremtidige Opdateringer[/b]
 
-        I am updating the game very often and trying to push an update at least every week!
+        Jeg opdaterer spillet meget ofte og prøver at få frigivet en opdatering mindst hver uge!
 
         [list]
-            [*] Different maps and challenges (e.g. maps with obstacles)
-            [*] Puzzles (Deliver the requested shape with a restricted area / set of buildings)
-            [*] A story mode where buildings have a cost
-            [*] Configurable map generator (Configure resource/shape size/density, seed and more)
-            [*] Additional types of shapes
-            [*] Performance improvements (The game already runs pretty well!)
-            [*] And much more!
+            [*] Forskellige spilleflader og udfordringer (f.eks. flader med forhindringer)
+            [*] Hjernevridere (Aflever den efterspurgte figur med et afgrænset areal / mængde bygninger)
+            [*] En 'story mode' hvor bygninger har en pris
+            [*] En spillefladeskaber med forskellige indstillinger (Konfigurer resurse/figur størrelse/tæthed, seed m.m.)
+            [*] Flere typer af figurer
+            [*] Forbedringer til hvor godt spillet kører (Det kører allerede rimelig godt!)
+            [*] Og meget mere!
         [/list]
 
-        [b]This game is open source![/b]
+        [b]Dette spil er open source![/b]
 
-        Anybody can contribute, I'm actively involved in the community and attempt to review all suggestions and take feedback into consideration where possible.
-        Be sure to check out my trello board for the full roadmap!
+        Enhver kan kontribuere, jeg er aktivt involveret i fælleskabet og prøver at gennemgå alle forslag og tage feedback i betragtning når det er muligt.
+        Husk at tjekke mit trello board for den fulde køreplan!
+        
 
-        [b]Links[/b]
+        [b]Link[/b]
 
         [list]
-            [*] [url=https://discord.com/invite/HN7EVzV]Official Discord[/url]
-            [*] [url=https://trello.com/b/ISQncpJP/shapezio]Roadmap[/url]
+            [*] [url=https://discord.com/invite/HN7EVzV]Officiel Discord[/url]
+            [*] [url=https://trello.com/b/ISQncpJP/shapezio]Køreplan[/url]
             [*] [url=https://www.reddit.com/r/shapezio]Subreddit[/url]
-            [*] [url=https://github.com/tobspr/shapez.io]Source code (GitHub)[/url]
-            [*] [url=https://github.com/tobspr/shapez.io/blob/master/translations/README.md]Help translate[/url]
+            [*] [url=https://github.com/tobspr/shapez.io]Kildekode (GitHub)[/url]
+            [*] [url=https://github.com/tobspr/shapez.io/blob/master/translations/README.md]Hjælp med at oversætte[/url]
         [/list]
 
-    discordLink: Official Discord - Chat with me!
+    discordLink: Officiel Discord - Snak lidt med mig!
 
 global:
-    loading: Loading
-    error: Error
+    loading: Indlæser
+    error: Fejl
 
     # How big numbers are rendered, e.g. "10,000"
-    thousandsDivider: ","
+    thousandsDivider: "."
 
     # What symbol to use to seperate the integer part from the fractional part of a number, e.g. "0.4"
-    decimalSeparator: "."
+    decimalSeparator: ","
 
     # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
     suffix:
         thousands: k
-        millions: M
-        billions: B
-        trillions: T
+        millions: mio
+        billions: mia
+        trillions: bio
 
     # Shown for infinitely big numbers
-    infinite: inf
+    infinite: uendelig
 
     time:
         # Used for formatting past time dates
-        oneSecondAgo: one second ago
-        xSecondsAgo: <x> seconds ago
-        oneMinuteAgo: one minute ago
-        xMinutesAgo: <x> minutes ago
-        oneHourAgo: one hour ago
-        xHoursAgo: <x> hours ago
-        oneDayAgo: one day ago
-        xDaysAgo: <x> days ago
+        oneSecondAgo: et sekund siden
+        xSecondsAgo: <x> sekunder siden
+        oneMinuteAgo: et minut siden
+        xMinutesAgo: <x> minutter siden
+        oneHourAgo: en time siden
+        xHoursAgo: <x> timer siden
+        oneDayAgo: en dag siden
+        xDaysAgo: <x> dage siden
 
         # Short formats for times, e.g. '5h 23m'
         secondsShort: <seconds>s
         minutesAndSecondsShort: <minutes>m <seconds>s
-        hoursAndMinutesShort: <hours>h <minutes>m
+        hoursAndMinutesShort: <hours>t <minutes>m
 
-        xMinutes: <x> minutes
+        xMinutes: <x> minutter
 
     keys:
         tab: TAB
@@ -128,683 +129,683 @@ global:
         alt: ALT
         escape: ESC
         shift: SHIFT
-        space: SPACE
+        space: MELLEMRUM
 
 demoBanners:
     # This is the "advertisement" shown in the main menu and other various places
     title: Demo Version
     intro: >-
-        Get the standalone to unlock all features!
+        Køb spillet for at få den fulde oplevelse!
 
 mainMenu:
-    play: Play
-    continue: Continue
-    newGame: New Game
+    play: Spil
+    continue: Fortsæt
+    newGame: Nyt Spil
     changelog: Changelog
     subreddit: Reddit
-    importSavegame: Import
-    openSourceHint: This game is open source!
-    discordLink: Official Discord Server
-    helpTranslate: Help translate!
-    madeBy: Made by <author-link>
+    importSavegame: Importer
+    openSourceHint: Dette spil er open source!
+    discordLink: Officiel Discord Server
+    helpTranslate: Hjælp med at oversætte!
+    madeBy: Lavet af <author-link>
 
     # This is shown when using firefox and other browsers which are not supported.
     browserWarning: >-
-        Sorry, but the game is known to run slow on your browser! Get the standalone version or download chrome for the full experience.
+        Undskyld, men spillet er kendt for at køre langsomt på denne browser! Køb spillet eller download chrome for den fulde oplevelse.
 
     savegameLevel: Level <x>
-    savegameLevelUnknown: Unknown Level
+    savegameLevelUnknown: Ukendt Level
 
 dialogs:
     buttons:
         ok: OK
-        delete: Delete
-        cancel: Cancel
-        later: Later
-        restart: Restart
-        reset: Reset
-        getStandalone: Get Standalone
-        deleteGame: I know what I do
-        viewUpdate: View Update
-        showUpgrades: Show Upgrades
-        showKeybindings: Show Keybindings
+        delete: Slet
+        cancel: Fortryd
+        later: Senere
+        restart: Genstart
+        reset: Nulstil
+        getStandalone: Køb spillet
+        deleteGame: Jeg ved hvad jeg laver
+        viewUpdate: Se Opdatering
+        showUpgrades: Vis Opgraderinger
+        showKeybindings: Vis Keybindings
 
     importSavegameError:
-        title: Import Error
+        title: Import Fejl
         text: >-
-            Failed to import your savegame:
+            Importering af gem fejlede:
 
     importSavegameSuccess:
-        title: Savegame Imported
+        title: Gem Importeret
         text: >-
-            Your savegame has been successfully imported.
+            Dit gem blev importet.
 
     gameLoadFailure:
-        title: Game is broken
+        title: Spillet er i stykker
         text: >-
-            Failed to load your savegame:
+            Det lykkedes ikke at åbne dit gem:
 
     confirmSavegameDelete:
-        title: Confirm deletion
+        title: Bekræft sletning
         text: >-
-            Are you sure you want to delete the game?
+            Er du sikker på du vil slette dit gem?
 
     savegameDeletionError:
-        title: Failed to delete
+        title: Sletning fejlede
         text: >-
-            Failed to delete the savegame:
+            Det lykkedes ikke at slette dit gem:
 
     restartRequired:
-        title: Restart required
+        title: Genstart er nødvendig
         text: >-
             You need to restart the game to apply the settings.
 
     editKeybinding:
-        title: Change Keybinding
-        desc: Press the key or mouse button you want to assign, or escape to cancel.
-
+        title: Ændr Keybinding
+        desc: Tryk på knappen du vil bruge, eller escape for at fortryde.
+        
     resetKeybindingsConfirmation:
-        title: Reset keybindings
-        desc: This will reset all keybindings to their default values. Please confirm.
+        title: Nulstil keybindings
+        desc: Dette vil nulstille alle keybindings til deres standarder. Vær sød at bekræfte.
 
     keybindingsResetOk:
-        title: Keybindings reset
-        desc: The keybindings have been reset to their respective defaults!
+        title: Keybindings nulstillet
+        desc: Keybindings er nulstillet til deres standarder!
 
     featureRestriction:
-        title: Demo Version
-        desc: You tried to access a feature (<feature>) which is not available in the demo. Consider to get the standalone for the full experience!
+        title: Demoversion
+        desc: Du prøvede at bruge en funktion (<feature>) der ikke er tilgængelig i demoen. Overvej at købe spillet for den fulde oplevelse!
 
     oneSavegameLimit:
-        title: Limited savegames
-        desc: You can only have one savegame at a time in the demo version. Please remove the existing one or get the standalone!
+        title: Begrænset mængde gem
+        desc: Du kan kun have et gem af gangen in demoversionen. Vær sød at slette det nuværende gem eller at købe spillet!
 
     updateSummary:
-        title: New update!
+        title: Ny opdatering!
         desc: >-
-            Here are the changes since you last played:
+            Dette har ændret sig siden sidst du spillede:
 
     upgradesIntroduction:
-        title: Unlock Upgrades
+        title: Få Opgraderinger
         desc: >-
-            All shapes you produce can be used to unlock upgrades - <strong>Don't destroy your old factories!</strong>
-            The upgrades tab can be found on the top right corner of the screen.
+            Alle figurer du producere kan blive brugt til at få opgraderinger - <strong>Ødelæg ikke dine gamle fabrikker!</strong>
+            Opgraderingeringsvinduet kan findes i det øverste højre hjørne af skærmen.
 
     massDeleteConfirm:
-        title: Confirm delete
+        title: Bekræft sletning
         desc: >-
-            You are deleting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
+            Du er ved at slette mange bygninger (<count> helt præcis)! Er du sikker på at det er det du vil gøre?
 
     massCutConfirm:
-        title: Confirm cut
+        title: Bekræft klip
         desc: >-
-            You are cutting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
+            Du er ved at klippe mange bygninger (<count> helt præcis)! Er du sikker på at det er det du vil gøre?
 
     blueprintsNotUnlocked:
-        title: Not unlocked yet
+        title: Ikke tilgængeligt endnu
         desc: >-
-            Complete level 12 to unlock Blueprints!
+            Klar level 12 for at bruge arbejdstegninger!
 
     keybindingsIntroduction:
-        title: Useful keybindings
+        title: Brugbare keybindings
         desc: >-
-            This game has a lot of keybindings which make it easier to build big factories.
-            Here are a few, but be sure to <strong>check out the keybindings</strong>!<br><br>
-            <code class='keybinding'>CTRL</code> + Drag: Select an area.<br>
-            <code class='keybinding'>SHIFT</code>: Hold to place multiple of one building.<br>
-            <code class='keybinding'>ALT</code>: Invert orientation of placed belts.<br>
+            Dette spil har mange keybindings, som gør det lettere at bygge store fabrikker.
+            Her er et par, men husk at <strong>tjekke keybindings</strong>!<br><br>
+            <code class='keybinding'>CTRL</code> + Træk: Vælg et område.<br>
+            <code class='keybinding'>SHIFT</code>: Hold for at sætte flere af en bygning.<br>
+            <code class='keybinding'>ALT</code>: Vend retningen af nedsatte transportbånd.<br>
 
     createMarker:
-        title: New Marker
-        desc: Give it a meaningful name, you can also include a <strong>short key</strong> of a shape (Which you can generate <a href="https://viewer.shapez.io" target="_blank">here</a>)
-        titleEdit: Edit Marker
+        title: Ny Markør
+        desc: Giv det et betydningsfuldt navn. du kan også inkludere en <strong>kort kode</strong> der repræsenterer en figur (Som du kan lave <a href="https://viewer.shapez.io" target="_blank">her</a>)
+        titleEdit: Rediger Markør
 
     markerDemoLimit:
-        desc: You can only create two custom markers in the demo. Get the standalone for unlimited markers!
+        desc: Du kan kun lave to markører i demoen. Køb spillet for uendelige markører!
 
     exportScreenshotWarning:
-        title: Export screenshot
-        desc: You requested to export your base as a screenshot. Please note that this can be quite slow for a big base and even crash your game!
+        title: Eksporter skærmbillede
+        desc: Du bad om at eksportere din fabrik som et skærmbillede. Bemærk at dette kan være rimelig langsomt for en stor base og kan endda lukke dit spil!
     massCutInsufficientConfirm:
-        title: Confirm cut
-        desc: You can not afford to paste this area! Are you sure you want to cut it?
+        title: Bekræft klip
+        desc: Du har ikke råd til at sætte dette område ind igen! Er du sikker på du vil klippe det?
 
 ingame:
     # This is shown in the top left corner and displays useful keybindings in
     # every situation
     keybindingsOverlay:
-        moveMap: Move
-        selectBuildings: Select area
-        stopPlacement: Stop placement
-        rotateBuilding: Rotate building
-        placeMultiple: Place multiple
-        reverseOrientation: Reverse orientation
-        disableAutoOrientation: Disable auto orientation
-        toggleHud: Toggle HUD
-        placeBuilding: Place building
-        createMarker: Create Marker
-        delete: Delete
-        pasteLastBlueprint: Paste last blueprint
-        lockBeltDirection: Enable belt planner
-        plannerSwitchSide: Flip planner side
-        cutSelection: Cut
-        copySelection: Copy
-        clearSelection: Clear Selection
+        moveMap: Bevæg dig
+        selectBuildings: Marker område
+        stopPlacement: Stop placering
+        rotateBuilding: Roter bygning
+        placeMultiple: Sæt flere
+        reverseOrientation: Omvend retning
+        disableAutoOrientation: Slå automatisk retning fra
+        toggleHud: Slå HUD til/fra
+        placeBuilding: Placer bygning
+        createMarker: Lav Markør
+        delete: Slet
+        pasteLastBlueprint: Sæt sidste arbejdstegning ind
+        lockBeltDirection: Aktiver bælteplanlægger
+        plannerSwitchSide: Flip planlægsningsside
+        cutSelection: Klip
+        copySelection: Kopier
+        clearSelection: Ryd Selektion
         pipette: Pipette
-        switchLayers: Switch Layers
+        switchLayers: Skift Lag
 
     # Names of the colors, used for the color blind mode
     colors:
-        red: Red
-        green: Green
-        blue: Blue
-        yellow: Yellow
-        purple: Purple
+        red: Rød
+        green: Grøn
+        blue: Blå
+        yellow: Gul
+        purple: Lilla
         cyan: Cyan
-        white: White
-        uncolored: No color
-        black: Black
+        white: Hvid
+        uncolored: Ingen farve
+        black: Sort
 
     # Everything related to placing buildings (I.e. as soon as you selected a building
     # from the toolbar)
     buildingPlacement:
         # Buildings can have different variants which are unlocked at later levels,
         # and this is the hint shown when there are multiple variants available.
-        cycleBuildingVariants: Press <key> to cycle variants.
+        cycleBuildingVariants: Tryk <key> for at vælge type.
 
         # Shows the hotkey in the ui, e.g. "Hotkey: Q"
         hotkeyLabel: >-
             Hotkey: <key>
 
         infoTexts:
-            speed: Speed
-            range: Range
-            storage: Storage
-            oneItemPerSecond: 1 item / second
-            itemsPerSecond: <x> items / s
+            speed: Fart
+            range: Rækkevidde
+            storage: Opbevaring
+            oneItemPerSecond: 1 genstand / sekund
+            itemsPerSecond: <x> genstande / s
             itemsPerSecondDouble: (x2)
 
-            tiles: <x> tiles
+            tiles: <x> flader
 
     # The notification when completing a level
     levelCompleteNotification:
         # <level> is replaced by the actual level, so this gets 'Level 03' for example.
-        levelTitle: Level <level>
-        completed: Completed
-        unlockText: Unlocked <reward>!
-        buttonNextLevel: Next Level
+        levelTitle: Niveau <level>
+        completed: Klaret
+        unlockText: <reward> er nu tilgængelig!
+        buttonNextLevel: Næste Niveau
 
     # Notifications on the lower right
     notifications:
-        newUpgrade: A new upgrade is available!
-        gameSaved: Your game has been saved.
+        newUpgrade: En ny opgradering er tilgængelig!
+        gameSaved: Dit spil er gemt.
 
     # The "Upgrades" window
     shop:
-        title: Upgrades
-        buttonUnlock: Upgrade
+        title: Opgraderinger
+        buttonUnlock: Opgrader
 
         # Gets replaced to e.g. "Tier IX"
-        tier: Tier <x>
+        tier: Trin <x>
 
         # The roman number for each tier
         tierLabels: [I, II, III, IV, V, VI, VII, VIII, IX, X]
 
-        maximumLevel: MAXIMUM LEVEL (Speed x<currentMult>)
+        maximumLevel: STØRSTE NIVEAU (Speed x<currentMult>)
 
     # The "Statistics" window
     statistics:
-        title: Statistics
+        title: Statistikker
         dataSources:
             stored:
-                title: Stored
-                description: Displaying amount of stored shapes in your central building.
+                title: Opbevaret
+                description: Viser mængden af opbevarede figurer i din centrale bygning.
             produced:
-                title: Produced
-                description: Displaying all shapes your whole factory produces, including intermediate products.
+                title: Produceret
+                description: Viser alle de figurer hele din fabrik producere, inklusiv produkter brugt til videre produktion.
             delivered:
-                title: Delivered
-                description: Displaying shapes which are delivered to your central building.
-        noShapesProduced: No shapes have been produced so far.
+                title: Afleveret
+                description: Viser figurer som er afleveret til din centrale bygning.
+        noShapesProduced: Ingen figurer er blevet produceret indtil videre.
 
         # Displays the shapes per minute, e.g. '523 / m'
         shapesPerMinute: <shapes> / m
 
     # Settings menu, when you press "ESC"
     settingsMenu:
-        playtime: Playtime
+        playtime: Spilletid
 
-        buildingsPlaced: Buildings
-        beltsPlaced: Belts
+        buildingsPlaced: Bygninger
+        beltsPlaced: Bælter
 
         buttons:
-            continue: Continue
-            settings: Settings
-            menu: Return to menu
+            continue: Fortsæt
+            settings: Indstillinger
+            menu: Til menu
 
     # Bottom left tutorial hints
     tutorialHints:
-        title: Need help?
-        showHint: Show hint
-        hideHint: Close
+        title: Har du brug for hjælp?
+        showHint: Vis hint
+        hideHint: Luk
 
     # When placing a blueprint
     blueprintPlacer:
-        cost: Cost
+        cost: Pris
 
     # Map markers
     waypoints:
-        waypoints: Markers
+        waypoints: Markører
         hub: HUB
-        description: Left-click a marker to jump to it, right-click to delete it.<br><br>Press <keybinding> to create a marker from the current view, or <strong>right-click</strong> to create a marker at the selected location.
-        creationSuccessNotification: Marker has been created.
+        description: Venstreklik en markør for at hoppe til den, højreklik for at slette den.<br><br>Tryk <keybinding> for at lave en markør på det nuværende sted, eller <strong>højreklik</strong> for at lave en markør på den valgte lokation.
+        creationSuccessNotification: Markør er sat.
 
     # Shape viewer
     shapeViewer:
-        title: Layers
-        empty: Empty
-        copyKey: Copy Key
+        title: Lag
+        empty: Tom
+        copyKey: Kopier Kode
 
     # Interactive tutorial
     interactiveTutorial:
         title: Tutorial
         hints:
-            1_1_extractor: Place an <strong>extractor</strong> on top of a <strong>circle shape</strong> to extract it!
+            1_1_extractor: Sæt en <strong>udvinder</strong> på toppen af en<strong>cirkelfigur</strong> for at begynde produktion af den!
             1_2_conveyor: >-
-                Connect the extractor with a <strong>conveyor belt</strong> to your hub!<br><br>Tip: <strong>Click and drag</strong> the belt with your mouse!
+                Forbind udvinderen med et <strong>transportbælte</strong> til din hub!<br><br>Tip: <strong>Tryk og træk</strong> bæltet med din mus!
 
             1_3_expand: >-
-                This is <strong>NOT</strong> an idle game! Build more extractors and belts to finish the goal quicker.<br><br>Tip: Hold <strong>SHIFT</strong> to place multiple extractors, and use <strong>R</strong> to rotate them.
+                Dette er <strong>IKKE</strong> et idle game! Byg flere udvindere og bælter for at færdiggøre målet hurtigere.<br><br>Tip: Hold <strong>SHIFT</strong> for at sætte flere udvindere, og tryk <strong>R</strong> for at rotere dem.
 
 # All shop upgrades
 shopUpgrades:
     belt:
-        name: Belts, Distributor & Tunnels
-        description: Speed x<currentMult> → x<newMult>
+        name: Bælter, Fordelere & Tuneller
+        description: Fart x<currentMult> → x<newMult>
     miner:
-        name: Extraction
-        description: Speed x<currentMult> → x<newMult>
+        name: Udvinding
+        description: Fart x<currentMult> → x<newMult>
     processors:
-        name: Cutting, Rotating & Stacking
-        description: Speed x<currentMult> → x<newMult>
+        name: Klipning, Rotering & Stabling
+        description: Fart x<currentMult> → x<newMult>
     painting:
-        name: Mixing & Painting
-        description: Speed x<currentMult> → x<newMult>
+        name: Blanding & Maling
+        description: Fart x<currentMult> → x<newMult>
 
 # Buildings and their name / description
 buildings:
     hub:
-        deliver: Deliver
-        toUnlock: to unlock
+        deliver: Aflever
+        toUnlock: for at få adgang til
         levelShortcut: LVL
 
     belt:
         default:
-            name: &belt Conveyor Belt
-            description: Transports items, hold and drag to place multiple.
+            name: &belt Transportbælte
+            description: Transportere varer, hold og træk for at sætte flere.
 
     miner: # Internal name for the Extractor
         default:
-            name: &miner Extractor
-            description: Place over a shape or color to extract it.
+            name: &miner Udvinder
+            description: Placer over en figur eller farve for at udvinde den.
 
         chainable:
-            name: Extractor (Chain)
-            description: Place over a shape or color to extract it. Can be chained.
+            name: Udvinder (Kæde)
+            description: Placer over en figur eller farve for at udvinde den. Kan sættes i kæder.
 
     underground_belt: # Internal name for the Tunnel
         default:
             name: &underground_belt Tunnel
-            description: Allows to tunnel resources under buildings and belts.
+            description: Laver tunneller under bygninger and bælter.
 
         tier2:
-            name: Tunnel Tier II
-            description: Allows to tunnel resources under buildings and belts.
+            name: Tunnel Trin II
+            description: Laver tunneller under bygninger and bælter.
 
     splitter: # Internal name for the Balancer
         default:
-            name: &splitter Balancer
-            description: Multifunctional - Evenly distributes all inputs onto all outputs.
+            name: &splitter Spalter
+            description: Flere funktioner - Fordeler alle modtagne varer jævnt.
 
         compact:
-            name: Merger (compact)
-            description: Merges two conveyor belts into one.
+            name: Sammenlægger (kompakt)
+            description: Sammenlægger to bælter til en.
 
         compact-inverse:
-            name: Merger (compact)
-            description: Merges two conveyor belts into one.
+            name: Sammenlægger (kompakt)
+            description: Sammenlægger to bælter til en.
 
     cutter:
         default:
-            name: &cutter Cutter
-            description: Cuts shapes from top to bottom and outputs both halfs. <strong>If you use only one part, be sure to destroy the other part or it will stall!</strong>
+            name: &cutter Klipper
+            description: Klipper figurer fra top til bund og udsender begge halvdele. <strong>Hvis du kun bruger den ene halvdel så husk at ødelæg den anden del eller maskinen går i stå!</strong>
         quad:
-            name: Cutter (Quad)
-            description: Cuts shapes into four parts. <strong>If you use only one part, be sure to destroy the other parts or it will stall!</strong>
+            name: Klipper (firdeler)
+            description: Klipper figurer om til fire dele. <strong>Hvis du kun bruger nogle af dem så husk at ødelæg de andre dele eller maskinen går i stå!</strong>
 
     rotater:
         default:
-            name: &rotater Rotate
-            description: Rotates shapes clockwise by 90 degrees.
+            name: &rotater Drejer
+            description: Drejer figurer med uret med 90 grader.
         ccw:
-            name: Rotate (CCW)
-            description: Rotates shapes counter clockwise by 90 degrees.
+            name: Drejer (mod uret)
+            description: Drejer figurer mod uret med 90 grader.
         fl:
-            name: Rotate (180)
-            description: Rotates shapes by 180 degrees.
+            name: Drejer (180)
+            description: Drejer figurer med 180 grader.
 
     stacker:
         default:
-            name: &stacker Stacker
-            description: Stacks both items. If they can not be merged, the right item is placed above the left item.
+            name: &stacker Stabler
+            description: Stabler begge figurer. Hvis de ikke kan sammensmeltes, så er den højre figur sat oven på den venstre.
 
     mixer:
         default:
-            name: &mixer Color Mixer
-            description: Mixes two colors using additive blending.
+            name: &mixer Farveblander
+            description: Blander to farver med additiv blanding.
 
     painter:
         default:
-            name: &painter Painter
-            description: &painter_desc Colors the whole shape on the left input with the color from the top input.
+            name: &painter Maler
+            description: &painter_desc Farver hele figuren fra venstre side med farven fra toppen.
 
         mirrored:
             name: *painter
             description: *painter_desc
 
         double:
-            name: Painter (Double)
-            description: Colors the shapes on the left inputs with the color from the top input.
+            name: Maler (Dobbelt)
+            description: Farver figurerne fra venstre side med farven fra toppen.
         quad:
-            name: Painter (Quad)
-            description: Allows to color each quadrant of the shape with a different color.
+            name: Maler (Quad)
+            description: Lader dig farve hver fjerdel af figuren med forskellige farver.
 
     trash:
         default:
-            name: &trash Trash
-            description: Accepts inputs from all sides and destroys them. Forever.
+            name: &trash Skrald
+            description: Tillader input fra alle sider og ødelææger dem. For evigt.
 
         storage:
-            name: Storage
-            description: Stores excess items, up to a given capacity. Can be used as an overflow gate.
+            name: Opbevaring
+            description: Opbevarer ekstra varer, til en given kapicitet. Kan bruges til at håndtere overproduktion.
 
     energy_generator:
-        deliver: Deliver
-        toGenerateEnergy: For <x> energy
+        deliver: Aflever
+        toGenerateEnergy: For <x> energi
 
         default:
-            name: &energy_generator Energy Generator
-            description: Generates energy by consuming shapes. Each energy generator requires a different shapes.
+            name: &energy_generator Energigenerator
+            description: Genererer energi ved at optage figurer. Hver energigenerator kræver forskellige figurer.
     wire:
         default:
-            name: Energy Wire
-            description: Allows you to transport energy.
+            name: Energiledning
+            description: Lader dig transportere energi.
     advanced_processor:
         default:
-            name: Color Inverter
-            description: Accepts a color or shape and inverts it.
+            name: Farveomvender
+            description: Tager imod en farve giver den modsatte.
     wire_crossings:
         default:
-            name: Wire Splitter
-            description: Splits a energy wire into two.
+            name: Ledningsspalter
+            description: Spalter en energiledning i to.
         merger:
-            name: Wire Merger
-            description: Merges two energy wires into one.
+            name: Ledningssammenlægger
+            description: Sammenlægger to energiledninger til en.
 
 storyRewards:
     # Those are the rewards gained from completing the store
     reward_cutter_and_trash:
-        title: Cutting Shapes
-        desc: You just unlocked the <strong>cutter</strong> - it cuts shapes half from <strong>top to bottom</strong> regardless of its orientation!<br><br>Be sure to get rid of the waste, or otherwise <strong>it will stall</strong> - For this purpose I gave you a trash, which destroys everything you put into it!
+        title: Klippe Figurer
+        desc: Du har lige fået adgang til <strong>klipperen</strong> - den klipper figurer i to fra <strong>top til bund</strong> uanset hvordan den vender!<br><br>Sørg for at ødelægge alt du ikke har brug for, ellers <strong>går den i stå</strong> - Til dette har jeg givet dig skraldespanden, som ødelægger alt du putter i den!
 
     reward_rotater:
-        title: Rotating
-        desc: The <strong>rotater</strong> has been unlocked! It rotates shapes clockwise by 90 degrees.
+        title: Rotation
+        desc: <strong>Drejeren</strong> er nu tilgængelig! Den drejer figurer med uret med 90 grader.
 
     reward_painter:
-        title: Painting
+        title: Maling
         desc: >-
-            The <strong>painter</strong> has been unlocked - Extract some color veins (just as you do with shapes) and combine it with a shape in the painter to color them!<br><br>PS: If you are colorblind, there is a <strong>color blind mode</strong> in the settings!
+            <strong>Maleren</strong> er nu tilgængelig - Få noget farve med udvinderen (som du også gør med figurer) og kombiner det med en farve i maleren for at farve dem!<br><br>PS: Hvis du er farveblind, så er der en <strong>farveblindstilstand</strong> i indstillingerne!
 
     reward_mixer:
-        title: Color Mixing
-        desc: The <strong>mixer</strong> has been unlocked - Combine two colors using <strong>additive blending</strong> with this building!
+        title: Farveblanding
+        desc: <strong>Farveblanderen</strong> er nu tilgængelig - Kombiner to farver ved brug af (strong>additiv blanding</strong> med denne bygning!
 
     reward_stacker:
-        title: Combiner
-        desc: You can now combine shapes with the <strong>combiner</strong>! Both inputs are combined, and if they can be put next to each other, they will be <strong>fused</strong>. If not, the right input is <strong>stacked on top</strong> of the left input!
+        title: Stabler
+        desc: Du kan du stable figurer med <strong>stableren</strong>! Begge input er stablet, hvis de kan sættes ved siden af hinanden, <strong>sammensmeltes de</strong>. Hvis ikke er det højre input <strong>stablet ovenpå</strong> det venstre!
 
     reward_splitter:
-        title: Splitter/Merger
-        desc: The multifunctional <strong>balancer</strong> has been unlocked - It can be used to build bigger factories by <strong>splitting and merging items</strong> onto multiple belts!<br><br>
+        title: Spalter/Sammenlægger
+        desc: Den flerfunktionelle <strong>spalter</strong> er nu tilgængelig - Den kan blive brugt til at bygge større fabrikker ved at <strong>spalte og sammenlægge varer</strong> på flere bælter!<br><br>
 
     reward_tunnel:
         title: Tunnel
-        desc: The <strong>tunnel</strong> has been unlocked - You can now tunnel items through belts and buildings with it!
+        desc: <strong>Tunnellen</strong> er nu tilgængelig - Du kan nu lave tuneller under bælter og bygninger!
 
     reward_rotater_ccw:
-        title: CCW Rotating
-        desc: You have unlocked a variant of the <strong>rotater</strong> - It allows to rotate counter clockwise! To build it, select the rotater and <strong>press 'T' to cycle its variants</strong>!
+        title: Rotation mod uret
+        desc: Du har fået adgang til en variant af <strong>drejeren</strong> - Den lader dig dreje ting mod uret! For at bygge den skal du vælge drejeren og <strong>trykke 'T'</strong>!
 
     reward_miner_chainable:
-        title: Chaining Extractor
-        desc: You have unlocked the <strong>chaining extractor</strong>! It can <strong>forward its resources</strong> to other extractors so you can more efficiently extract resources!
+        title: Kædeudvinder
+        desc: <strong>Kædeudvinder</strong> er nu tilgængelig! Den kan <strong>videregive sine resurser</strong> til andre udvindere, så du kan udvinde resurser mere effektivt!
 
     reward_underground_belt_tier_2:
-        title: Tunnel Tier II
-        desc: You have unlocked a new variant of the <strong>tunnel</strong> - It has a <strong>bigger range</strong>, and you can also mix-n-match those tunnels now!
+        title: Tunnel Trin II
+        desc: Du har fået adgang til en variant af <strong>tunnellen</strong> - Den har en <strong>større rækkevidde</strong>, og du kan også bruge begge typer tunneller på den samme strækning!
 
     reward_splitter_compact:
-        title: Compact Balancer
+        title: Kompakt Spalter
         desc: >-
-            You have unlocked a compact variant of the <strong>balancer</strong> - It accepts two inputs and merges them into one!
+            Du har fået adgang til en kompakt variant af <strong>spalteren</strong> - Den tager to inputs og sammenlægger dem til en!
 
     reward_cutter_quad:
-        title: Quad Cutting
-        desc: You have unlocked a variant of the <strong>cutter</strong> - It allows you to cut shapes in <strong>four parts</strong> instead of just two!
+        title: Quad Klipining
+        desc: Du har fået adgang til en variant af <strong>klipperen</strong> - Den lader dig klippe figurer i <strong>fire dele</strong> i stedet for bare to!
 
     reward_painter_double:
-        title: Double Painting
-        desc: You have unlocked a variant of the <strong>painter</strong> - It works as the regular painter but processes <strong>two shapes at once</strong> consuming just one color instead of two!
+        title: Dobbelt Maling
+        desc: Du har fået adgang til en variant af <strong>maleren</strong> - Den virker som en normal maler, men maler <strong>to figurer samtidig</strong> og bruger kun en farve i stedet for to.
 
     reward_painter_quad:
-        title: Quad Painting
-        desc: You have unlocked a variant of the <strong>painter</strong> - It allows to paint each part of the shape individually!
+        title: Quad Maling
+        desc: Du har fået adgang til en variant af <strong>maleren</strong> - Den lader dig male hver del af en figur for sig!
 
     reward_storage:
-        title: Storage Buffer
-        desc: You have unlocked a variant of the <strong>trash</strong> - It allows to store items up to a given capacity!
+        title: Opbevaringsbuffer
+        desc: Du har fået adgang til en variant af <strong>skraldespanden</strong> - Den lader dig opbevarer varer til en hvis kapacitet!
 
     reward_freeplay:
-        title: Freeplay
-        desc: You did it! You unlocked the <strong>free-play mode</strong>! This means that shapes are now randomly generated! (No worries, more content is planned for the standalone!)
+        title: Frit spil
+        desc: Du klarede det! Du har fået adgang til <strong>frit spil</strong>! Dette betyder at figurer nu er tilfældigt genereret! (Vær ikke bekymret, mere indhold er planlagt for den købte version!)
 
     reward_blueprints:
-        title: Blueprints
-        desc: You can now <strong>copy and paste</strong> parts of your factory! Select an area (Hold CTRL, then drag with your mouse), and press 'C' to copy it.<br><br>Pasting it is <strong>not free</strong>, you need to produce <strong>blueprint shapes</strong> to afford it! (Those you just delivered).
+        title: Arbejdstegninger
+        desc: Du kan nu <strong>kopiere og indsætte</strong> dele af din fabrik! Vælg et område (Hold CTRL, og træk med musen), og tryk 'C' for at kopiere det.<br><br>At sætte det ind er <strong>ikke gratis</strong>, du skal producere <strong>arbejdstegning figurer</strong> for at have råd til det! (Dem du lige har leveret).
 
     # Special reward, which is shown when there is no reward actually
     no_reward:
-        title: Next level
+        title: Næste level
         desc: >-
-            This level gave you no reward, but the next one will! <br><br> PS: Better don't destroy your existing factory - You need <strong>all</strong> those shapes later again to <strong>unlock upgrades</strong>!
+            Dette level gav dig ingen belønninger, men det vil det næste! <br><br> PS: Du må hellere lade være med at ødelægge din fabrik - Du får brug for <strong>alle</strong> de figurer senere igen for at <strong>få opgraderinger</strong>!
 
     no_reward_freeplay:
-        title: Next level
+        title: Næste level
         desc: >-
-            Congratulations! By the way, more content is planned for the standalone!
+            Tillykke! Forresten er mere indhold planlagt for den købte version!
 
 settings:
-    title: Settings
+    title: Indstillinger
     categories:
-        general: General
-        userInterface: User Interface
-        advanced: Advanced
+        general: Generelt
+        userInterface: Brugerflade
+        advanced: Advanceret
 
     versionBadges:
-        dev: Development
-        staging: Staging
-        prod: Production
-    buildDate: Built <at-date>
+        dev: Udvikling
+        staging: Iscenesættelse
+        prod: Produktion
+    buildDate: Bygget <at-date>
 
     labels:
         uiScale:
-            title: Interface scale
+            title: Grænseflade størrelse
             description: >-
-                Changes the size of the user interface. The interface will still scale based on your device resolution, but this setting controls the amount of scale.
+                Ændrer størrelsen på brugerfladen. Den vil stadig skalere baseret på opløsningen af din skærm, men denne indstilling bestemmer hvor meget den skalere.
             scales:
-                super_small: Super small
-                small: Small
-                regular: Regular
-                large: Large
-                huge: Huge
+                super_small: Meget lille
+                small: Lille
+                regular: Normal
+                large: Store
+                huge: Kæmpe
 
         autosaveInterval:
-            title: Autosave Interval
+            title: Autogem Interval
             description: >-
-                Controls how often the game saves automatically. You can also disable it entirely here.
-
+                Kontrollere hvor ofte spillet gemmer automatisk. Du kan også slå det helt fra her.
+                
             intervals:
-                one_minute: 1 Minute
-                two_minutes: 2 Minutes
-                five_minutes: 5 Minutes
-                ten_minutes: 10 Minutes
-                twenty_minutes: 20 Minutes
-                disabled: Disabled
+                one_minute: 1 Minut
+                two_minutes: 2 Minuter
+                five_minutes: 5 Minuter
+                ten_minutes: 10 Minuter
+                twenty_minutes: 20 Minuter
+                disabled: Slået fra
 
         scrollWheelSensitivity:
-            title: Zoom sensitivity
+            title: Zoom følsomhed
             description: >-
-                Changes how sensitive the zoom is (Either mouse wheel or trackpad).
+                Ændrer hvor følsomt zoomet er (Enten mussehjulet eller trackpad).
             sensitivity:
-                super_slow: Super slow
-                slow: Slow
-                regular: Regular
-                fast: Fast
-                super_fast: Super fast
+                super_slow: Meget langsom
+                slow: Langsom
+                regular: Normal
+                fast: Hurtig
+                super_fast: Meget hurtig
 
         movementSpeed:
-            title: Movement speed
+            title: Bevægelseshastighed
             description: >-
-                Changes how fast the view moves when using the keyboard.
+                Ændrer hvor hurtigt du kan bevæge dit overblik når du bruger tastaturet.
             speeds:
-                super_slow: Super slow
-                slow: Slow
-                regular: Regular
-                fast: Fast
-                super_fast: Super Fast
-                extremely_fast: Extremely Fast
+                super_slow: Meget langsom
+                slow: Langsom
+                regular: Normal
+                fast: Hurtig
+                super_fast: Meget hurtig
+                extremely_fast: Ekstremt hurtig
 
         language:
-            title: Language
+            title: Sprog
             description: >-
-                Change the language. All translations are user contributed and might be incomplete!
+                Ændrer sproget. All oversættelser er lavet af fælleskabet og kan være ufuldstændige!
 
         enableColorBlindHelper:
-            title: Color Blind Mode
+            title: Farveblindstilstand
             description: >-
-                Enables various tools which allow to play the game if you are color blind.
+                Aktivere forskellige redskaber der lader dig spille, selv hvis du er farveblind.
 
         fullscreen:
-            title: Fullscreen
+            title: Fuld skærm
             description: >-
-                It is recommended to play the game in fullscreen to get the best experience. Only available in the standalone.
+                Det er forslået at spille i fuld skærm for den bedste oplevelse. Kun tilgængelig i den købte version.
 
         soundsMuted:
-            title: Mute Sounds
+            title: Slå lydeffekterne fra
             description: >-
-                If enabled, mutes all sound effects.
+                Aktiver for at slå alle lydeffekter fra.
 
         musicMuted:
-            title: Mute Music
+            title: Slå musik fra
             description: >-
-                If enabled, mutes all music.
+                Aktiver for at slå al musik fra.
 
         theme:
-            title: Game theme
+            title: Spiltilstand
             description: >-
-                Choose the game theme (light / dark).
+                Vælg spiltilstand (lys / mørk).
             themes:
-                dark: Dark
-                light: Light
+                dark: Mørk
+                light: Lys
 
         refreshRate:
-            title: Simulation Target
+            title: Simulationsmål
             description: >-
-                If you have a 144hz monitor, change the refresh rate here so the game will properly simulate at higher refresh rates. This might actually decrease the FPS if your computer is too slow.
+                Hvis du har en 144hz skærm ændr opdateringshastigheden her så spillet vil simulere den højere opdateringshastighed korrekt. Dette kan faktisk sænke din FPS hvis din computer er for langsom.
 
         alwaysMultiplace:
-            title: Multiplace
+            title: Multiplacer
             description: >-
-                If enabled, all buildings will stay selected after placement until you cancel it. This is equivalent to holding SHIFT permanently.
+                Aktiver for at alle bygninger fortsætter med at være valgt efter placering, indtil du vælger den fra. Dette svarer til altid at holde SHIFT nede.
 
         offerHints:
-            title: Hints & Tutorials
+            title: Hints & Vejledning
             description: >-
-                Whether to offer hints and tutorials while playing. Also hides certain UI elements onto a given level to make it easier to get into the game.
+                Om spillet skal tilbyde hints og vejledning imens du spiller. Skjuler også visse dele af brugerfladen indtil et givent level for at gøre det nemmere at lære spillet at kende.
 
         enableTunnelSmartplace:
-            title: Smart Tunnels
+            title: Smarte Tunneller
             description: >-
-                When enabled, placing tunnels will automatically remove unnecessary belts. This also enables to drag tunnels and excess tunnels will get removed.
+                Aktiver for at placering af tunneller automatisk fjerner unødige bælter. Dette gør igså at du kan trække tunneller så overskydende tunneller fjernes.
 
         vignette:
             title: Vignette
             description: >-
-                Enables the vignette which darkens the screen corners and makes text easier to read.
+                Aktivere vignette hvilket mørkner kanterne af skærmen og gør teksten nemmere at læse.
 
         rotationByBuilding:
-            title: Rotation by building type
+            title: Rotation baseret på bygningstype
             description: >-
-                Each building type remembers the rotation you last set it to individually. This may be more comfortable if you frequently switch between placing different building types.
+                Hver bygningstype husker den rotation du sidst satte den til. Dette kan være komfortabelt hvis du ofte skifter mellem at placere forskellige bygninger.
 
         compactBuildingInfo:
-            title: Compact Building Infos
+            title: Kompakt Bygningsinfo
             description: >-
-                Shortens info boxes for buildings by only showing their ratios. Otherwise a description and image is shown.
+                Forkorter infobokse til bygninger ved kun at vise deres ratioer. Ellers er en beskrivelse og et billede også vist.
 
         disableCutDeleteWarnings:
-            title: Disable Cut/Delete Warnings
+            title: Slå klip/slet advarsler fra
             description: >-
-                Disable the warning dialogs brought up when cutting/deleting more than 100 entities.
+                Slå advarselsboksene, der dukker op når mere end 100 ting slettes, fra.
 
 keybindings:
     title: Keybindings
     hint: >-
-        Tip: Be sure to make use of CTRL, SHIFT and ALT! They enable different placement options.
+        Tip: Husk at bruge CTRL, SHIFT og ALT! De byder på forskellige placeringsmuligheder.
 
-    resetKeybindings: Reset Keybindings
+    resetKeybindings: Nulstil Keybindings
 
     categoryLabels:
-        general: Application
-        ingame: Game
-        navigation: Navigating
-        placement: Placement
-        massSelect: Mass Select
-        buildings: Building Shortcuts
-        placementModifiers: Placement Modifiers
+        general: Applikation
+        ingame: Spil
+        navigation: Navigation
+        placement: Placering
+        massSelect: Massemarkering
+        buildings: Bygningsgenveje
+        placementModifiers: Placeringsmodifikationer
 
     mappings:
-        confirm: Confirm
-        back: Back
-        mapMoveUp: Move Up
-        mapMoveRight: Move Right
-        mapMoveDown: Move Down
-        mapMoveLeft: Move Left
-        mapMoveFaster: Move Faster
-        centerMap: Center Map
+        confirm: Bekræft
+        back: Tilbage
+        mapMoveUp: Bevæg dig op
+        mapMoveRight: Bevæg dig til højre
+        mapMoveDown: Bevæg dig ned
+        mapMoveLeft: Bevæg dig til venstre
+        mapMoveFaster: Bevæg dig hurtigere
+        centerMap: Centrer kortet
 
-        mapZoomIn: Zoom in
-        mapZoomOut: Zoom out
-        createMarker: Create Marker
+        mapZoomIn: Zoom ind
+        mapZoomOut: Zoom ud
+        createMarker: Lav Markør
 
-        menuOpenShop: Upgrades
-        menuOpenStats: Statistics
+        menuOpenShop: Opgraderinger
+        menuOpenStats: Statistikker
 
-        toggleHud: Toggle HUD
-        toggleFPSInfo: Toggle FPS and Debug Info
-        switchLayers: Switch layers
-        exportScreenshot: Export whole Base as Image
+        toggleHud: Slå HUD til/fra
+        toggleFPSInfo: Slå FPS og Debug Info til/fra
+        switchLayers: Skift lag
+        exportScreenshot: Eksporter hele basen som et billede
         belt: *belt
         splitter: *splitter
         underground_belt: *underground_belt
@@ -818,51 +819,51 @@ keybindings:
         trash: *trash
 
         pipette: Pipette
-        rotateWhilePlacing: Rotate
+        rotateWhilePlacing: Roter
         rotateInverseModifier: >-
-            Modifier: Rotate CCW instead
-        cycleBuildingVariants: Cycle Variants
-        confirmMassDelete: Delete area
-        pasteLastBlueprint: Paste last blueprint
-        cycleBuildings: Cycle Buildings
-        lockBeltDirection: Enable belt planner
+            Modifier: Roter mod uret i stedet
+        cycleBuildingVariants: Gennemgå Varianter
+        confirmMassDelete: Slet område
+        pasteLastBlueprint: Sæt sidste arbejdstegning ind
+        cycleBuildings: Gennemgå bygninger
+        lockBeltDirection: Slå bælteplanlægger til
         switchDirectionLockSide: >-
-            Planner: Switch side
+            Planner: Skift side
 
-        massSelectStart: Hold and drag to start
-        massSelectSelectMultiple: Select multiple areas
-        massSelectCopy: Copy area
-        massSelectCut: Cut area
+        massSelectStart: Hold og træk for at starte
+        massSelectSelectMultiple: Vælg flere områder
+        massSelectCopy: Kopier område
+        massSelectCut: Klip område
 
-        placementDisableAutoOrientation: Disable automatic orientation
-        placeMultiple: Stay in placement mode
-        placeInverse: Invert automatic belt orientation
-        menuClose: Close Menu
-        advanced_processor: Color Inverter
-        wire: Energy Wire
+        placementDisableAutoOrientation: Slå automatisk orientering fra
+        placeMultiple: Bliv i placeringstilstand
+        placeInverse: Spejlvend automatisk bælteorientering
+        menuClose: Luk Menu
+        advanced_processor: Farveomvender
+        wire: Energiledning
 
 about:
-    title: About this Game
+    title: Om dette spil
     body: >-
-        This game is open source and developed by <a href="https://github.com/tobspr" target="_blank">Tobias Springer</a> (this is me).<br><br>
+        Dette spil er open source og er udviklet af <a href="https://github.com/tobspr" target="_blank">Tobias Springer</a> (dette er mig).<br><br>
 
-        If you want to contribute, check out <a href="<githublink>" target="_blank">shapez.io on github</a>.<br><br>
+        Hvis du vil kontribuere, tjek <a href="<githublink>" target="_blank">shapez.io på github</a>.<br><br>
 
-        This game wouldn't have been possible without the great Discord community around my games - You should really join the <a href="<discordlink>" target="_blank">Discord server</a>!<br><br>
+        Dette spil ville ikke have været muligt uden det fremragende Discord-fælleskab omkring mine spil - Du burde virkelig deltage på <a href="<discordlink>" target="_blank">Discordserveren</a>!<br><br>
 
-        The soundtrack was made by <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsen</a> - He's awesome.<br><br>
+        Lydsporet er lavet af <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsen</a> - Han er fantastisk.<br><br>
 
-        Finally, huge thanks to my best friend <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Without our factorio sessions this game would never have existed.
+        Endelig, tusind tak til min bedste ven <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Uden vi havde spillet factorio sammen ville dette spil aldrig have eksisteret.
 
 changelog:
     title: Changelog
 
 demo:
     features:
-        restoringGames: Restoring savegames
-        importingGames: Importing savegames
-        oneGameLimit: Limited to one savegame
-        customizeKeybindings: Customizing Keybindings
-        exportingBase: Exporting whole Base as Image
+        restoringGames: Genopretter gem
+        importingGames: Importerer gem
+        oneGameLimit: Afgrænset til et gem
+        customizeKeybindings: Tilpasser Keybindings
+        exportingBase: Eksportere hele basen som et billede
 
-    settingNotAvailable: Not available in the demo.
+    settingNotAvailable: Ikke tilgængelig i demoen.


### PR DESCRIPTION
Some words are easier left in English. Many words that have to do with technology are mostly just used directly in English, and though there are some proposed ways of translating them, most would easier time understanding the English version. E.g. changelogs, keybindings, levels...