### PR TITLE
Releasing SHIFT no longer cancels the belt planner

### DIFF
--- a/src/js/changelog.js
+++ b/src/js/changelog.js
@@ -21,6 +21,7 @@ export const CHANGELOG = [
             "Fix tunnels entrances connecting to exits sometimes when they shouldn't",
             "The initial belt planner direction is now based on the cursor movement (by MizardX)",
             "Fix preferred variant not getting saved when clicking on the hud (by Danacus)",
+            "Releasing SHIFT no longer cancels the belt planner (by bcmpinc)",
         ],
     },
     {


### PR DESCRIPTION
This (sort of) implements #584 by only needing to hold shift while starting to use the belt planner. To cancel the belt planner, use right-click. It is implemented by setting `this.currentDirectionLockDragging` while the player is dragging in direction lock/planning mode.

As this causes SHIFT and right click to be more likely to be used together, it would make bug #594 more noticeable.

In `abortDragging()` I changed `this.currentlyDragging = true;` to `this.currentlyDragging = false;`, as I believed this was a programming error. Please check.