### PR TITLE
"Fix" getStringForKeyCode returning incorrect strings

### DIFF
--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -262,7 +262,9 @@ export function getStringForKeyCode(code) {
             return "'";
     }
 
-    return 48 <= code && code <= 57 || 65 <= code && code <= 90 ? String.fromCharCode(code) : "[" + code + "]";
+    return (48 <= code && code <= 57) || (65 <= code && code <= 90)
+        ? String.fromCharCode(code)
+        : "[" + code + "]";
 }
 
 export class Keybinding {

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -262,7 +262,7 @@ export function getStringForKeyCode(code) {
             return "'";
     }
 
-    return "�";
+    return code >= 65 && code <= 90 ? String.fromCharCode(code) : "�";
 }
 
 export class Keybinding {

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -262,7 +262,7 @@ export function getStringForKeyCode(code) {
             return "'";
     }
 
-    return code >= 65 && code <= 90 ? String.fromCharCode(code) : "�";
+    return 48 <= code && code <= 57 || 65 <= code && code <= 90 ? String.fromCharCode(code) : "[" + code + "]";
 }
 
 export class Keybinding {

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -248,6 +248,8 @@ export function getStringForKeyCode(code) {
             return ",";
         case 189:
             return "-";
+        case 190:
+            return ".";
         case 191:
             return "/";
         case 219:
@@ -260,7 +262,7 @@ export function getStringForKeyCode(code) {
             return "'";
     }
 
-    return String.fromCharCode(code);
+    return "�";
 }
 
 export class Keybinding {


### PR DESCRIPTION
This adds the full stop/period `.` to the switch statement. This also modifies the function executed if the key code is not found so that it will return the key code surrounded by brackets if it does not correspond to a letter or a digit key. (For example, the grave accent <code>`</code> returns ``[192]``. Keys like <code>2</code> and <code>F</code> pass normally, but not the numpad keys.)

This is definitely not a great fix, but it should prevent keys not specified from displaying incorrectly. Maybe using <code>�</code> would be better?
![image](https://user-images.githubusercontent.com/69981203/94999562-b58f8780-057f-11eb-9154-35a1a36d5406.png)
(Fixes issue #751)
