### PR TITLE
Fix non-uniform distribution for freeplay shape color palette

### DIFF
--- a/src/js/core/rng.js
+++ b/src/js/core/rng.js
@@ -108,17 +108,6 @@ export class RandomNumberGenerator {
         assert(max > min, "rng: max <= min");
         return Math.floor(this.next() * (max - min) + min);
     }
-    /**
-     * @param {number} min
-     * @param {number} max
-     * @returns {number} Integer in range [min, max]
-     */
-    nextIntRangeInclusive(min, max) {
-        assert(Number.isFinite(min), "Minimum is no integer");
-        assert(Number.isFinite(max), "Maximum is no integer");
-        assert(max > min, "rng: max <= min");
-        return Math.round(this.next() * (max - min) + min);
-    }
 
     /**
      * @param {number} min

--- a/src/js/game/hub_goals.js
+++ b/src/js/game/hub_goals.js
@@ -369,7 +369,7 @@ export class HubGoals extends BasicSerializableObject {
         if (allowUncolored) {
             universalColors.push(enumColors.uncolored);
         }
-        const index = rng.nextIntRangeInclusive(0, colorWheel.length - 3);
+        const index = rng.nextIntRange(0, colorWheel.length - 2);
         const pickedColors = colorWheel.slice(index, index + 3);
         pickedColors.push(rng.choice(universalColors));
         return pickedColors;


### PR DESCRIPTION
This fixes the issue mentioned in #747 by using the nextIntRange function instead of the nextIntRangeInclusive function.
The nextIntRangeInclusive function is also removed, since it gives the minimum and maximum integer half as much weight. It is not used elsewhere.

tl;dr does what i said in that other pr