### PR TITLE
Replace enumDirection with string literal Direction

### DIFF
--- a/src/js/core/rectangle.js
+++ b/src/js/core/rectangle.js
@@ -54,27 +54,6 @@ export class Rectangle {
     }
 
     /**
-     * Returns a rectangle arround a rotated point
-     * @param {Array<Vector>} points
-     * @param {number} angle
-     * @returns {Rectangle}
-     */
-    static getAroundPointsRotated(points, angle) {
-        let minX = 1e10;
-        let minY = 1e10;
-        let maxX = -1e10;
-        let maxY = -1e10;
-        for (let i = 0; i < points.length; ++i) {
-            const rotated = points[i].rotated(angle);
-            minX = Math.min(minX, rotated.x);
-            minY = Math.min(minY, rotated.y);
-            maxX = Math.max(maxX, rotated.x);
-            maxY = Math.max(maxY, rotated.y);
-        }
-        return new Rectangle(minX, minY, maxX - minX, maxY - minY);
-    }
-
-    /**
      * Copies this instance
      * @returns {Rectangle}
      */

--- a/src/js/core/vector.js
+++ b/src/js/core/vector.js
@@ -4,53 +4,105 @@ import { safeModulo } from "./utils";
 const tileSize = globalConfig.tileSize;
 const halfTileSize = globalConfig.halfTileSize;
 
-/**
- * @enum {string}
- */
-export const enumDirection = {
-    top: "top",
-    right: "right",
-    bottom: "bottom",
-    left: "left",
+/** @type {Angle[]} **/
+export const angles = [0, 90, 180, 270];
+
+/** @type {Direction[]} **/
+export const directions = ["top", "right", "bottom", "left"];
+
+/** @type {Record<Direction, Direction>} **/
+export const inverseDirectionMap = {
+    top: "bottom",
+    right: "left",
+    bottom: "top",
+    left: "right",
+};
+
+/** @type {Record<Direction, Angle>} **/
+export const directionAngleMap = {
+    top: 0,
+    right: 90,
+    bottom: 180,
+    left: 270,
+};
+
+/** @type {Record<Angle, Direction>} **/
+export const angleDirectionMap = {
+    0: "top",
+    90: "right",
+    180: "bottom",
+    270: "left",
+};
+
+/** @type {Record<Angle, Angle>} **/
+export const inverseAngleMap = {
+    0: 0,
+    90: 270,
+    180: 180,
+    270: 90,
+};
+
+/** @type {Record<Angle, Angle>} **/
+export const clockwiseAngleMap = {
+    0: 90,
+    90: 180,
+    180: 270,
+    270: 0,
+};
+
+/** @type {Record<Angle, Angle>} **/
+export const counterClockwiseAngleMap = {
+    0: 270,
+    90: 0,
+    180: 90,
+    270: 180,
+};
+
+/** @type {Record<Direction, Record<Angle, Direction>>} **/
+export const directionRotationMap = {
+    top: {
+        0: "top",
+        90: "right",
+        180: "bottom",
+        270: "left",
+    },
+    right: {
+        0: "right",
+        90: "bottom",
+        180: "left",
+        270: "top",
+    },
+    bottom: {
+        0: "bottom",
+        90: "left",
+        180: "top",
+        270: "right",
+    },
+    left: {
+        0: "left",
+        90: "top",
+        180: "right",
+        270: "bottom",
+    },
 };
 
 /**
- * @enum {string}
+ * @param {number} n
+ * @return {n is Angle}
  */
-export const enumInvertedDirections = {
-    [enumDirection.top]: enumDirection.bottom,
-    [enumDirection.right]: enumDirection.left,
-    [enumDirection.bottom]: enumDirection.top,
-    [enumDirection.left]: enumDirection.right,
-};
+function isAngle(n) {
+    return angles.includes(/** @type {Angle} **/ (n));
+}
 
 /**
- * @enum {number}
+ * @param {number} radians
+ * @return {Angle}
  */
-export const enumDirectionToAngle = {
-    [enumDirection.top]: 0,
-    [enumDirection.right]: 90,
-    [enumDirection.bottom]: 180,
-    [enumDirection.left]: 270,
-};
-
-/**
- * @enum {enumDirection}
- */
-export const enumAngleToDirection = {
-    0: enumDirection.top,
-    90: enumDirection.right,
-    180: enumDirection.bottom,
-    270: enumDirection.left,
-};
-
-/** @type {Array<enumDirection>} */
-export const arrayAllDirections = [
-    enumDirection.top,
-    enumDirection.right,
-    enumDirection.bottom,
-    enumDirection.left,
-];
+export function snapToAngle(radians) {
+    const angle = (Math.round(Math.degrees(radians) / 90) * 90 + 360) % 360;
+    if (!isAngle(angle)) throw new Error("invalid Angle");
+    return angle;
+}
 
 export class Vector {
     /**
@@ -92,7 +144,7 @@ export class Vector {
     }
 
     /**
-     * Substracts a vector and return a new vector
+     * Subtracts a vector and return a new vector
      * @param {Vector} other
      * @returns {Vector}
      */
@@ -341,14 +393,6 @@ export class Vector {
     }
 
     /**
-     * Converts this vector from world to street space and return a new vector
-     * @returns {Vector}
-     */
-    toStreetSpace() {
-        return new Vector(Math.floor(this.x / halfTileSize + 0.25), Math.floor(this.y / halfTileSize + 0.25));
-    }
-
-    /**
      * Converts this vector to world space and return a new vector
      * @returns {Vector}
      */
@@ -438,162 +482,24 @@ export class Vector {
 
     /**
      * Rotates this vector
-     * @param {number} angle
+     * @param {Angle} angle
      * @returns {Vector} new vector
      */
-    rotated(angle) {
-        const sin = Math.sin(angle);
-        const cos = Math.cos(angle);
-        return new Vector(this.x * cos - this.y * sin, this.x * sin + this.y * cos);
-    }
-
-    /**
-     * Rotates this vector
-     * @param {number} angle
-     * @returns {Vector} this vector
-     */
-    rotateInplaceFastMultipleOf90(angle) {
-        // const sin = Math.sin(angle);
-        // const cos = Math.cos(angle);
-        // let sin = 0, cos = 1;
-        assert(angle >= 0 && angle <= 360, "Invalid angle, please clamp first: " + angle);
-
+    rotate(angle) {
+        const { x, y } = this;
         switch (angle) {
-            case 0:
-            case 360: {
-                return this;
-            }
-            case 90: {
-                // sin = 1;
-                // cos = 0;
-
-                const x = this.x;
-                this.x = -this.y;
-                this.y = x;
-                return this;
-            }
-            case 180: {
-                // sin = 0
-                // cos = -1
-                this.x = -this.x;
-                this.y = -this.y;
-                return this;
-            }
-            case 270: {
-                // sin = -1
-                // cos = 0
-                const x = this.x;
-                this.x = this.y;
-                this.y = -x;
-                return this;
-            }
-            default: {
-                assertAlways(false, "Invalid fast inplace rotation: " + angle);
-                return this;
-            }
-        }
-        // return new Vector(this.x * cos - this.y * sin, this.x * sin + this.y * cos);
-    }
-
-    /**
-     * Rotates this vector
-     * @param {number} angle
-     * @returns {Vector} new vector
-     */
-    rotateFastMultipleOf90(angle) {
-        assert(angle >= 0 && angle <= 360, "Invalid angle, please clamp first: " + angle);
-
-        switch (angle) {
-            case 360:
             case 0: {
-                return new Vector(this.x, this.y);
+                return new Vector(x, y);
             }
             case 90: {
-                return new Vector(-this.y, this.x);
+                return new Vector(-y, x);
             }
             case 180: {
-                return new Vector(-this.x, -this.y);
+                return new Vector(-x, -y);
             }
             case 270: {
-                return new Vector(this.y, -this.x);
+                return new Vector(y, -x);
             }
-            default: {
-                assertAlways(false, "Invalid fast inplace rotation: " + angle);
-                return new Vector();
-            }
-        }
-    }
-
-    /**
-     * Helper method to rotate a direction
-     * @param {enumDirection} direction
-     * @param {number} angle
-     * @returns {enumDirection}
-     */
-    static transformDirectionFromMultipleOf90(direction, angle) {
-        if (angle === 0 || angle === 360) {
-            return direction;
-        }
-        assert(angle >= 0 && angle <= 360, "Invalid angle: " + angle);
-        switch (direction) {
-            case enumDirection.top: {
-                switch (angle) {
-                    case 90:
-                        return enumDirection.right;
-                    case 180:
-                        return enumDirection.bottom;
-                    case 270:
-                        return enumDirection.left;
-                    default:
-                        assertAlways(false, "Invalid angle: " + angle);
-                        return;
-                }
-            }
-
-            case enumDirection.right: {
-                switch (angle) {
-                    case 90:
-                        return enumDirection.bottom;
-                    case 180:
-                        return enumDirection.left;
-                    case 270:
-                        return enumDirection.top;
-                    default:
-                        assertAlways(false, "Invalid angle: " + angle);
-                        return;
-                }
-            }
-
-            case enumDirection.bottom: {
-                switch (angle) {
-                    case 90:
-                        return enumDirection.left;
-                    case 180:
-                        return enumDirection.top;
-                    case 270:
-                        return enumDirection.right;
-                    default:
-                        assertAlways(false, "Invalid angle: " + angle);
-                        return;
-                }
-            }
-
-            case enumDirection.left: {
-                switch (angle) {
-                    case 90:
-                        return enumDirection.top;
-                    case 180:
-                        return enumDirection.right;
-                    case 270:
-                        return enumDirection.bottom;
-                    default:
-                        assertAlways(false, "Invalid angle: " + angle);
-                        return;
-                }
-            }
-            default:
-                assertAlways(false, "Invalid angle: " + angle);
-                return;
         }
     }
 
@@ -607,7 +513,7 @@ export class Vector {
     }
 
     /**
-     * Returns the angle
+     * Returns the angle in radians
      * @returns {number} 0 .. 2 PI
      */
     angle() {
@@ -680,9 +586,9 @@ export function mixVector(v1, v2, a) {
 
 /**
  * Mapping from string direction to actual vector
- * @enum {Vector}
+ * @type {Record<Direction, Vector>}
  */
-export const enumDirectionToVector = {
+export const directionVectorMap = {
     top: new Vector(0, -1),
     right: new Vector(1, 0),
     bottom: new Vector(0, 1),

--- a/src/js/game/belt_path.js
+++ b/src/js/game/belt_path.js
@@ -3,7 +3,7 @@ import { DrawParameters } from "../core/draw_parameters";
 import { createLogger } from "../core/logging";
 import { Rectangle } from "../core/rectangle";
 import { epsilonCompare, round4Digits } from "../core/utils";
-import { enumDirection, enumDirectionToVector, enumInvertedDirections, Vector } from "../core/vector";
+import { directionVectorMap, inverseDirectionMap, Vector } from "../core/vector";
 import { BasicSerializableObject, types } from "../savegame/serialization";
 import { BaseItem } from "./base_item";
 import { Entity } from "./entity";
@@ -186,7 +186,7 @@ export class BeltPath extends BasicSerializableObject {
 
     /**
      * Finds the entity which accepts our items
-     * @return {{ entity: Entity, slot: number, direction?: enumDirection }}
+     * @return {{ entity: Entity, slot: number, direction?: Direction }}
      */
     computeAcceptingEntityAndSlot() {
         const lastEntity = this.entityPath[this.entityPath.length - 1];
@@ -196,7 +196,7 @@ export class BeltPath extends BasicSerializableObject {
         // Figure out where and into which direction we eject items
         const ejectSlotWsTile = lastStatic.localTileToWorld(new Vector(0, 0));
         const ejectSlotWsDirection = lastStatic.localDirectionToWorld(lastBeltComp.direction);
-        const ejectSlotWsDirectionVector = enumDirectionToVector[ejectSlotWsDirection];
+        const ejectSlotWsDirectionVector = directionVectorMap[ejectSlotWsDirection];
         const ejectSlotTargetWsTile = ejectSlotWsTile.add(ejectSlotWsDirectionVector);
 
         // Try to find the given acceptor component to take the item
@@ -212,7 +212,7 @@ export class BeltPath extends BasicSerializableObject {
 
             // Check for belts (special case)
             if (targetBeltComp) {
-                const beltAcceptingDirection = targetStaticComp.localDirectionToWorld(enumDirection.top);
+                const beltAcceptingDirection = targetStaticComp.localDirectionToWorld("top");
                 if (ejectSlotWsDirection === beltAcceptingDirection) {
                     return {
                         entity: targetEntity,
@@ -243,7 +243,7 @@ export class BeltPath extends BasicSerializableObject {
             return {
                 entity: targetEntity,
                 slot: matchingSlot.index,
-                direction: enumInvertedDirections[ejectingDirection],
+                direction: inverseDirectionMap[ejectingDirection],
             };
         }
     }

--- a/src/js/game/blueprint.js
+++ b/src/js/game/blueprint.js
@@ -1,7 +1,6 @@
 import { DrawParameters } from "../core/draw_parameters";
-import { Loader } from "../core/loader";
 import { createLogger } from "../core/logging";
-import { Vector } from "../core/vector";
+import { clockwiseAngleMap, counterClockwiseAngleMap, Vector } from "../core/vector";
 import { Entity } from "./entity";
 import { GameRoot } from "./root";
 import { findNiceIntegerValue } from "../core/utils";
@@ -102,41 +101,23 @@ export class Blueprint {
      */
     rotateCw() {
         for (let i = 0; i < this.entities.length; ++i) {
-            const entity = this.entities[i];
-            const staticComp = entity.components.StaticMapEntity;
-
-            staticComp.rotation = (staticComp.rotation + 90) % 360;
-            staticComp.originalRotation = (staticComp.originalRotation + 90) % 360;
-            staticComp.origin = staticComp.origin.rotateFastMultipleOf90(90);
+            const { components: { StaticMapEntity } } = this.entities[i];
+            StaticMapEntity.rotation = clockwiseAngleMap[StaticMapEntity.rotation];
+            StaticMapEntity.originalRotation = clockwiseAngleMap[StaticMapEntity.originalRotation];
+            StaticMapEntity.origin = StaticMapEntity.origin.rotate(90);
         }
     }
 
     /**
-     * Rotates the blueprint counter clock wise
+     * Rotates the blueprint counter-clockwise
      */
     rotateCcw() {
-        // Well ...
-        for (let i = 0; i < 3; ++i) {
-            this.rotateCw();
-        }
-    }
-
-    /**
-     * Checks if the blueprint can be placed at the given tile
-     * @param {GameRoot} root
-     * @param {Vector} tile
-     */
-    canPlace(root, tile) {
-        let anyPlaceable = false;
-
         for (let i = 0; i < this.entities.length; ++i) {
-            const entity = this.entities[i];
-            if (root.logic.checkCanPlaceEntity(entity, tile)) {
-                anyPlaceable = true;
-            }
+            const { components: { StaticMapEntity } } = this.entities[i];
+            StaticMapEntity.rotation = counterClockwiseAngleMap[StaticMapEntity.rotation];
+            StaticMapEntity.originalRotation = counterClockwiseAngleMap[StaticMapEntity.originalRotation];
+            StaticMapEntity.origin = StaticMapEntity.origin.rotate(270);
         }
-
-        return anyPlaceable;
     }
 
     /**

--- a/src/js/game/building_codes.js
+++ b/src/js/game/building_codes.js
@@ -9,7 +9,7 @@ import { Vector } from "../core/vector";
  *   metaClass: typeof MetaBuilding,
  *   metaInstance?: MetaBuilding,
  *   variant?: string,
- *   rotationVariant?: number,
+ *   rotationVariant?: RotationVariant,
  *   tileSize?: Vector,
  *   sprite?: AtlasSprite,
  *   blueprintSprite?: AtlasSprite,
@@ -30,7 +30,7 @@ export const gBuildingVariants = {
  * @param {number} id
  * @param {typeof MetaBuilding} meta
  * @param {string} variant
- * @param {number} rotationVariant
+ * @param {RotationVariant} rotationVariant
  */
 export function registerBuildingVariant(
     id,
@@ -62,7 +62,7 @@ export function getBuildingDataFromCode(code) {
  * Finds the code for a given variant
  * @param {MetaBuilding} metaBuilding
  * @param {string} variant
- * @param {number} rotationVariant
+ * @param {RotationVariant} rotationVariant
  */
 export function getCodeFromBuildingData(metaBuilding, variant, rotationVariant) {
     for (const key in gBuildingVariants) {

--- a/src/js/game/buildings/belt.js
+++ b/src/js/game/buildings/belt.js
@@ -1,5 +1,4 @@
 import { Loader } from "../../core/loader";
-import { enumDirection } from "../../core/vector";
 import { SOUNDS } from "../../platform/sound";
 import { arrayBeltVariantToRotation, MetaBeltBaseBuilding } from "./belt_base";
 
@@ -18,13 +17,13 @@ export class MetaBeltBuilding extends MetaBeltBaseBuilding {
 
     getPreviewSprite(rotationVariant) {
         switch (arrayBeltVariantToRotation[rotationVariant]) {
-            case enumDirection.top: {
+            case "top": {
                 return Loader.getSprite("sprites/buildings/belt_top.png");
             }
-            case enumDirection.left: {
+            case "left": {
                 return Loader.getSprite("sprites/buildings/belt_left.png");
             }
-            case enumDirection.right: {
+            case "right": {
                 return Loader.getSprite("sprites/buildings/belt_right.png");
             }
             default: {
@@ -35,13 +34,13 @@ export class MetaBeltBuilding extends MetaBeltBaseBuilding {
 
     getBlueprintSprite(rotationVariant) {
         switch (arrayBeltVariantToRotation[rotationVariant]) {
-            case enumDirection.top: {
+            case "top": {
                 return Loader.getSprite("sprites/blueprints/belt_top.png");
             }
-            case enumDirection.left: {
+            case "left": {
                 return Loader.getSprite("sprites/blueprints/belt_left.png");
             }
-            case enumDirection.right: {
+            case "right": {
                 return Loader.getSprite("sprites/blueprints/belt_right.png");
             }
             default: {

--- a/src/js/game/buildings/constant_signal.js
+++ b/src/js/game/buildings/constant_signal.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { enumPinSlotType, WiredPinsComponent } from "../components/wired_pins";
 import { Entity } from "../entity";
 import { MetaBuilding } from "../meta_building";
@@ -41,7 +41,7 @@ export class MetaConstantSignalBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                         type: enumPinSlotType.logicalEjector,
                     },
                 ],

--- a/src/js/game/buildings/cutter.js
+++ b/src/js/game/buildings/cutter.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -80,7 +80,7 @@ export class MetaCutterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "shape",
                     },
                 ],
@@ -91,25 +91,25 @@ export class MetaCutterBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {
         switch (variant) {
             case defaultBuildingVariant: {
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                    { pos: new Vector(1, 0), direction: enumDirection.top },
+                    { pos: new Vector(0, 0), direction: "top" },
+                    { pos: new Vector(1, 0), direction: "top" },
                 ]);
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.cutter;
                 break;
             }
             case enumCutterVariants.quad: {
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                    { pos: new Vector(1, 0), direction: enumDirection.top },
-                    { pos: new Vector(2, 0), direction: enumDirection.top },
-                    { pos: new Vector(3, 0), direction: enumDirection.top },
+                    { pos: new Vector(0, 0), direction: "top" },
+                    { pos: new Vector(1, 0), direction: "top" },
+                    { pos: new Vector(2, 0), direction: "top" },
+                    { pos: new Vector(3, 0), direction: "top" },
                 ]);
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.cutterQuad;
                 break;

--- a/src/js/game/buildings/display.js
+++ b/src/js/game/buildings/display.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { enumPinSlotType, WiredPinsComponent } from "../components/wired_pins";
 import { Entity } from "../entity";
 import { MetaBuilding } from "../meta_building";
@@ -40,7 +40,7 @@ export class MetaDisplayBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.bottom,
+                        direction: "bottom",
                         type: enumPinSlotType.logicalAcceptor,
                     },
                 ],

--- a/src/js/game/buildings/filter.js
+++ b/src/js/game/buildings/filter.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { enumPinSlotType, WiredPinsComponent } from "../components/wired_pins";
 import { Entity } from "../entity";
 import { MetaBuilding } from "../meta_building";
@@ -43,7 +43,7 @@ export class MetaFilterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.left,
+                        direction: "left",
                         type: enumPinSlotType.logicalAcceptor,
                     },
                 ],
@@ -55,7 +55,7 @@ export class MetaFilterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                 ],
             })
@@ -66,11 +66,11 @@ export class MetaFilterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                     {
                         pos: new Vector(1, 0),
-                        direction: enumDirection.right,
+                        direction: "right",
                     },
                 ],
             })

--- a/src/js/game/buildings/hub.js
+++ b/src/js/game/buildings/hub.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { HubComponent } from "../components/hub";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { enumItemProcessorTypes, ItemProcessorComponent } from "../components/item_processor";
@@ -55,7 +55,7 @@ export class MetaHubBuilding extends MetaBuilding {
                     {
                         pos: new Vector(0, 2),
                         type: enumPinSlotType.logicalEjector,
-                        direction: enumDirection.left,
+                        direction: "left",
                     },
                 ],
             })
@@ -66,72 +66,72 @@ export class MetaHubBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.top, enumDirection.left],
+                        directions: ["top", "left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(2, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(3, 0),
-                        directions: [enumDirection.top, enumDirection.right],
+                        directions: ["top", "right"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(0, 3),
-                        directions: [enumDirection.bottom, enumDirection.left],
+                        directions: ["bottom", "left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(1, 3),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(2, 3),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(3, 3),
-                        directions: [enumDirection.bottom, enumDirection.right],
+                        directions: ["bottom", "right"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(0, 1),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(0, 2),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(0, 3),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(3, 1),
-                        directions: [enumDirection.right],
+                        directions: ["right"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(3, 2),
-                        directions: [enumDirection.right],
+                        directions: ["right"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(3, 3),
-                        directions: [enumDirection.right],
+                        directions: ["right"],
                         filter: "shape",
                     },
                 ],

--- a/src/js/game/buildings/lever.js
+++ b/src/js/game/buildings/lever.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { enumPinSlotType, WiredPinsComponent } from "../components/wired_pins";
 import { Entity } from "../entity";
 import { MetaBuilding } from "../meta_building";
@@ -49,7 +49,7 @@ export class MetaLeverBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                         type: enumPinSlotType.logicalEjector,
                     },
                 ],

--- a/src/js/game/buildings/logic_gate.js
+++ b/src/js/game/buildings/logic_gate.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { enumPinSlotType, WiredPinsComponent } from "../components/wired_pins";
 import { Entity } from "../entity";
 import { MetaBuilding, defaultBuildingVariant } from "../meta_building";
@@ -66,7 +66,7 @@ export class MetaLogicGateBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      */
     updateVariants(entity, rotationVariant, variant) {
         const gateType = enumVariantToGate[variant];
@@ -81,17 +81,17 @@ export class MetaLogicGateBuilding extends MetaBuilding {
                 pinComp.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                         type: enumPinSlotType.logicalEjector,
                     },
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.left,
+                        direction: "left",
                         type: enumPinSlotType.logicalAcceptor,
                     },
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.right,
+                        direction: "right",
                         type: enumPinSlotType.logicalAcceptor,
                     },
                 ]);
@@ -101,17 +101,17 @@ export class MetaLogicGateBuilding extends MetaBuilding {
                 pinComp.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                         type: enumPinSlotType.logicalEjector,
                     },
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.left,
+                        direction: "left",
                         type: enumPinSlotType.logicalAcceptor,
                     },
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.bottom,
+                        direction: "bottom",
                         type: enumPinSlotType.logicalAcceptor,
                     },
                 ]);
@@ -122,12 +122,12 @@ export class MetaLogicGateBuilding extends MetaBuilding {
                 pinComp.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                         type: enumPinSlotType.logicalEjector,
                     },
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.bottom,
+                        direction: "bottom",
                         type: enumPinSlotType.logicalAcceptor,
                     },
                 ]);

--- a/src/js/game/buildings/miner.js
+++ b/src/js/game/buildings/miner.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { MinerComponent } from "../components/miner";
 import { Entity } from "../entity";
@@ -44,8 +44,8 @@ export class MetaMinerBuilding extends MetaBuilding {
     }
 
     /**
-     * @param {number} rotation
-     * @param {number} rotationVariant
+     * @param {Angle} rotation
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      * @param {Entity} entity
      */
@@ -61,7 +61,7 @@ export class MetaMinerBuilding extends MetaBuilding {
         entity.addComponent(new MinerComponent({}));
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(0, 0), direction: enumDirection.top }],
+                slots: [{ pos: new Vector(0, 0), direction: "top" }],
             })
         );
     }
@@ -69,7 +69,7 @@ export class MetaMinerBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {

--- a/src/js/game/buildings/mixer.js
+++ b/src/js/game/buildings/mixer.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -53,7 +53,7 @@ export class MetaMixerBuilding extends MetaBuilding {
 
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(0, 0), direction: enumDirection.top }],
+                slots: [{ pos: new Vector(0, 0), direction: "top" }],
             })
         );
         entity.addComponent(
@@ -61,12 +61,12 @@ export class MetaMixerBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "color",
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "color",
                     },
                 ],

--- a/src/js/game/buildings/painter.js
+++ b/src/js/game/buildings/painter.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -88,7 +88,7 @@ export class MetaPainterBuilding extends MetaBuilding {
 
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(1, 0), direction: enumDirection.right }],
+                slots: [{ pos: new Vector(1, 0), direction: "right" }],
             })
         );
         entity.addComponent(
@@ -96,12 +96,12 @@ export class MetaPainterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: "color",
                     },
                 ],
@@ -112,7 +112,7 @@ export class MetaPainterBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {
@@ -122,87 +122,77 @@ export class MetaPainterBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [
-                            variant === defaultBuildingVariant ? enumDirection.top : enumDirection.bottom,
-                        ],
+                        directions: [variant === defaultBuildingVariant ? "top" : "bottom"],
                         filter: "color",
                     },
                 ]);
 
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.painter;
                 entity.components.ItemProcessor.inputsPerCharge = 2;
-                entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(1, 0), direction: enumDirection.right },
-                ]);
+                entity.components.ItemEjector.setSlots([{ pos: new Vector(1, 0), direction: "right" }]);
                 break;
             }
             case enumPainterVariants.double: {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(0, 1),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.top],
+                        directions: ["top"],
                         filter: "color",
                     },
                 ]);
 
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.painterDouble;
                 entity.components.ItemProcessor.inputsPerCharge = 3;
-
-                entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(1, 0), direction: enumDirection.right },
-                ]);
+                entity.components.ItemEjector.setSlots([{ pos: new Vector(1, 0), direction: "right" }]);
                 break;
             }
             case enumPainterVariants.quad: {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.left],
+                        directions: ["left"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "color",
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "color",
                     },
                     {
                         pos: new Vector(2, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "color",
                     },
                     {
                         pos: new Vector(3, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "color",
                     },
                 ]);
 
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.painterQuad;
                 entity.components.ItemProcessor.inputsPerCharge = 5;
-
-                entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                ]);
+                entity.components.ItemEjector.setSlots([{ pos: new Vector(0, 0), direction: "top" }]);
                 break;
             }
             default:

--- a/src/js/game/buildings/rotater.js
+++ b/src/js/game/buildings/rotater.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -79,7 +79,7 @@ export class MetaRotaterBuilding extends MetaBuilding {
 
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(0, 0), direction: enumDirection.top }],
+                slots: [{ pos: new Vector(0, 0), direction: "top" }],
             })
         );
         entity.addComponent(
@@ -87,7 +87,7 @@ export class MetaRotaterBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "shape",
                     },
                 ],
@@ -98,7 +98,7 @@ export class MetaRotaterBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {

--- a/src/js/game/buildings/splitter.js
+++ b/src/js/game/buildings/splitter.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { enumItemProcessorTypes, ItemProcessorComponent } from "../components/item_processor";
@@ -95,7 +95,7 @@ export class MetaSplitterBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {
@@ -104,22 +104,22 @@ export class MetaSplitterBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                 ]);
 
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                    { pos: new Vector(1, 0), direction: enumDirection.top },
+                    { pos: new Vector(0, 0), direction: "top" },
+                    { pos: new Vector(1, 0), direction: "top" },
                 ]);
 
                 entity.components.BeltUnderlays.underlays = [
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                    { pos: new Vector(1, 0), direction: enumDirection.top },
+                    { pos: new Vector(0, 0), direction: "top" },
+                    { pos: new Vector(1, 0), direction: "top" },
                 ];
 
                 break;
@@ -129,25 +129,17 @@ export class MetaSplitterBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                     {
                         pos: new Vector(0, 0),
-                        directions: [
-                            variant === enumSplitterVariants.compactInverse
-                                ? enumDirection.left
-                                : enumDirection.right,
-                        ],
+                        directions: [variant === enumSplitterVariants.compactInverse ? "left" : "right"],
                     },
                 ]);
 
-                entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                ]);
+                entity.components.ItemEjector.setSlots([{ pos: new Vector(0, 0), direction: "top" }]);
 
-                entity.components.BeltUnderlays.underlays = [
-                    { pos: new Vector(0, 0), direction: enumDirection.top },
-                ];
+                entity.components.BeltUnderlays.underlays = [{ pos: new Vector(0, 0), direction: "top" }];
 
                 break;
             }

--- a/src/js/game/buildings/stacker.js
+++ b/src/js/game/buildings/stacker.js
@@ -1,5 +1,5 @@
 import { formatItemsPerSecond } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -53,7 +53,7 @@ export class MetaStackerBuilding extends MetaBuilding {
 
         entity.addComponent(
             new ItemEjectorComponent({
-                slots: [{ pos: new Vector(0, 0), direction: enumDirection.top }],
+                slots: [{ pos: new Vector(0, 0), direction: "top" }],
             })
         );
         entity.addComponent(
@@ -61,12 +61,12 @@ export class MetaStackerBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(1, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                         filter: "shape",
                     },
                 ],

--- a/src/js/game/buildings/trash.js
+++ b/src/js/game/buildings/trash.js
@@ -1,5 +1,5 @@
 import { formatBigNumber } from "../../core/utils";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { T } from "../../translations";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
@@ -86,12 +86,7 @@ export class MetaTrashBuilding extends MetaBuilding {
                 slots: [
                     {
                         pos: new Vector(0, 0),
-                        directions: [
-                            enumDirection.top,
-                            enumDirection.right,
-                            enumDirection.bottom,
-                            enumDirection.left,
-                        ],
+                        directions: ["top", "right", "bottom", "left"],
                     },
                 ],
             })
@@ -101,7 +96,7 @@ export class MetaTrashBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {
@@ -125,12 +120,7 @@ export class MetaTrashBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [
-                            enumDirection.top,
-                            enumDirection.right,
-                            enumDirection.bottom,
-                            enumDirection.left,
-                        ],
+                        directions: ["top", "right", "bottom", "left"],
                     },
                 ]);
                 entity.components.ItemEjector.setSlots([]);
@@ -150,12 +140,12 @@ export class MetaTrashBuilding extends MetaBuilding {
                             slots: [
                                 {
                                     pos: new Vector(1, 1),
-                                    direction: enumDirection.right,
+                                    direction: "right",
                                     type: enumPinSlotType.logicalEjector,
                                 },
                                 {
                                     pos: new Vector(0, 1),
-                                    direction: enumDirection.left,
+                                    direction: "left",
                                     type: enumPinSlotType.logicalEjector,
                                 },
                             ],
@@ -167,22 +157,22 @@ export class MetaTrashBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 1),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                     {
                         pos: new Vector(1, 1),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                 ]);
 
                 entity.components.ItemEjector.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                     {
                         pos: new Vector(1, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                 ]);
                 break;

--- a/src/js/game/buildings/underground_belt.js
+++ b/src/js/game/buildings/underground_belt.js
@@ -1,5 +1,5 @@
 import { Loader } from "../../core/loader";
-import { enumDirection, Vector, enumAngleToDirection, enumDirectionToVector } from "../../core/vector";
+import { Vector, angleDirectionMap, directionVectorMap, clockwiseAngleMap } from "../../core/vector";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { enumUndergroundBeltMode, UndergroundBeltComponent } from "../components/underground_belt";
@@ -51,8 +51,8 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
     }
 
     /**
-     * @param {number} rotation
-     * @param {number} rotationVariant
+     * @param {Angle} rotation
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      * @param {Entity} entity
      */
@@ -90,7 +90,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
     }
 
     /**
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     getPreviewSprite(rotationVariant, variant) {
@@ -110,7 +110,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
     }
 
     /**
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     getBlueprintSprite(rotationVariant, variant) {
@@ -130,7 +130,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
     }
 
     /**
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     getSprite(rotationVariant, variant) {
@@ -169,17 +169,17 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
      * @param {object} param0
      * @param {GameRoot} param0.root
      * @param {Vector} param0.tile
-     * @param {number} param0.rotation
+     * @param {Angle} param0.rotation
      * @param {string} param0.variant
      * @param {Layer} param0.layer
-     * @return {{ rotation: number, rotationVariant: number, connectedEntities?: Array<Entity> }}
+     * @return {{ rotation: Angle, rotationVariant: RotationVariant, connectedEntities?: Array<Entity> }}
      */
     computeOptimalDirectionAndRotationVariantAtTile({ root, tile, rotation, variant, layer }) {
-        const searchDirection = enumAngleToDirection[rotation];
-        const searchVector = enumDirectionToVector[searchDirection];
+        const searchDirection = angleDirectionMap[rotation];
+        const searchVector = directionVectorMap[searchDirection];
         const tier = enumUndergroundBeltVariantToTier[variant];
 
-        const targetRotation = (rotation + 180) % 360;
+        const targetRotation = clockwiseAngleMap[clockwiseAngleMap[rotation]];
         const targetSenderRotation = rotation;
 
         for (
@@ -209,7 +209,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                         // Draw connections to receivers
                         if (undergroundComp.mode === enumUndergroundBeltMode.receiver) {
                             return {
-                                rotation: rotation,
+                                rotation,
                                 rotationVariant: 0,
                                 connectedEntities: [contents],
                             };
@@ -230,7 +230,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {
@@ -243,7 +243,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                 entity.components.ItemAcceptor.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        directions: [enumDirection.bottom],
+                        directions: ["bottom"],
                     },
                 ]);
                 return;
@@ -254,7 +254,7 @@ export class MetaUndergroundBeltBuilding extends MetaBuilding {
                 entity.components.ItemEjector.setSlots([
                     {
                         pos: new Vector(0, 0),
-                        direction: enumDirection.top,
+                        direction: "top",
                     },
                 ]);
                 return;

--- a/src/js/game/buildings/wire.js
+++ b/src/js/game/buildings/wire.js
@@ -1,6 +1,6 @@
 import { Loader } from "../../core/loader";
 import { generateMatrixRotations } from "../../core/utils";
-import { enumDirection, enumDirectionToAngle, enumDirectionToVector, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { SOUNDS } from "../../platform/sound";
 import { enumWireType, WireComponent } from "../components/wire";
 import { Entity } from "../entity";
@@ -83,7 +83,7 @@ export class MetaWireBuilding extends MetaBuilding {
     /**
      *
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      */
     updateVariants(entity, rotationVariant) {
         entity.components.Wire.type = arrayWireRotationVariantToType[rotationVariant];
@@ -91,8 +91,8 @@ export class MetaWireBuilding extends MetaBuilding {
 
     /**
      *
-     * @param {number} rotation
-     * @param {number} rotationVariant
+     * @param {Angle} rotation
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      * @param {Entity} entity
      */
@@ -145,17 +145,17 @@ export class MetaWireBuilding extends MetaBuilding {
      * @param {object} param0
      * @param {GameRoot} param0.root
      * @param {Vector} param0.tile
-     * @param {number} param0.rotation
+     * @param {Angle} param0.rotation
      * @param {string} param0.variant
      * @param {string} param0.layer
-     * @return {{ rotation: number, rotationVariant: number, connectedEntities?: Array<Entity> }}
+     * @return {{ rotation: Angle, rotationVariant: RotationVariant, connectedEntities?: Array<Entity> }}
      */
     computeOptimalDirectionAndRotationVariantAtTile({ root, tile, rotation, variant, layer }) {
         const connections = {
-            top: root.logic.computeWireEdgeStatus({ tile, rotation, edge: enumDirection.top }),
-            right: root.logic.computeWireEdgeStatus({ tile, rotation, edge: enumDirection.right }),
-            bottom: root.logic.computeWireEdgeStatus({ tile, rotation, edge: enumDirection.bottom }),
-            left: root.logic.computeWireEdgeStatus({ tile, rotation, edge: enumDirection.left }),
+            top: root.logic.computeWireEdgeStatus({ tile, rotation, edge: "top" }),
+            right: root.logic.computeWireEdgeStatus({ tile, rotation, edge: "right" }),
+            bottom: root.logic.computeWireEdgeStatus({ tile, rotation, edge: "bottom" }),
+            left: root.logic.computeWireEdgeStatus({ tile, rotation, edge: "left" }),
         };
 
         let flag = 0;
@@ -176,7 +176,7 @@ export class MetaWireBuilding extends MetaBuilding {
 
             case 0x0001:
                 // Left
-                rotation += 90;
+                rotation = 90;
                 break;
 
             case 0x0010:
@@ -187,17 +187,17 @@ export class MetaWireBuilding extends MetaBuilding {
             case 0x0011:
                 // Bottom | Left
                 targetType = enumWireType.turn;
-                rotation += 90;
+                rotation = 90;
                 break;
 
             case 0x0100:
                 // Right
-                rotation += 90;
+                rotation = 90;
                 break;
 
             case 0x0101:
                 // Right | Left
-                rotation += 90;
+                rotation = 90;
                 break;
 
             case 0x0110:
@@ -217,7 +217,7 @@ export class MetaWireBuilding extends MetaBuilding {
             case 0x1001:
                 // Top | Left
                 targetType = enumWireType.turn;
-                rotation += 180;
+                rotation = 180;
                 break;
 
             case 0x1010:
@@ -227,25 +227,25 @@ export class MetaWireBuilding extends MetaBuilding {
             case 0x1011:
                 // Top | Bottom | Left
                 targetType = enumWireType.split;
-                rotation += 90;
+                rotation = 90;
                 break;
 
             case 0x1100:
                 // Top | Right
                 targetType = enumWireType.turn;
-                rotation -= 90;
+                rotation = 270;
                 break;
 
             case 0x1101:
                 // Top | Right | Left
                 targetType = enumWireType.split;
-                rotation += 180;
+                rotation = 180;
                 break;
 
             case 0x1110:
                 // Top | Right | Bottom
                 targetType = enumWireType.split;
-                rotation -= 90;
+                rotation = 270;
                 break;
 
             case 0x1111:
@@ -254,10 +254,13 @@ export class MetaWireBuilding extends MetaBuilding {
                 break;
         }
 
+        const rotationVariant = /** @type {RotationVariant} **/ (arrayWireRotationVariantToType.indexOf(
+            targetType
+        ));
+
         return {
-            // Clamp rotation
-            rotation: (rotation + 360 * 10) % 360,
-            rotationVariant: arrayWireRotationVariantToType.indexOf(targetType),
+            rotation,
+            rotationVariant,
         };
     }
 }

--- a/src/js/game/buildings/wire_tunnel.js
+++ b/src/js/game/buildings/wire_tunnel.js
@@ -34,8 +34,8 @@ export class MetaWireTunnelBuilding extends MetaBuilding {
 
     /**
      *
-     * @param {number} rotation
-     * @param {number} rotationVariant
+     * @param {Angle} rotation
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      * @param {Entity} entity
      */
@@ -78,7 +78,7 @@ export class MetaWireTunnelBuilding extends MetaBuilding {
 
     /**
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {

--- a/src/js/game/components/belt.js
+++ b/src/js/game/components/belt.js
@@ -1,5 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
-import { types } from "../../savegame/serialization";
+import { Vector } from "../../core/vector";
 import { BeltPath } from "../belt_path";
 import { Component } from "../component";
 
@@ -8,28 +7,28 @@ export const curvedBeltLength = /* Math.PI / 4 */ 0.78;
 /** @type {import("./item_acceptor").ItemAcceptorSlot} */
 export const FAKE_BELT_ACCEPTOR_SLOT = {
     pos: new Vector(0, 0),
-    directions: [enumDirection.bottom],
+    directions: ["bottom"],
 };
 
-/** @type {Object<enumDirection, import("./item_ejector").ItemEjectorSlot>} */
+/** @type {Object<Direction, import("./item_ejector").ItemEjectorSlot>} */
 export const FAKE_BELT_EJECTOR_SLOT_BY_DIRECTION = {
-    [enumDirection.top]: {
+    top: {
         pos: new Vector(0, 0),
-        direction: enumDirection.top,
+        direction: "top",
         item: null,
         progress: 0,
     },
 
-    [enumDirection.right]: {
+    right: {
         pos: new Vector(0, 0),
-        direction: enumDirection.right,
+        direction: "right",
         item: null,
         progress: 0,
     },
 
-    [enumDirection.left]: {
+    left: {
         pos: new Vector(0, 0),
-        direction: enumDirection.left,
+        direction: "left",
         item: null,
         progress: 0,
     },
@@ -47,9 +46,9 @@ export class BeltComponent extends Component {
     /**
      *
      * @param {object} param0
-     * @param {enumDirection=} param0.direction The direction of the belt
+     * @param {Direction=} param0.direction The direction of the belt
      */
-    constructor({ direction = enumDirection.top }) {
+    constructor({ direction = "top" }) {
         super();
 
         this.direction = direction;
@@ -66,7 +65,7 @@ export class BeltComponent extends Component {
      * @returns {number}
      */
     getEffectiveLengthTiles() {
-        return this.direction === enumDirection.top ? 1.0 : curvedBeltLength;
+        return this.direction === "top" ? 1.0 : curvedBeltLength;
     }
 
     /**
@@ -99,16 +98,16 @@ export class BeltComponent extends Component {
     transformBeltToLocalSpace(progress) {
         assert(progress >= 0.0, "Invalid progress ( < 0): " + progress);
         switch (this.direction) {
-            case enumDirection.top:
+            case "top":
                 assert(progress <= 1.02, "Invalid progress: " + progress);
                 return new Vector(0, 0.5 - progress);
 
-            case enumDirection.right: {
+            case "right": {
                 assert(progress <= curvedBeltLength + 0.02, "Invalid progress 2: " + progress);
                 const arcProgress = (progress / curvedBeltLength) * 0.5 * Math.PI;
                 return new Vector(0.5 - 0.5 * Math.cos(arcProgress), 0.5 - 0.5 * Math.sin(arcProgress));
             }
-            case enumDirection.left: {
+            case "left": {
                 assert(progress <= curvedBeltLength + 0.02, "Invalid progress 3: " + progress);
                 const arcProgress = (progress / curvedBeltLength) * 0.5 * Math.PI;
                 return new Vector(-0.5 + 0.5 * Math.cos(arcProgress), 0.5 - 0.5 * Math.sin(arcProgress));

--- a/src/js/game/components/belt_underlays.js
+++ b/src/js/game/components/belt_underlays.js
@@ -1,6 +1,6 @@
 import { Component } from "../component";
 import { types } from "../../savegame/serialization";
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 
 export class BeltUnderlaysComponent extends Component {
     static getId() {
@@ -24,7 +24,7 @@ export class BeltUnderlaysComponent extends Component {
 
     /**
      * @param {object} param0
-     * @param {Array<{pos: Vector, direction: enumDirection}>=} param0.underlays Where to render belt underlays
+     * @param {Array<{pos: Vector, direction: Direction}>=} param0.underlays Where to render belt underlays
      */
     constructor({ underlays }) {
         super();

--- a/src/js/game/components/item_acceptor.js
+++ b/src/js/game/components/item_acceptor.js
@@ -1,11 +1,10 @@
-import { enumDirection, enumInvertedDirections, Vector } from "../../core/vector";
-import { types } from "../../savegame/serialization";
+import { inverseDirectionMap, Vector } from "../../core/vector";
 import { BaseItem } from "../base_item";
 import { Component } from "../component";
 
 /** @typedef {{
  * pos: Vector,
- * directions: enumDirection[],
+ * directions: Direction[],
  * filter?: ItemType
  * }} ItemAcceptorSlot */
 
@@ -14,12 +13,12 @@ import { Component } from "../component";
  * @typedef {{
  *  slot: ItemAcceptorSlot,
  *  index: number,
- *  acceptedDirection: enumDirection
+ *  acceptedDirection: Direction
  * }} ItemAcceptorLocatedSlot */
 
 /** @typedef {{
  * pos: Vector,
- * directions: enumDirection[],
+ * directions: Direction[],
  * filter?: ItemType
  * }} ItemAcceptorSlotConfig */
 
@@ -54,7 +53,7 @@ export class ItemAcceptorComponent extends Component {
 
         /**
          * Fixes belt animations
-         * @type {Array<{ item: BaseItem, slotIndex: number, animProgress: number, direction: enumDirection }>}
+         * @type {Array<{ item: BaseItem, slotIndex: number, animProgress: number, direction: Direction }>}
          */
         this.itemConsumptionAnimations = [];
 
@@ -93,7 +92,7 @@ export class ItemAcceptorComponent extends Component {
     /**
      * Called when an item has been accepted so that
      * @param {number} slotIndex
-     * @param {enumDirection} direction
+     * @param {Direction} direction
      * @param {BaseItem} item
      */
     onItemAccepted(slotIndex, direction, item) {
@@ -108,27 +107,21 @@ export class ItemAcceptorComponent extends Component {
     /**
      * Tries to find a slot which accepts the current item
      * @param {Vector} targetLocalTile
-     * @param {enumDirection} fromLocalDirection
+     * @param {Direction} fromLocalDirection
      * @returns {ItemAcceptorLocatedSlot|null}
      */
     findMatchingSlot(targetLocalTile, fromLocalDirection) {
         // We need to invert our direction since the acceptor specifies *from* which direction
         // it accepts items, but the ejector specifies *into* which direction it ejects items.
         // E.g.: Ejector ejects into "right" direction but acceptor accepts from "left" direction.
-        const desiredDirection = enumInvertedDirections[fromLocalDirection];
+        const desiredDirection = inverseDirectionMap[fromLocalDirection];
 
         // Go over all slots and try to find a target slot
         for (let slotIndex = 0; slotIndex < this.slots.length; ++slotIndex) {
             const slot = this.slots[slotIndex];
 
-            // Make sure the acceptor slot is on the right position
-            if (!slot.pos.equals(targetLocalTile)) {
-                continue;
-            }
-
             // Check if the acceptor slot accepts items from our direction
             for (let i = 0; i < slot.directions.length; ++i) {
-                // const localDirection = targetStaticComp.localDirectionToWorld(slot.directions[l]);
                 if (desiredDirection === slot.directions[i]) {
                     return {
                         slot,

--- a/src/js/game/components/item_ejector.js
+++ b/src/js/game/components/item_ejector.js
@@ -1,4 +1,4 @@
-import { enumDirection, enumDirectionToVector, Vector } from "../../core/vector";
+import { directionVectorMap, Vector } from "../../core/vector";
 import { types } from "../../savegame/serialization";
 import { BaseItem } from "../base_item";
 import { BeltPath } from "../belt_path";
@@ -7,9 +7,10 @@ import { Entity } from "../entity";
 import { typeItemSingleton } from "../item_resolver";
 
 /**
+ * @typedef {import("./item_acceptor").ItemAcceptorLocatedSlot} ItemAcceptorLocatedSlot
  * @typedef {{
  *    pos: Vector,
- *    direction: enumDirection,
+ *    direction: Direction,
  *    item: BaseItem,
  *    progress: number?,
  *    cachedDestSlot?: import("./item_acceptor").ItemAcceptorLocatedSlot,
@@ -53,7 +54,7 @@ export class ItemEjectorComponent extends Component {
     /**
      *
      * @param {object} param0
-     * @param {Array<{pos: Vector, direction: enumDirection }>=} param0.slots The slots to eject on
+     * @param {Array<{pos: Vector, direction: Direction }>=} param0.slots The slots to eject on
      */
     constructor({ slots = [] }) {
         super();
@@ -67,7 +68,7 @@ export class ItemEjectorComponent extends Component {
     }
 
     /**
-     * @param {Array<{pos: Vector, direction: enumDirection }>} slots The slots to eject on
+     * @param {Array<{pos: Vector, direction: Direction }>} slots The slots to eject on
      */
     setSlots(slots) {
         /** @type {Array<ItemEjectorSlot>} */
@@ -91,7 +92,7 @@ export class ItemEjectorComponent extends Component {
      * @returns {Vector}
      */
     getSlotTargetLocalTile(slot) {
-        const directionVector = enumDirectionToVector[slot.direction];
+        const directionVector = directionVectorMap[slot.direction];
         return slot.pos.add(directionVector);
     }
 

--- a/src/js/game/components/wired_pins.js
+++ b/src/js/game/components/wired_pins.js
@@ -1,4 +1,4 @@
-import { enumDirection, Vector } from "../../core/vector";
+import { Vector } from "../../core/vector";
 import { BaseItem } from "../base_item";
 import { Component } from "../component";
 import { types } from "../../savegame/serialization";
@@ -13,13 +13,13 @@ export const enumPinSlotType = {
 /** @typedef {{
  *   pos: Vector,
  *   type: enumPinSlotType,
- *   direction: enumDirection
+ *   direction: Direction
  * }} WirePinSlotDefinition */
 
 /** @typedef {{
  *   pos: Vector,
  *   type: enumPinSlotType,
- *   direction: enumDirection,
+ *   direction: Direction,
  *   value: BaseItem,
  *   linkedNetwork: import("../systems/wire").WireNetwork
  * }} WirePinSlot */

--- a/src/js/game/entity.js
+++ b/src/js/game/entity.js
@@ -5,7 +5,7 @@ import { Component } from "./component";
 
 import { GameRoot } from "./root";
 import { globalConfig } from "../core/config";
-import { enumDirectionToVector, enumDirectionToAngle } from "../core/vector";
+import { directionAngleMap, directionVectorMap } from "../core/vector";
 import { BasicSerializableObject, types } from "../savegame/serialization";
 import { EntityComponentStorage } from "./entity_components";
 import { Loader } from "../core/loader";
@@ -172,8 +172,8 @@ export class Entity extends BasicSerializableObject {
                     const slot = ejectorComp.slots[i];
                     const slotTile = staticComp.localTileToWorld(slot.pos);
                     const direction = staticComp.localDirectionToWorld(slot.direction);
-                    const directionVector = enumDirectionToVector[direction];
-                    const angle = Math.radians(enumDirectionToAngle[direction]);
+                    const directionVector = directionVectorMap[direction];
+                    const angle = Math.radians(directionAngleMap[direction]);
 
                     context.globalAlpha = slot.item ? 1 : 0.2;
                     drawRotatedSprite({
@@ -195,8 +195,8 @@ export class Entity extends BasicSerializableObject {
                     const slotTile = staticComp.localTileToWorld(slot.pos);
                     for (let k = 0; k < slot.directions.length; ++k) {
                         const direction = staticComp.localDirectionToWorld(slot.directions[k]);
-                        const directionVector = enumDirectionToVector[direction];
-                        const angle = Math.radians(enumDirectionToAngle[direction] + 180);
+                        const directionVector = directionVectorMap[direction];
+                        const angle = Math.radians(directionAngleMap[direction] + 180);
                         context.globalAlpha = 0.4;
                         drawRotatedSprite({
                             parameters,

--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -4,13 +4,7 @@ import { DrawParameters } from "../../../core/draw_parameters";
 import { drawRotatedSprite } from "../../../core/draw_utils";
 import { Loader } from "../../../core/loader";
 import { clamp, makeDiv, removeAllChildren } from "../../../core/utils";
-import {
-    enumDirectionToAngle,
-    enumDirectionToVector,
-    enumInvertedDirections,
-    Vector,
-    enumDirection,
-} from "../../../core/vector";
+import { directionVectorMap, directionAngleMap, inverseDirectionMap, Vector } from "../../../core/vector";
 import { T } from "../../../translations";
 import { KEYMAPPINGS } from "../../key_action_mapper";
 import { defaultBuildingVariant } from "../../meta_building";
@@ -208,8 +202,8 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
             const dimensions = metaBuilding.getDimensions(variant);
             const sprite = metaBuilding.getPreviewSprite(0, variant);
             const spriteWrapper = makeDiv(element, null, ["iconWrap"]);
-            spriteWrapper.setAttribute("data-tile-w", dimensions.x);
-            spriteWrapper.setAttribute("data-tile-h", dimensions.y);
+            spriteWrapper.setAttribute("data-tile-w", `${dimensions.x}`);
+            spriteWrapper.setAttribute("data-tile-h", `${dimensions.y}`);
 
             spriteWrapper.innerHTML = sprite.getAsHTML(iconSize * dimensions.x, iconSize * dimensions.y);
 
@@ -495,7 +489,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                 const worldDirection = staticComp.localDirectionToWorld(direction);
 
                 // Figure out which tile ejects to this slot
-                const sourceTile = acceptorSlotWsTile.add(enumDirectionToVector[worldDirection]);
+                const sourceTile = acceptorSlotWsTile.add(directionVectorMap[worldDirection]);
 
                 let isBlocked = false;
                 let isConnected = false;
@@ -519,7 +513,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                     } else if (
                         sourceBeltComp &&
                         sourceStaticComp.localDirectionToWorld(sourceBeltComp.direction) ===
-                            enumInvertedDirections[worldDirection]
+                            inverseDirectionMap[worldDirection]
                     ) {
                         // Belt connected
                         isConnected = true;
@@ -538,7 +532,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                     sprite,
                     x: acceptorSlotWsPos.x,
                     y: acceptorSlotWsPos.y,
-                    angle: Math.radians(enumDirectionToAngle[enumInvertedDirections[worldDirection]]),
+                    angle: Math.radians(directionAngleMap[inverseDirectionMap[worldDirection]]),
                     size: 13,
                     offsetY: offsetShift + 13,
                 });
@@ -550,7 +544,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
         for (let ejectorSlotIndex = 0; ejectorSlotIndex < ejectorSlots.length; ++ejectorSlotIndex) {
             const slot = ejectorSlots[ejectorSlotIndex];
 
-            const ejectorSlotLocalTile = slot.pos.add(enumDirectionToVector[slot.direction]);
+            const ejectorSlotLocalTile = slot.pos.add(directionVectorMap[slot.direction]);
             const ejectorSlotWsTile = staticComp.localTileToWorld(ejectorSlotLocalTile);
 
             const ejectorSLotWsPos = ejectorSlotWsTile.toWorldSpaceCenterOfTile();
@@ -576,7 +570,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                 if (destAcceptor && destAcceptor.findMatchingSlot(destLocalTile, destLocalDir)) {
                     // This one is connected, all good
                     isConnected = true;
-                } else if (destEntity.components.Belt && destLocalDir === enumDirection.top) {
+                } else if (destEntity.components.Belt && destLocalDir === "top") {
                     // Connected to a belt
                     isConnected = true;
                 } else {
@@ -594,7 +588,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                 sprite,
                 x: ejectorSLotWsPos.x,
                 y: ejectorSLotWsPos.y,
-                angle: Math.radians(enumDirectionToAngle[ejectorSlotWsDirection]),
+                angle: Math.radians(directionAngleMap[ejectorSlotWsDirection]),
                 size: 13,
                 offsetY: offsetShift,
             });

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -2,7 +2,7 @@ import { globalConfig } from "../../../core/config";
 import { gMetaBuildingRegistry } from "../../../core/global_registries";
 import { Signal, STOP_PROPAGATION } from "../../../core/signal";
 import { TrackedState } from "../../../core/tracked_state";
-import { Vector } from "../../../core/vector";
+import { clockwiseAngleMap, counterClockwiseAngleMap, snapToAngle, Vector } from "../../../core/vector";
 import { enumMouseButton } from "../../camera";
 import { StaticMapEntityComponent } from "../../components/static_map_entity";
 import { Entity } from "../../entity";
@@ -46,13 +46,13 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
         /**
          * The current rotation
-         * @type {number}
+         * @type {Angle}
          */
         this.currentBaseRotationGeneral = 0;
 
         /**
          * The current rotation preference for each building.
-         * @type{Object.<string,number>}
+         * @type{Object.<string,Angle>}
          */
         this.preferredBaseRotations = {};
 
@@ -146,7 +146,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
     /**
      * Returns the current base rotation for the current meta-building.
-     * @returns {number}
+     * @returns {Angle}
      */
     get currentBaseRotation() {
         if (!this.root.app.settings.getAllSettings().rotationByBuilding) {
@@ -162,7 +162,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
     /**
      * Sets the base rotation for the current meta-building.
-     * @param {number} rotation The new rotation/angle.
+     * @param {Angle} rotation The new rotation/angle.
      */
     set currentBaseRotation(rotation) {
         if (!this.root.app.settings.getAllSettings().rotationByBuilding) {
@@ -274,9 +274,9 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         const selectedBuilding = this.currentMetaBuilding.get();
         if (selectedBuilding) {
             if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateInverseModifier).pressed) {
-                this.currentBaseRotation = (this.currentBaseRotation + 270) % 360;
+                this.currentBaseRotation = counterClockwiseAngleMap[this.currentBaseRotation];
             } else {
-                this.currentBaseRotation = (this.currentBaseRotation + 90) % 360;
+                this.currentBaseRotation = clockwiseAngleMap[this.currentBaseRotation];
             }
             const staticComp = this.fakeEntity.components.StaticMapEntity;
             staticComp.rotation = this.currentBaseRotation;
@@ -424,7 +424,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
                     KEYMAPPINGS.placementModifiers.placementDisableAutoOrientation
                 ).pressed
             ) {
-                this.currentBaseRotation = (180 + this.currentBaseRotation) % 360;
+                this.currentBaseRotation = clockwiseAngleMap[clockwiseAngleMap[this.currentBaseRotation]];
             }
 
             // Check if we should stop placement
@@ -508,7 +508,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
     /**
      * Finds the path which the current direction lock will use
-     * @returns {Array<{ tile: Vector, rotation: number }>}
+     * @returns {Array<{ tile: Vector, rotation: Angle }>}
      */
     computeDirectionLockPath() {
         const mousePosition = this.root.app.mousePosition;
@@ -537,7 +537,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         const lengthToCorner = Math.round(pathToCorner.length());
         let currentPos = startTile.copy();
 
-        let rotation = (Math.round(Math.degrees(deltaToCorner.angle()) / 90) * 90 + 360) % 360;
+        let rotation = snapToAngle(deltaToCorner.angle());
 
         if (lengthToCorner > 0) {
             for (let i = 0; i < lengthToCorner; ++i) {
@@ -555,7 +555,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         const lengthFromCorner = Math.round(pathFromCorner.length());
 
         if (lengthFromCorner > 0) {
-            rotation = (Math.round(Math.degrees(deltaFromCorner.angle()) / 90) * 90 + 360) % 360;
+            rotation = snapToAngle(deltaFromCorner.angle());
             for (let i = 0; i < lengthFromCorner + 1; ++i) {
                 result.push({
                     tile: currentPos.copy(),
@@ -692,12 +692,12 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
                     ).pressed
                 ) {
                     const delta = newPos.sub(oldPos);
-                    const angleDeg = Math.degrees(delta.angle());
-                    this.currentBaseRotation = (Math.round(angleDeg / 90) * 90 + 360) % 360;
+                    this.currentBaseRotation = snapToAngle(delta.angle());
 
                     // Holding alt inverts the placement
                     if (this.root.keyMapper.getBinding(KEYMAPPINGS.placementModifiers.placeInverse).pressed) {
-                        this.currentBaseRotation = (180 + this.currentBaseRotation) % 360;
+                        this.currentBaseRotation =
+                            clockwiseAngleMap[clockwiseAngleMap[this.currentBaseRotation]];
                     }
                 }
 

--- a/src/js/game/meta_building.js
+++ b/src/js/game/meta_building.js
@@ -55,9 +55,9 @@ export class MetaBuilding {
     }
 
     /**
-     * Can return a special interlaved 9 elements overlay matrix for rendering
-     * @param {number} rotation
-     * @param {number} rotationVariant
+     * Can return a special interleved 9 elements overlay matrix for rendering
+     * @param {Angle} rotation
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      * @param {Entity} entity
      * @returns {Array<number>|null}
@@ -192,9 +192,9 @@ export class MetaBuilding {
      * @param {object} param0
      * @param {GameRoot} param0.root
      * @param {Vector} param0.origin Origin tile
-     * @param {number=} param0.rotation Rotation
-     * @param {number} param0.originalRotation Original Rotation
-     * @param {number} param0.rotationVariant Rotation variant
+     * @param {Angle=} param0.rotation Rotation
+     * @param {Angle} param0.originalRotation Original Rotation
+     * @param {RotationVariant} param0.rotationVariant Rotation variant
      * @param {string} param0.variant
      */
     createEntity({ root, origin, rotation, originalRotation, rotationVariant, variant }) {
@@ -216,7 +216,7 @@ export class MetaBuilding {
 
     /**
      * Returns the sprite for a given variant
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      * @returns {AtlasSprite}
      */
@@ -234,10 +234,10 @@ export class MetaBuilding {
      * @param {object} param0
      * @param {GameRoot} param0.root
      * @param {Vector} param0.tile
-     * @param {number} param0.rotation
+     * @param {Angle} param0.rotation
      * @param {string} param0.variant
      * @param {Layer} param0.layer
-     * @return {{ rotation: number, rotationVariant: number, connectedEntities?: Array<Entity> }}
+     * @return {{ rotation: Angle, rotationVariant: RotationVariant, connectedEntities?: Array<Entity> }}
      */
     computeOptimalDirectionAndRotationVariantAtTile({ root, tile, rotation, variant, layer }) {
         if (!this.getIsRotateable(variant)) {
@@ -255,7 +255,7 @@ export class MetaBuilding {
     /**
      * Should update the entity to match the given variants
      * @param {Entity} entity
-     * @param {number} rotationVariant
+     * @param {RotationVariant} rotationVariant
      * @param {string} variant
      */
     updateVariants(entity, rotationVariant, variant) {}

--- a/src/js/game/systems/belt_underlays.js
+++ b/src/js/game/systems/belt_underlays.js
@@ -1,7 +1,7 @@
 import { globalConfig } from "../../core/config";
 import { drawRotatedSprite } from "../../core/draw_utils";
 import { Loader } from "../../core/loader";
-import { enumDirectionToAngle } from "../../core/vector";
+import { directionAngleMap } from "../../core/vector";
 import { BeltUnderlaysComponent } from "../components/belt_underlays";
 import { GameSystemWithFilter } from "../game_system_with_filter";
 import { BELT_ANIM_COUNT } from "./belt";
@@ -62,7 +62,7 @@ export class BeltUnderlaysSystem extends GameSystemWithFilter {
                     continue;
                 }
 
-                const angle = enumDirectionToAngle[staticComp.localDirectionToWorld(direction)];
+                const angle = directionAngleMap[staticComp.localDirectionToWorld(direction)];
 
                 // SYNC with systems/belt.js:drawSingleEntity!
                 const animationIndex = Math.floor(

--- a/src/js/game/systems/item_acceptor.js
+++ b/src/js/game/systems/item_acceptor.js
@@ -1,7 +1,7 @@
 import { globalConfig } from "../../core/config";
 import { DrawParameters } from "../../core/draw_parameters";
 import { fastArrayDelete } from "../../core/utils";
-import { enumDirectionToVector } from "../../core/vector";
+import { directionVectorMap } from "../../core/vector";
 import { ItemAcceptorComponent } from "../components/item_acceptor";
 import { GameSystemWithFilter } from "../game_system_with_filter";
 import { MapChunkView } from "../map_chunk_view";
@@ -64,7 +64,7 @@ export class ItemAcceptorSystem extends GameSystemWithFilter {
                     continue;
                 }
 
-                const fadeOutDirection = enumDirectionToVector[staticComp.localDirectionToWorld(direction)];
+                const fadeOutDirection = directionVectorMap[staticComp.localDirectionToWorld(direction)];
                 const finalTile = realSlotPos.subScalars(
                     fadeOutDirection.x * (animProgress / 2 - 0.5),
                     fadeOutDirection.y * (animProgress / 2 - 0.5)

--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -2,7 +2,7 @@ import { globalConfig } from "../../core/config";
 import { DrawParameters } from "../../core/draw_parameters";
 import { createLogger } from "../../core/logging";
 import { Rectangle } from "../../core/rectangle";
-import { enumDirection, enumDirectionToVector, Vector } from "../../core/vector";
+import { directionVectorMap } from "../../core/vector";
 import { BaseItem } from "../base_item";
 import { ItemEjectorComponent } from "../components/item_ejector";
 import { Entity } from "../entity";
@@ -132,7 +132,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
             // Figure out where and into which direction we eject items
             const ejectSlotWsTile = staticComp.localTileToWorld(ejectorSlot.pos);
             const ejectSlotWsDirection = staticComp.localDirectionToWorld(ejectorSlot.direction);
-            const ejectSlotWsDirectionVector = enumDirectionToVector[ejectSlotWsDirection];
+            const ejectSlotWsDirectionVector = directionVectorMap[ejectSlotWsDirection];
             const ejectSlotTargetWsTile = ejectSlotWsTile.add(ejectSlotWsDirectionVector);
 
             // Try to find the given acceptor component to take the item
@@ -150,7 +150,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
 
                 // Check for belts (special case)
                 if (targetBeltComp) {
-                    const beltAcceptingDirection = targetStaticComp.localDirectionToWorld(enumDirection.top);
+                    const beltAcceptingDirection = targetStaticComp.localDirectionToWorld("top");
                     if (ejectSlotWsDirection === beltAcceptingDirection) {
                         ejectorSlot.cachedTargetEntity = targetEntity;
                         ejectorSlot.cachedBeltPath = targetBeltComp.assignedPath;
@@ -368,7 +368,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                 }
 
                 const realDirection = staticComp.localDirectionToWorld(slot.direction);
-                const realDirectionVector = enumDirectionToVector[realDirection];
+                const realDirectionVector = directionVectorMap[realDirection];
 
                 const tileX = realPosition.x + 0.5 + realDirectionVector.x * 0.5 * slot.progress;
                 const tileY = realPosition.y + 0.5 + realDirectionVector.y * 0.5 * slot.progress;

--- a/src/js/game/systems/miner.js
+++ b/src/js/game/systems/miner.js
@@ -1,6 +1,6 @@
 import { globalConfig } from "../../core/config";
 import { DrawParameters } from "../../core/draw_parameters";
-import { enumDirectionToVector } from "../../core/vector";
+import { directionVectorMap } from "../../core/vector";
 import { BaseItem } from "../base_item";
 import { MinerComponent } from "../components/miner";
 import { Entity } from "../entity";
@@ -73,7 +73,7 @@ export class MinerSystem extends GameSystemWithFilter {
             const ejectingPos = staticComp.localTileToWorld(ejectingSlot.pos);
             const ejectingDirection = staticComp.localDirectionToWorld(ejectingSlot.direction);
 
-            const targetTile = ejectingPos.add(enumDirectionToVector[ejectingDirection]);
+            const targetTile = ejectingPos.add(directionVectorMap[ejectingDirection]);
             const targetContents = this.root.map.getTileContent(targetTile, "regular");
 
             // Check if we are connected to another miner and thus do not eject directly

--- a/src/js/game/systems/underground_belt.js
+++ b/src/js/game/systems/underground_belt.js
@@ -3,11 +3,10 @@ import { Loader } from "../../core/loader";
 import { createLogger } from "../../core/logging";
 import { Rectangle } from "../../core/rectangle";
 import {
-    enumAngleToDirection,
-    enumDirection,
-    enumDirectionToAngle,
-    enumDirectionToVector,
-    enumInvertedDirections,
+    angleDirectionMap,
+    directionAngleMap,
+    directionVectorMap,
+    inverseDirectionMap,
 } from "../../core/vector";
 import { enumUndergroundBeltMode, UndergroundBeltComponent } from "../components/underground_belt";
 import { Entity } from "../entity";
@@ -81,9 +80,9 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
             const staticComp = entity.components.StaticMapEntity;
             const tile = staticComp.origin;
 
-            const direction = enumAngleToDirection[staticComp.rotation];
-            const inverseDirection = enumInvertedDirections[direction];
-            const offset = enumDirectionToVector[inverseDirection];
+            const direction = angleDirectionMap[staticComp.rotation];
+            const inverseDirection = inverseDirectionMap[direction];
+            const offset = directionVectorMap[inverseDirection];
 
             let currentPos = tile.copy();
 
@@ -106,7 +105,7 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
                     contentsUndergroundComp &&
                     contentsUndergroundComp.tier === undergroundComp.tier &&
                     contentsUndergroundComp.mode === enumUndergroundBeltMode.sender &&
-                    enumAngleToDirection[contentsStaticComp.rotation] === direction
+                    angleDirectionMap[contentsStaticComp.rotation] === direction
                 ) {
                     matchingEntrance = {
                         entity: contents,
@@ -143,8 +142,8 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
 
                 // It's a belt
                 if (
-                    contentsBeltComp.direction !== enumDirection.top ||
-                    enumAngleToDirection[contentsStaticComp.rotation] !== direction
+                    contentsBeltComp.direction !== "top" ||
+                    angleDirectionMap[contentsStaticComp.rotation] !== direction
                 ) {
                     allBeltsMatch = false;
                     break;
@@ -207,8 +206,8 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
                 const staticAfter = entityAfter.components.StaticMapEntity;
 
                 if (
-                    enumAngleToDirection[staticBefore.rotation] !== direction ||
-                    enumAngleToDirection[staticAfter.rotation] !== direction
+                    angleDirectionMap[staticBefore.rotation] !== direction ||
+                    angleDirectionMap[staticAfter.rotation] !== direction
                 ) {
                     // Wrong rotation
                     continue;
@@ -284,9 +283,9 @@ export class UndergroundBeltSystem extends GameSystemWithFilter {
     findRecieverForSender(entity) {
         const staticComp = entity.components.StaticMapEntity;
         const undergroundComp = entity.components.UndergroundBelt;
-        const searchDirection = staticComp.localDirectionToWorld(enumDirection.top);
-        const searchVector = enumDirectionToVector[searchDirection];
-        const targetRotation = enumDirectionToAngle[searchDirection];
+        const searchDirection = staticComp.localDirectionToWorld("top");
+        const searchVector = directionVectorMap[searchDirection];
+        const targetRotation = directionAngleMap[searchDirection];
         let currentTile = staticComp.origin;
 
         // Search in the direction of the tunnel

--- a/src/js/game/systems/wire.js
+++ b/src/js/game/systems/wire.js
@@ -5,13 +5,7 @@ import { createLogger } from "../../core/logging";
 import { Rectangle } from "../../core/rectangle";
 import { StaleAreaDetector } from "../../core/stale_area_detector";
 import { fastArrayDeleteValueIfContained } from "../../core/utils";
-import {
-    arrayAllDirections,
-    enumDirection,
-    enumDirectionToVector,
-    enumInvertedDirections,
-    Vector,
-} from "../../core/vector";
+import { directions, directionVectorMap, inverseDirectionMap, Vector } from "../../core/vector";
 import { BaseItem } from "../base_item";
 import { BooleanItem } from "../items/boolean_item";
 import { arrayWireRotationVariantToType, MetaWireBuilding } from "../buildings/wire";
@@ -248,7 +242,7 @@ export class WireSystem extends GameSystemWithFilter {
                     wireComp.linkedNetwork = currentNetwork;
                     currentNetwork.wires.push(nextEntity);
 
-                    newSearchDirections = arrayAllDirections;
+                    newSearchDirections = directions;
                     newSearchTile = nextEntity.components.StaticMapEntity.origin;
                 }
             }
@@ -345,7 +339,7 @@ export class WireSystem extends GameSystemWithFilter {
     /**
      * Finds surrounding entities which are not yet assigned to a network
      * @param {Vector} initialTile
-     * @param {Array<enumDirection>} directions
+     * @param {Array<Direction>} directions
      * @param {WireNetwork} network
      * @returns {Array<any>}
      */
@@ -358,7 +352,7 @@ export class WireSystem extends GameSystemWithFilter {
         // Go over all directions we should search for
         for (let i = 0; i < directions.length; ++i) {
             const direction = directions[i];
-            const offset = enumDirectionToVector[direction];
+            const offset = directionVectorMap[direction];
             const initialSearchTile = initialTile.add(offset);
 
             // Store which tunnels we already visited to avoid infinite loops
@@ -410,7 +404,7 @@ export class WireSystem extends GameSystemWithFilter {
 
                         // Check if the direction (inverted) matches
                         const pinDirection = staticComp.localDirectionToWorld(slot.direction);
-                        if (pinDirection !== enumInvertedDirections[direction]) {
+                        if (pinDirection !== inverseDirectionMap[direction]) {
                             continue;
                         }
 
@@ -438,8 +432,8 @@ export class WireSystem extends GameSystemWithFilter {
                     if (
                         !tunnelComp.multipleDirections &&
                         !(
-                            direction === staticComp.localDirectionToWorld(enumDirection.top) ||
-                            direction === staticComp.localDirectionToWorld(enumDirection.bottom)
+                            direction === staticComp.localDirectionToWorld("top") ||
+                            direction === staticComp.localDirectionToWorld("bottom")
                         )
                     ) {
                         // It's a coating, and it doesn't connect here

--- a/src/js/game/systems/wired_pins.js
+++ b/src/js/game/systems/wired_pins.js
@@ -3,7 +3,7 @@ import { DrawParameters } from "../../core/draw_parameters";
 import { drawRotatedSprite } from "../../core/draw_utils";
 import { Loader } from "../../core/loader";
 import { STOP_PROPAGATION } from "../../core/signal";
-import { enumDirectionToAngle, Vector } from "../../core/vector";
+import { directionAngleMap, Vector } from "../../core/vector";
 import { enumPinSlotType, WiredPinsComponent } from "../components/wired_pins";
 import { Entity } from "../entity";
 import { GameSystemWithFilter } from "../game_system_with_filter";
@@ -181,9 +181,7 @@ export class WiredPinsSystem extends GameSystemWithFilter {
                     continue;
                 }
 
-                const effectiveRotation = Math.radians(
-                    staticComp.rotation + enumDirectionToAngle[slot.direction]
-                );
+                const angle = directionAngleMap[staticComp.localDirectionToWorld(slot.direction)];
 
                 if (staticComp.getMetaBuilding().getRenderPins()) {
                     drawRotatedSprite({
@@ -191,7 +189,7 @@ export class WiredPinsSystem extends GameSystemWithFilter {
                         sprite: this.pinSprites[slot.type],
                         x: worldPos.x,
                         y: worldPos.y,
-                        angle: effectiveRotation,
+                        angle: Math.radians(angle),
                         size: globalConfig.tileSize + 2,
                         offsetX: 0,
                         offsetY: 0,
@@ -201,7 +199,7 @@ export class WiredPinsSystem extends GameSystemWithFilter {
                 // Draw contained item to visualize whats emitted
                 const value = slot.value;
                 if (value) {
-                    const offset = new Vector(0, -9).rotated(effectiveRotation);
+                    const offset = new Vector(0, -9).rotate(angle);
                     value.drawItemCenteredClipped(
                         worldPos.x + offset.x,
                         worldPos.y + offset.y,
@@ -212,7 +210,7 @@ export class WiredPinsSystem extends GameSystemWithFilter {
 
                 // Debug view
                 if (G_IS_DEV && globalConfig.debug.renderWireNetworkInfos) {
-                    const offset = new Vector(0, -10).rotated(effectiveRotation);
+                    const offset = new Vector(0, -10).rotate(angle);
                     const network = slot.linkedNetwork;
                     parameters.context.fillStyle = "blue";
                     parameters.context.font = "5px Tahoma";

--- a/src/js/globals.d.ts
+++ b/src/js/globals.d.ts
@@ -193,8 +193,11 @@ declare interface TypedSignal<T extends Array<any>> {
     removeAll();
 }
 
-declare type Layer = "regular" | "wires";
+declare type Angle = 0 | 90 | 180 | 270;
+declare type Direction = "top" | "right" | "bottom" | "left";
 declare type ItemType = "shape" | "color" | "boolean";
+declare type Layer = "regular" | "wires";
+declare type RotationVariant = 0 | 1 | 2 | 3;
 
 declare module "worker-loader?inline=true&fallback=false!*" {
     class WebpackWorker extends Worker {

--- a/src/js/savegame/serialization_data_types.js
+++ b/src/js/savegame/serialization_data_types.js
@@ -484,7 +484,7 @@ export class TypeEnum extends BaseDataType {
     }
 
     verifySerializedValue(value) {
-        if (this.availableValues.indexOf(value) < 0) {
+        if (!this.availableValues.includes(value)) {
             return "Unknown enum value: " + value;
         }
     }


### PR DESCRIPTION
This also introduces `Angle` which is `0 | 90 | 180 | 270` since everything in the game uses right angles.

I ran into a bug with `inverseAngleMap` where it only works if the vertical directions are not inverted. I'd love some help tracking down how to fix that. I ended up using `clockwiseAngleMap[clockwiseAngleMap[rotation]]` in places that functioned correctly and left the `inverseAngleMap` usage where that behavior is required.

Earlier you said you didn't like this change, but I'd like to hear what you don't like about it.
