### PR TITLE
Fix button right click bug

### DIFF
--- a/src/js/game/hud/parts/layer_preview.js
+++ b/src/js/game/hud/parts/layer_preview.js
@@ -76,6 +76,12 @@ export class HUDLayerPreview extends BaseHUDPart {
                 const tileY = dy + startTileY;
 
                 const content = this.root.map.getLayerContentXY(tileX, tileY, "wires");
+                const contentRegular = this.root.map.getLayerContentXY(tileX, tileY, "regular");
+                if (contentRegular && content) {
+                    // We don't want to count something on the wires layer here if it is on the normal layer,
+                    // because then it will get rendered twice
+                    continue;
+                }
                 if (content) {
                     MapChunkView.drawSingleWiresOverviewTile({
                         context: this.context,

--- a/src/js/game/hud/parts/lever_toggle.js
+++ b/src/js/game/hud/parts/lever_toggle.js
@@ -21,9 +21,6 @@ export class HUDLeverToggle extends BaseHUDPart {
                 if (button === enumMouseButton.left) {
                     leverComp.toggled = !leverComp.toggled;
                     return STOP_PROPAGATION;
-                } else if (button === enumMouseButton.right) {
-                    this.root.logic.tryDeleteBuilding(contents);
-                    return STOP_PROPAGATION;
                 }
             }
         }

--- a/src/js/game/map_chunk.js
+++ b/src/js/game/map_chunk.js
@@ -372,10 +372,24 @@ export class MapChunk {
         assert(localY >= 0, "Local Y is < 0");
         assert(localX < globalConfig.mapChunkSize, "Local X is >= chunk size");
         assert(localY < globalConfig.mapChunkSize, "Local Y is >= chunk size");
+        const regularContents = this.contents[localX][localY] || null;
         if (layer === "regular") {
-            return this.contents[localX][localY] || null;
+            return regularContents;
         } else {
-            return this.wireContents[localX][localY] || null;
+            const wireContents = this.wireContents[localX][localY] || null;
+            // If there is a reader, lever, or display on the tile, we count it
+            // as a wires component and act as if it is on the wires layer.
+            const regularContentsIsWireComponent =
+                regularContents ?
+                    regularContents.components.BeltReader ||
+                    regularContents.components.Lever ||
+                    regularContents.components.Display
+                : false;
+            if (!wireContents && regularContentsIsWireComponent) {
+                return regularContents;
+            } else {
+                return wireContents;
+            }
         }
     }
     /**


### PR DESCRIPTION
Previously, right clicking a button with an item selected would delete the button (instead of just deselect the item in hand). Looks like it was because the button right click had its own handler. Removing it seems to have fixed the issue.