### PR TITLE
Fix camera pan

### DIFF
--- a/src/js/application.js
+++ b/src/js/application.js
@@ -231,7 +231,15 @@ export class Application {
      * @param {MouseEvent} event
      */
     handleMousemove(event) {
-        this.mousePosition = new Vector(event.clientX, event.clientY);
+        let x = event.clientX;
+        let y = event.clientY;
+
+        if (event.type === "mouseout" || event.type === "mouseleave") {
+            x = -1;
+            y = -1;
+        }
+
+        this.mousePosition = new Vector(x, y);
     }
 
     /**

--- a/src/js/application.js
+++ b/src/js/application.js
@@ -231,15 +231,7 @@ export class Application {
      * @param {MouseEvent} event
      */
     handleMousemove(event) {
-        let x = event.clientX;
-        let y = event.clientY;
-
-        if (event.type === "mouseout" || event.type === "mouseleave") {
-            x = -1;
-            y = -1;
-        }
-
-        this.mousePosition = new Vector(x, y);
+        this.mousePosition = new Vector(event.clientX, event.clientY);
     }
 
     /**

--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -862,7 +862,11 @@ export class Camera extends BasicSerializableObject {
      * @param {number} dt
      */
     internalUpdateMousePanning(now, dt) {
-        if (!this.root.app.settings.getAllSettings().enableMousePan || !this.root.app.focused) {
+        if (!this.root.app.focused) {
+            return;
+        }
+
+        if (!this.root.app.settings.getAllSettings().enableMousePan) {
             // Not enabled
             return;
         }

--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -862,7 +862,7 @@ export class Camera extends BasicSerializableObject {
      * @param {number} dt
      */
     internalUpdateMousePanning(now, dt) {
-        if (!this.root.app.settings.getAllSettings().enableMousePan) {
+        if (!this.root.app.settings.getAllSettings().enableMousePan || !this.root.app.focused) {
             // Not enabled
             return;
         }
@@ -882,10 +882,10 @@ export class Camera extends BasicSerializableObject {
         }
 
         if (
-            mousePos.x < 0 ||
-            mousePos.y < 0 ||
-            mousePos.x > this.root.gameWidth ||
-            mousePos.y > this.root.gameHeight
+            mousePos.x <= 0 ||
+            mousePos.y <= 0 ||
+            mousePos.x >= this.root.gameWidth ||
+            mousePos.y >= this.root.gameHeight
         ) {
             // Out of screen
             return;

--- a/src/js/game/hud/parts/shape_viewer.js
+++ b/src/js/game/hud/parts/shape_viewer.js
@@ -48,6 +48,10 @@ export class HUDShapeViewer extends BaseHUDPart {
         this.close();
     }
 
+    isBlockingOverlay() {
+        return this.visible;
+    }
+
     /**
      * Called when the copying of a key was requested
      */


### PR DESCRIPTION
You could still move when the shape viewer was opened
You were also able to leave the browser viewport and still have the camera pan