### PR TITLE
Fix reader maximum displayed speed

### DIFF
--- a/src/js/game/systems/belt_reader.js
+++ b/src/js/game/systems/belt_reader.js
@@ -48,7 +48,7 @@ export class BeltReaderSystem extends GameSystemWithFilter {
                     throughput = 1 / (averageSpacing / averageSpacingNum);
                 }
 
-                readerComp.lastThroughput = Math.min(30, throughput);
+                readerComp.lastThroughput = Math.min(globalConfig.beltSpeedItemsPerSecond * 23.9, throughput);
             }
         }
     }


### PR DESCRIPTION
This sets the maximum reader value to the correct number. It will reflect changes in the belt's base speed but will not reflect changes in the maximum upgrade multiplier.