### PR TITLE
Fix crash on camera zoom change (and add another one)

### DIFF
--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -503,7 +503,7 @@ export class Camera extends BasicSerializableObject {
         const prevZoom = this.zoomLevel;
 
         const scale = 1 + 0.15 * this.root.app.settings.getScrollWheelSensitivity();
-        assert(Number.isFinite(delta), "Got invalid delta in mouse wheel event: " + event.deltaY);
+        assert(Number.isFinite(scale), "Got invalid scale in mouse wheel event: " + event.deltaY);
         assert(Number.isFinite(this.zoomLevel), "Got invalid zoom level *before* wheel: " + this.zoomLevel);
         this.zoomLevel *= event.deltaY < 0 ? scale : 1 / scale;
         assert(Number.isFinite(this.zoomLevel), "Got invalid zoom level *after* wheel: " + this.zoomLevel);


### PR DESCRIPTION
Changed references to `delta` with `scale`, not sure whether that's all, but it's a local variable.﻿
It looks like zooming works properly.
