### PR TITLE
Easier contributions

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,4 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get update \ 
+    && sudo apt install ffmpeg -yq

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,10 @@
+image: 
+  file: .gitpod.Dockerfile
+tasks:
+  - init: yarn && gp sync-done boot
+  - before: cd gulp
+    init: gp sync-await boot && yarn
+    command: yarn gulp 
+ports: 
+  - port: 3005
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Your goal is to produce shapes by cutting, rotating, merging and painting parts 
 
 **Notice**: This will produce a debug build with several debugging flags enabled. If you want to disable them, modify [`src/js/core/config.js`](src/js/core/config.js).
 
+## Build Online with one-click setup
+
+You can use [Gitpod](https://www.gitpod.io/) (an Online Open Source VS Code-like IDE which is free for Open Source) for working on issues and making PRs to this project. With a single click it will start a workspace and automatically:
+
+- clone the `shapez.io` repo.
+- install all of the dependencies.
+- start `gulp` in `gulp/` directory.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ## Helping translate
 
 Please checkout the [Translations readme](translations/).


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects.

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `shapez.io` repo.
- install all of the dependencies.
- start `gulp` in `gulp/` directory.

This way anyone interested in contributing can start straight away without any friction.

You can give it a try on my fork of the repo via the following link: 

https://gitpod.io/#https://github.com/nisarhassan12/shapez.io

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95644780-6b079100-0ad2-11eb-8e81-40512a32c921.png)

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95134600-9a3d9b80-077c-11eb-89ea-f9a90423e678.png)
