### PR TITLE
Fix types for v1000->v1001 migration

### DIFF
--- a/src/js/savegame/schemas/1001.js
+++ b/src/js/savegame/schemas/1001.js
@@ -1,6 +1,7 @@
 import { SavegameInterface_V1000 } from "./1000.js";
 import { createLogger } from "../../core/logging.js";
 import { T } from "../../translations.js";
+import { TypeVector, TypeNumber, TypeString, TypeNullable } from "../serialization_data_types.js";
 
 const schema = require("./1001.json");
 
@@ -43,9 +44,25 @@ export class SavegameInterface_V1001 extends SavegameInterface_V1000 {
         for (let i = 0; i < entities.length; ++i) {
             const entity = entities[i];
 
-            // FIXME - https://github.com/tobspr/shapez.io/issues/514
-            // Broken in https://github.com/tobspr/shapez.io/commit/bf2eee908fedb84dbbabd359a200c446020a340e
-            /** @type any **/
+            /**
+             * @typedef {{
+             *   origin: TypeVector,
+             *   tileSize: TypeVector,
+             *   rotation: TypeNumber,
+             *   originalRotation: TypeNumber,
+             *   spriteKey?: string,
+             *   blueprintSpriteKey: string,
+             *   silhouetteColor: string
+             * }} OldStaticMapEntity
+             */
+
+            // Here we mock the old type of the StaticMapEntity before the change to using
+            // a building ID based system (see building_codes.js) to stop the linter from
+            // complaining that the type doesn't have the properties.
+            // The ignored error is the error that the types do not overlap.  In the case
+            // of a v1000 save though, the data will match the mocked type above.
+            /** @type OldStaticMapEntity **/
+            // @ts-ignore
             const staticComp = entity.components.StaticMapEntity;
             const beltComp = entity.components.Belt;
             if (staticComp) {


### PR DESCRIPTION
The change to use an ID based system for buildings (bf2eee908fedb84dbbabd359a200c446020a340e) broke the v1000->v1001 migration by making the StaticMapEntityComponent type incompatible with the correspinding type in older saves.  Instead, we can mock the type of the old StaticMapEntityComponent and use it in the migration.  A `@ts-ignore` is required to suppress the warning that the types do not match, but since the code will only be run on old data, the types should always match.

This resolves #514 in a way that keeps type safety.