### PR TITLE
Another small French translation fix

### DIFF
--- a/translations/base-fr.yaml
+++ b/translations/base-fr.yaml
@@ -645,7 +645,7 @@ settings:
         dev: Développement
         staging: Test
         prod: Production
-    buildDate: Créé le <at-date>
+    buildDate: Créé <at-date>
 
     labels:
         uiScale:


### PR DESCRIPTION
"Créé le" must be followed by an absolute date, but this is always interpolated with a relative date, e.g. "il y a 42 jours", so the article is redundant.

I've had a look at all other French translations containing variables and found no other problems.