### PR TITLE
FIX screenshot. Use same scale for Atlas==zoomLvl

### DIFF
--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -87,7 +87,7 @@ export class HUDScreenshotExporter extends BaseHUDPart {
         const parameters = new DrawParameters({
             context,
             visibleRect,
-            desiredAtlasScale: "1",
+            desiredAtlasScale: chunkScale,
             root: this.root,
             zoomLevel: chunkScale,
         });


### PR DESCRIPTION
Scale 1 is never gonnna be saved as screenshot. for most image exports 0.5 is used. chunkScale is determining that.