### PR TITLE
Make zoom in and zoom out equal

### DIFF
--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -505,7 +505,7 @@ export class Camera extends BasicSerializableObject {
         const scale = 1 + 0.15 * this.root.app.settings.getScrollWheelSensitivity();
         assert(Number.isFinite(delta), "Got invalid delta in mouse wheel event: " + event.deltaY);
         assert(Number.isFinite(this.zoomLevel), "Got invalid zoom level *before* wheel: " + this.zoomLevel);
-        this.zoomLevel *= (event.deltaY < 0) ? scale : 1/scale;
+        this.zoomLevel *= event.deltaY < 0 ? scale : 1 / scale;
         assert(Number.isFinite(this.zoomLevel), "Got invalid zoom level *after* wheel: " + this.zoomLevel);
 
         this.clampZoomLevel();

--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -353,7 +353,7 @@ export class Camera extends BasicSerializableObject {
             .add(() => (this.desiredZoom = this.zoomLevel * 1.2));
         mapper
             .getBinding(KEYMAPPINGS.navigation.mapZoomOut)
-            .add(() => (this.desiredZoom = this.zoomLevel * 0.8));
+            .add(() => (this.desiredZoom = this.zoomLevel / 1.2));
 
         mapper.getBinding(KEYMAPPINGS.navigation.centerMap).add(() => this.centerOnMap());
     }

--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -939,6 +939,7 @@ export class Camera extends BasicSerializableObject {
                 this.zoomLevel = this.zoomLevel * fade + this.desiredZoom * (1 - fade);
                 assert(Number.isFinite(this.zoomLevel), "Zoom level is NaN after fade: " + this.zoomLevel);
             } else {
+                this.zoomLevel = this.desiredZoom;
                 this.desiredZoom = null;
             }
         }

--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -502,10 +502,10 @@ export class Camera extends BasicSerializableObject {
         }
         const prevZoom = this.zoomLevel;
 
-        const delta = Math.sign(event.deltaY) * -0.15 * this.root.app.settings.getScrollWheelSensitivity();
+        const scale = 1 + 0.15 * this.root.app.settings.getScrollWheelSensitivity();
         assert(Number.isFinite(delta), "Got invalid delta in mouse wheel event: " + event.deltaY);
         assert(Number.isFinite(this.zoomLevel), "Got invalid zoom level *before* wheel: " + this.zoomLevel);
-        this.zoomLevel *= 1 + delta;
+        this.zoomLevel *= (event.deltaY < 0) ? scale : 1/scale;
         assert(Number.isFinite(this.zoomLevel), "Got invalid zoom level *after* wheel: " + this.zoomLevel);
 
         this.clampZoomLevel();


### PR DESCRIPTION
Makes zooming out zoom an amount equal to zooming in. This changes both mouse zoom and +/- zoom. All zoom that uses a smooth transition is now exact. (Rapidly zooming in and out will still not guarantee equal zoom, since the transitions are canceled.)

![zoomfix2](https://user-images.githubusercontent.com/69981203/94494956-156be400-01b6-11eb-9ce6-d4e9a1285037.gif)

Also tested through an unorthodox method