### PR TITLE
Format all upgrade tiers as Roman numerals

### DIFF
--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -714,7 +714,7 @@ export function startFileChoose(acceptedType = ".bin") {
     });
 }
 
-const MAX_ROMAN_NUMBER = 3999;
+const MAX_ROMAN_NUMBER = 49;
 const romanLiteralsCache = ["0"];
 
 /**

--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -714,29 +714,8 @@ export function startFileChoose(acceptedType = ".bin") {
     });
 }
 
-const romanLiterals = [
-    "0", // NULL
-    "I",
-    "II",
-    "III",
-    "IV",
-    "V",
-    "VI",
-    "VII",
-    "VIII",
-    "IX",
-    "X",
-    "XI",
-    "XII",
-    "XIII",
-    "XIV",
-    "XV",
-    "XVI",
-    "XVII",
-    "XVIII",
-    "XIX",
-    "XX",
-];
+const MAX_ROMAN_NUMBER = 3999;
+const romanLiteralsCache = ["0"];
 
 /**
  *
@@ -745,8 +724,52 @@ const romanLiterals = [
  */
 export function getRomanNumber(number) {
     number = Math.max(0, Math.round(number));
-    if (number < romanLiterals.length) {
-        return romanLiterals[number];
+    if (romanLiteralsCache[number]) {
+        return romanLiteralsCache[number];
     }
-    return String(number);
+
+    if (number > MAX_ROMAN_NUMBER) {
+        return String(number);
+    }
+
+    function formatDigit(digit, unit, quintuple, decuple) {
+        switch (digit) {
+            case 0:
+                return "";
+            case 1: // I
+                return unit;
+            case 2: // II
+                return unit + unit;
+            case 3: // III
+                return unit + unit + unit;
+            case 4: // IV
+                return unit + quintuple;
+            case 9: // IX
+                return unit + decuple;
+            default:
+                // V, VI, VII, VIII
+                return quintuple + formatDigit(digit - 5, unit, quintuple, decuple);
+        }
+    }
+
+    let thousands = Math.floor(number / 1000);
+    let thousandsPart = "";
+    while (thousands > 0) {
+        thousandsPart += "M";
+        thousands -= 1;
+    }
+
+    const hundreds = Math.floor((number % 1000) / 100);
+    const hundredsPart = formatDigit(hundreds, "C", "D", "M");
+
+    const tens = Math.floor((number % 100) / 10);
+    const tensPart = formatDigit(tens, "X", "L", "C");
+
+    const units = number % 10;
+    const unitsPart = formatDigit(units, "I", "V", "X");
+
+    const formatted = thousandsPart + hundredsPart + tensPart + unitsPart;
+
+    romanLiteralsCache[number] = formatted;
+    return formatted;
 }


### PR DESCRIPTION
Currently, upgrade tiers up to 20 are formatted as Roman numerals, but fall back to Arabic numerals from tier 21.

<img width="165" alt="Tier 20 is shown as Tier XX, but not tier 21" src="https://user-images.githubusercontent.com/5007648/95657984-c4de7a00-0b17-11eb-84dc-02afdca9588d.png">

This PR adds Roman-numeral formatting up to the limit of the standard system (3999), which covers all 1000 tiers.

![Tier 388 shown as Tier CCCLXXXVIII](https://user-images.githubusercontent.com/5007648/95658018-14bd4100-0b18-11eb-97c9-c314f1bd3af9.png)
