### PR TITLE
Small improvements to French translation

### DIFF
--- a/translations/base-fr.yaml
+++ b/translations/base-fr.yaml
@@ -47,7 +47,7 @@ steamPage:
 global:
     loading: Chargement
     error: Erreur
-    thousandsDivider:  
+    thousandsDivider: " "
     decimalSeparator: ","
     suffix:
         thousands: k
@@ -98,7 +98,7 @@ mainMenu:
 dialogs:
     buttons:
         ok: OK
-        delete: Effacer
+        delete: Supprimer
         cancel: Annuler
         later: Plus tard
         restart: Relancer
@@ -176,15 +176,16 @@ dialogs:
             usines. En voici quelques-uns, n’hésitez pas à aller
             <strong>découvrir les raccourcis</strong> !<br><br> <code
             class="keybinding">CTRL</code> + glisser : Sélectionne une zone à
-            copier / effacer.<br> <code class="keybinding">MAJ</code> : Laissez
+            copier / supprimer.<br> <code class="keybinding">MAJ</code> : Laissez
             appuyé pour placer plusieurs fois le même bâtiment.<br> <code
             class="keybinding">ALT</code> : Inverse l’orientation des convoyeurs
             placés.<br>'
     createMarker:
         title: Nouvelle balise
         titleEdit: Modifier cette balise
-        desc: Give it a meaningful name, you can also include a <strong>short
-            key</strong> of a shape (Which you can generate <link>here</link>)
+        desc: Donnez-lui un nom. Vous pouvez aussi inclure <strong>le raccourci</strong>
+            d’une forme (que vous pouvez générer <a
+            href="https://viewer.shapez.io" target="_blank">ici</a>).
     editSignal:
         title: Définir le signal
         descItems: "Choisissez un objet prédéfini :"
@@ -282,7 +283,7 @@ ingame:
             - XVIII
             - XIX
             - XX
-        maximumLevel: NIVEAU MAXIMAL (Vitesse ×<currentMult>)
+        maximumLevel: NIVEAU MAX (Vitesse ×<currentMult>)
     statistics:
         title: Statistiques
         dataSources:
@@ -319,7 +320,7 @@ ingame:
         waypoints: Balise
         hub: Centre
         description: Cliquez sur une balise pour vous y rendre, clic-droit pour
-            l’effacer.<br><br> Appuyez sur <keybinding> pour créer une balise
+            la supprimer.<br><br> Appuyez sur <keybinding> pour créer une balise
             sur la vue actuelle, ou <strong>clic-droit</strong> pour en créer
             une sur l’endroit pointé.
         creationSuccessNotification: La balise a été créée.
@@ -596,12 +597,11 @@ buildings:
 storyRewards:
     reward_cutter_and_trash:
         title: Découpage de formes
-        desc: You just unlocked the <strong>cutter</strong>, which cuts shapes in half
-            from top to bottom <strong>regardless of its
-            orientation</strong>!<br><br>Be sure to get rid of the waste, or
-            otherwise <strong>it will clog and stall</strong> - For this purpose
-            I have given you the <strong>trash</strong>, which destroys
-            everything you put into it!
+        desc: Vous avez débloqué le <strong>découpeur</strong>. Il coupe des formes en
+            deux <strong>de haut en bas</strong> quelle que soit son
+            orientation !<br><br> Assurez-vous de vous débarrasser des déchets,
+            sinon <strong>gare au blocage</strong>. À cet effet, je mets à votre
+            disposition la poubelle, qui détruit tout ce que vous y mettez !
     reward_rotater:
         title: Rotation
         desc: Le <strong>pivoteur</strong> a été débloqué ! Il pivote les formes de 90
@@ -654,14 +654,12 @@ storyRewards:
             les deux variantes de tunnels !
     reward_merger:
         title: Fusionneur compact
-        desc: You have unlocked a <strong>merger</strong> variant of the
-            <strong>balancer</strong> - It accepts two inputs and merges them
-            into one belt!
+        desc: Vous avez débloqué une variante du <strong>répartiteur</strong>. Il
+            accepte deux entrées et les fusionne en un seul convoyeur !
     reward_splitter:
         title: Répartiteur compact
-        desc: You have unlocked a <strong>splitter</strong> variant of the
-            <strong>balancer</strong> - It accepts one input and splits them
-            into two!
+        desc: Vous avez débloqué une variante compacte du <strong>répartiteur</strong> —
+            Il accepte une seule entrée et la divise en deux sorties !
     reward_belt_reader:
         title: Lecteur de débit
         desc: Vous avez débloqué le <strong>lecteur de débit</strong> ! Il vous permet
@@ -735,14 +733,17 @@ storyRewards:
             <strong>transistor</strong> !"
     reward_virtual_processing:
         title: Traitement virtuel
-        desc: I just gave a whole bunch of new buildings which allow you to
-            <strong>simulate the processing of shapes</strong>!<br><br> You can
-            now simulate a cutter, rotater, stacker and more on the wires layer!
-            With this you now have three options to continue the game:<br><br> -
-            Build an <strong>automated machine</strong> to create any possible
-            shape requested by the HUB (I recommend to try it!).<br><br> - Build
-            something cool with wires.<br><br> - Continue to play
-            regulary.<br><br> Whatever you choose, remember to have fun!
+        desc: Je viens de vous donner tout un tas de nouveaux bâtiments qui vous
+            permettent de <strong>simuler le traitement des
+            formes</strong> !<br><br> Vous pouvez maintenant simuler un
+            découpeur, un pivoteur, un combineur et plus encore sur le calque de
+            câblage !<br><br> Avec ça, vous avez trois possibilités pour
+            continuer le jeu :<br><br> - Construire une <strong>machine
+            automatisée</strong> pour fabriquer n’importe quelle forme demandée
+            par le centre (je conseille d’essayer !).<br><br> - Construire
+            quelque chose de cool avec des câbles.<br><br> - Continuer à jouer
+            normalement.<br><br> Dans tous les cas, l’important c’est de
+            s’amuser !
     no_reward:
         title: Niveau suivant
         desc: "Ce niveau n’a pas de récompense mais le prochain, si !<br><br> PS : Ne
@@ -892,9 +893,9 @@ settings:
                 n’affichant que les ratios. Si désactivé, montre une description
                 et une image.
         disableCutDeleteWarnings:
-            title: Désactive les avertissements pour Couper / Effacer
+            title: Désactive les avertissements pour Couper / Supprimer
             description: Désactive la boîte de dialogue qui s’affiche lorsque vous vous
-                apprêtez à couper / effacer plus de 100 entités.
+                apprêtez à couper / supprimer plus de 100 entités.
         lowQualityMapResources:
             title: Ressources de la carte de plus basse qualité
             description: Simplifie le rendu des ressources sur la carte lorsqu’elle est
@@ -1082,7 +1083,7 @@ tips:
       Planifiez vos usines pour qu’elles soient réutilisables.
     - Parfois, vous pouvez trouver une forme nécessaire sur la carte sans la
       créer avec des combineurs.
-    - Les formes en moulin à vent complètes ne peuvent jamais apparaître
+    - Les formes en hélice complètes ne peuvent jamais apparaître
       naturellement.
     - Colorez vos formes avant de les découper pour une efficacité maximale.
     - Avec les modules, l’espace n’est qu’une perception ; une préoccupation


### PR DESCRIPTION
- restore missing translations
- rename "moulin" to "hélice"
- use "supprimer" rather than "effacer" when appropriate
- abbreviate "maximal" to fit in available space