### PR TITLE
Update item_processor.js

### DIFF
--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -76,16 +76,23 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
 
             const currentCharge = processorComp.ongoingCharges[0];
 
-            if (currentCharge) {
-                // Process next charge
-                if (currentCharge.remainingTime > 0.0) {
-                    currentCharge.remainingTime -= this.root.dynamicTickrate.deltaSeconds;
-                    if (currentCharge.remainingTime < 0.0) {
+            // Select active charge, prevent process delayd caused when having more outputted items then ejectors (double painter)
+            for (let j = 0; j < processorComp.ongoingCharges.length; ++j) {
+                const charge = processorComp.ongoingCharges[j];
+                if (charge && charge.remainingTime > 0.0) {
+                    // Remove bonus time from charge
+                    charge.remainingTime -= this.root.dynamicTickrate.deltaSeconds + processorComp.bonusTime;
+                    // Reset bonus time
+                    processorComp.bonusTime = 0;
+                    if (charge.remainingTime < 0.0) {
                         // Add bonus time, this is the time we spent too much
-                        processorComp.bonusTime += -currentCharge.remainingTime;
+                        processorComp.bonusTime += -charge.remainingTime;
                     }
+                    break;
                 }
+            }
 
+            if (currentCharge) {
                 // Check if it finished
                 if (currentCharge.remainingTime <= 0.0) {
                     const itemsToEject = currentCharge.items;


### PR DESCRIPTION
Fixes https://github.com/tobspr/shapez.io/issues/842
Fix for delays in processor charge time, pervents processing delays when having more outputted items then ejectors (double painter) and delays in update ticks

Belt Speed x8(Tier VIII), all others x8.10(Tier IX)
Before
![image](https://user-images.githubusercontent.com/18009311/96057000-fb88fd00-0e55-11eb-9602-03d21f387bb9.png)

After
![image](https://user-images.githubusercontent.com/18009311/96056907-c1b7f680-0e55-11eb-9899-d60d9dd8c5b6.png)
