### PR TITLE
Make reward notification scrollable

### DIFF
--- a/src/css/ingame_hud/unlock_notification.scss
+++ b/src/css/ingame_hud/unlock_notification.scss
@@ -4,9 +4,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    display: flex;
-    justify-content: center;
-    align-items: center;
+    overflow: auto;
     pointer-events: all;
 
     & {
@@ -33,7 +31,6 @@
         display: flex;
         align-items: center;
         flex-direction: column;
-        max-height: 100vh;
 
         color: #fff;
         text-align: center;


### PR DESCRIPTION
Some level rewards have a long description. This can push the "Next level" button below the screen. The user is then stuck and can't proceed without relaunching the game.

![Level 20 in German overflows the screen, hiding the button](https://cdn.discordapp.com/attachments/706122201077645333/764459392321716244/screen.jpg)

This PR allows the user to scroll and reveal the button.