### PR TITLE
Dockerfile use for Node12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,10 @@ RUN apt-get update \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/* 
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
-    git-lfs
-
 FROM base as shape_base
 
 WORKDIR /shapez.io
 
-RUN git-lfs pull
 RUN yarn
 
 WORKDIR /shapez.io/gulp

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get dist-upgrade -y \
     && apt-get install -y --no-install-recommends \
-    git \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/* \
     && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ RUN apt-get update \
     && apt-get dist-upgrade -y \
     && apt-get install -y --no-install-recommends \
     ffmpeg \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash
+    && rm -rf /var/lib/apt/lists/* 
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -1077,3 +1077,6 @@ tips:
     - You have an infinite map, don't cramp your factory, expand!
     - Also try Factorio! It's my favourite game.
     - The quad cutter cuts clockwise starting from the top right!
+    - You can download your savegames in the main menu!
+    - This game has a lot of useful keybindings! Be sure to check out the settings page.
+    - This game has a lot of settings, be sure to check them out!


### PR DESCRIPTION
I've been using this dockerfile successfully to build and run Shapez.io without needing to install and maintain node.

Building is straight forward: "docker build -t shapezio ."

After building you and start and stop the image whenever you need to.

Running is just as straight forward: "docker run --name="shapezio" --rm -p 3005:3005 shapezio"

To stop the instance: "docker stop shapezio"

Due to --rm the instance should be deleted once stopped.


If you want to stop the messages about not being able to open the browser, you can edit line 155 of gulp/gulpfile.js, and add
"open: false," 
It shouldn't affect anything having it still there, but altering it may mess up future pull requests so I would suggest leaving it as is and just ignore the warning.

function serve({ standalone }) {
    browserSync.init({
        server: buildFolder,
        port: 3005,
        ghostMode: {
            clicks: false,
            scroll: false,
            location: false,
            forms: false,
        },
        logLevel: "info",
        logPrefix: "BS",
        online: false,
        **open: false,**
        xip: false,
        notify: false,
        reloadDebounce: 100,
        reloadOnRestart: true,
        watchEvents: ["add", "change"],
    });
