### PR TITLE
Added 75, 144 and 165hz refresh rates

### DIFF
--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -123,7 +123,7 @@ export const autosaveIntervals = [
     },
 ];
 
-const refreshRateOptions = ["30", "60", "120", "180", "240"];
+const refreshRateOptions = ["30", "60", "75", "120", "144", "165", "180", "240"];
 
 if (G_IS_DEV) {
     refreshRateOptions.unshift("10");


### PR DESCRIPTION
These are pretty common refresh rates for most monitors, 75 being old
and 165 being somewhat new, but used reasonably often in higher-end
monitors.

I was using the 144 and when I went to the beta it was no longer there.