### PR TITLE
Prevent insta-crash when screenshotting larger bases

### DIFF
--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -87,7 +87,7 @@ export class HUDScreenshotExporter extends BaseHUDPart {
         const parameters = new DrawParameters({
             context,
             visibleRect,
-            desiredAtlasScale: chunkScale,
+            desiredAtlasScale: 0.25,
             root: this.root,
             zoomLevel: chunkScale,
         });


### PR DESCRIPTION
This prevents the game from trying to access an atlas link of nonexistent resolution. Whenever a base is larger than 128 chunks long or wide, the `chunkScale` value is set to below 0.25, the smallest atlas scale. This changes it so that the atlas scale used is always 0.25.

I really don't know how the atlas works that well, though I have tested this on my large base from the standalone version (producing an image of ~30.2 MB). The image (downscaled 4x on each axis) is below:
![basebigsmall](https://user-images.githubusercontent.com/69981203/95156168-7fa6fa80-075b-11eb-96b8-905cf64a2e83.png)