### PR TITLE
Fix stacking cache

### DIFF
--- a/src/js/game/shape_definition_manager.js
+++ b/src/js/game/shape_definition_manager.js
@@ -185,7 +185,7 @@ export class ShapeDefinitionManager extends BasicSerializableObject {
      * @returns {ShapeDefinition}
      */
     shapeActionStack(lowerDefinition, upperDefinition) {
-        const key = "stack:" + lowerDefinition.getHash() + ":" + upperDefinition.getHash();
+        const key = "stack:" + lowerDefinition.getHash() + "+" + upperDefinition.getHash();
         if (this.operationCache[key]) {
             return /** @type {ShapeDefinition} */ (this.operationCache[key]);
         }
@@ -202,7 +202,7 @@ export class ShapeDefinitionManager extends BasicSerializableObject {
      * @returns {ShapeDefinition}
      */
     shapeActionPaintWith(definition, color) {
-        const key = "paint:" + definition.getHash() + ":" + color;
+        const key = "paint:" + definition.getHash() + "+" + color;
         if (this.operationCache[key]) {
             return /** @type {ShapeDefinition} */ (this.operationCache[key]);
         }
@@ -219,7 +219,7 @@ export class ShapeDefinitionManager extends BasicSerializableObject {
      * @returns {ShapeDefinition}
      */
     shapeActionPaintWith4Colors(definition, colors) {
-        const key = "paint4:" + definition.getHash() + ":" + colors.join(",");
+        const key = "paint4:" + definition.getHash() + "+" + colors.join(",");
         if (this.operationCache[key]) {
             return /** @type {ShapeDefinition} */ (this.operationCache[key]);
         }


### PR DESCRIPTION
This changes the key used to cache the result of a stack such that it is no longer ambiguous, by separating the two shape keys with a `+` instead of a `:`. The keys for the other two-input buildings are also changed to match.
![image](https://user-images.githubusercontent.com/69981203/95627743-4ebc1380-0a42-11eb-8170-d048a0cb2ffb.png)
Fixes #806