### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[{src, translations}/*]
+end_of_line = crlf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+charset = utf-8


### PR DESCRIPTION
Editorconfig file for defining how github displays files and set guidelines for supported editors.

VSCode has a Supported plugin [here](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig).
and [here](https://github.com/cirosantilli/test-editorconfig) is a example repo to see it working in action. (the 1024 space version doesn't work)