### PR TITLE
Fix build errors

### DIFF
--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -191,7 +191,7 @@ dialogs:
     confirmSavegameDelete:
         title: Confirm deletion
         text: >-
-            Are you sure you want to delete the following game?<br><br>            
+            Are you sure you want to delete the following game?<br><br>
             '<savegameName>' at level <savegameLevel><br><br>
             This can not be undone!
 


### PR DESCRIPTION
* YAML lint: Remove trailing spaces introduced in 7d6af359a192bc6aa27dcaaa366bd58c45266a89
* ~~ESLint: Buffer stats now contain  `backlogKeys` and `backlogSize` instead of `backlog`, but the logger still tries to log `backlog`. Lint fails and it logs "undefined". Logging both of the new stats instead.~~ Never mind, you did that in 1cd52f6dbdc94a28684576296e3c3091d6e75b57