### PR TITLE
Show that chainable miners can connect to eachother during placement

### DIFF
--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -454,6 +454,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
         const ejectorComp = this.fakeEntity.components.ItemEjector;
         const staticComp = this.fakeEntity.components.StaticMapEntity;
         const beltComp = this.fakeEntity.components.Belt;
+        const minerComp = this.fakeEntity.components.Miner;
 
         const goodArrowSprite = Loader.getSprite("sprites/misc/slot_good_arrow.png");
         const badArrowSprite = Loader.getSprite("sprites/misc/slot_bad_arrow.png");
@@ -571,6 +572,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                 const destEntity = destEntities[i];
                 const destAcceptor = destEntity.components.ItemAcceptor;
                 const destStaticComp = destEntity.components.StaticMapEntity;
+                const destMiner = destEntity.components.Miner;
 
                 const destLocalTile = destStaticComp.worldToLocalTile(ejectorSlotWsTile);
                 const destLocalDir = destStaticComp.worldDirectionToLocal(ejectorSlotWsDirection);
@@ -579,6 +581,9 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                     isConnected = true;
                 } else if (destEntity.components.Belt && destLocalDir === enumDirection.top) {
                     // Connected to a belt
+                    isConnected = true;
+                } else if (minerComp && minerComp.chainable && destMiner && destMiner.chainable) {
+                    // Chainable miners connected to eachother
                     isConnected = true;
                 } else {
                     // This one is blocked


### PR DESCRIPTION
Removes the red X when placing a chainable miner feeding into another chainable miner, and instead shows it as a green arrow.

Screenshot showing placing a chainable miner before this PR (left) and after this PR (right):
![chainable-before](https://user-images.githubusercontent.com/2389051/91701709-8626ce80-eb2c-11ea-83bc-da5c9cdb07c1.png) ![chainable-after](https://user-images.githubusercontent.com/2389051/91701730-8de67300-eb2c-11ea-8d31-098b62cc2ce2.png)

Still correctly shows that a chainable miner can't connect to a regular miner:
![chainable-unchainable](https://user-images.githubusercontent.com/2389051/91701742-950d8100-eb2c-11ea-9415-516ab36952af.png)

