### PR TITLE
Don't try to launch git lfs from gulpfile.js

### DIFF
--- a/gulp/gulpfile.js
+++ b/gulp/gulpfile.js
@@ -8,23 +8,6 @@ const path = require("path");
 const deleteEmpty = require("delete-empty");
 const execSync = require("child_process").execSync;
 
-const lfsOutput = execSync("git lfs install", { encoding: "utf-8" });
-if (!lfsOutput.toLowerCase().includes("git lfs initialized")) {
-    console.error(`
-    Git LFS is not installed, unable to build.
-
-    To install Git LFS on Linux:
-      - Arch:
-        sudo pacman -S git-lfs
-      - Debian/Ubuntu:
-        sudo apt install git-lfs
-
-    For other systems, see:
-    https://github.com/git-lfs/git-lfs/wiki/Installation
-    `);
-    process.exit(1);
-}
-
 // Load other plugins dynamically
 const $ = require("gulp-load-plugins")({
     scope: ["devDependencies"],


### PR DESCRIPTION
Cloning repo is nearly impossible while having Git LFS hooks installed, and most
Linux distros also don't have Git LFS installed by default. When running Gulp with
Git LFS without hooks, they'll get installed, thus breaking checkouts again.

Made this PR from web interface because my clone is broken again... :slightly_frowning_face: 