### PR TITLE
Fixed spelling error

### DIFF
--- a/translations/base-sv.yaml
+++ b/translations/base-sv.yaml
@@ -637,7 +637,7 @@ storyRewards:
         title: Ritningar
         desc: Du kan nu <strong>kopiera och klistra in</strong> delar av din fabrik!
             Välj ett område (håll in CTRL, dra sedan med musen), och tryck 'C'
-            för att kopiera det. <br><br>Att klistra in är<strong>inte
+            för att kopiera det. <br><br>Att klistra in är <strong>inte
             gratis</strong>, du behöver producera
             <strong>ritningsformer</strong> för att ha råd med det! (De du just
             levererade).


### PR DESCRIPTION
I notices that a space was missing after "är" so I inserted it