### PR TITLE
Add a setting to disable picking the miner when on a resource patch

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -327,7 +327,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             const tileBelow = this.root.map.getLowerLayerContentXY(tile.x, tile.y);
 
             // Check if there's a shape or color item below, if so select the miner
-            if (tileBelow) {
+            if (tileBelow && this.root.app.settings.getAllSettings().pickMinerOnPatch) {
                 this.currentMetaBuilding.set(gMetaBuildingRegistry.findByClass(MetaMinerBuilding));
 
                 // Select chained miner if available, since thats always desired once unlocked

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -277,6 +277,7 @@ export const allApplicationSettings = [
     new BoolSetting("disableCutDeleteWarnings", enumCategories.advanced, (app, value) => {}),
     new BoolSetting("rotationByBuilding", enumCategories.advanced, (app, value) => {}),
     new BoolSetting("displayChunkBorders", enumCategories.advanced, (app, value) => {}),
+    new BoolSetting("pickMinerOnPatch", enumCategories.advanced, (app, value) => {}),
 
     new EnumSetting("refreshRate", {
         options: refreshRateOptions,
@@ -323,6 +324,7 @@ class SettingsStorage {
         this.rotationByBuilding = true;
         this.clearCursorOnDeleteWhilePlacing = true;
         this.displayChunkBorders = false;
+        this.pickMinerOnPatch = true;
 
         this.enableColorBlindHelper = false;
 
@@ -529,7 +531,7 @@ export class ApplicationSettings extends ReadWriteProxy {
     }
 
     getCurrentVersion() {
-        return 24;
+        return 25;
     }
 
     /** @param {{settings: SettingsStorage, version: number}} data */
@@ -636,7 +638,11 @@ export class ApplicationSettings extends ReadWriteProxy {
             data.settings.musicVolume = 1.0;
             data.settings.soundVolume = 1.0;
             data.settings.refreshRate = "60";
-            data.version = 24;
+        }
+
+        if(data.version < 25) {
+            data.settings.pickMinerOnPatch = true;
+            data.version = 25;
         }
 
         return ExplainedResult.good();

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -885,6 +885,11 @@ settings:
             description: >-
                 The game is divided into chunks of 16x16 tiles, if this setting is enabled the borders of each chunk are displayed.
 
+        pickMinerOnPatch:
+            title: Pick miner on resource patch
+            description: >-
+                Enabled by default, selects the miner if you use the pipette when hovering a resource patch.
+
 keybindings:
     title: Keybindings
     hint: >-


### PR DESCRIPTION
I found the automatic miner picker when using the pipette on a resource patch annoying but I can't disable it. I totally see why it can be nice to have but making it a setting doesn't take much.