### PR TITLE
Slightly more sandbox controls

### DIFF
--- a/src/css/ingame_hud/sandbox_controller.scss
+++ b/src/css/ingame_hud/sandbox_controller.scss
@@ -21,7 +21,7 @@
     .plusMinus {
         @include S(margin-top, 4px);
         display: grid;
-        grid-template-columns: 1fr auto auto;
+        grid-template-columns: 1fr auto auto auto;
         align-items: center;
         @include S(grid-gap, 4px);
 

--- a/src/css/ingame_hud/sandbox_controller.scss
+++ b/src/css/ingame_hud/sandbox_controller.scss
@@ -46,5 +46,15 @@
             @include IncreasedClickArea(0px);
             @include SuperSmallText;
         }
+        .bigPlusMinus {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            @include S(grid-gap, 2px);
+            button {
+                @include S(margin-bottom, 2px);
+                @include IncreasedClickArea(0px);
+                @include SuperSmallText;
+            }
+        }
     }
 }

--- a/src/js/game/hud/parts/sandbox_controller.js
+++ b/src/js/game/hud/parts/sandbox_controller.js
@@ -26,7 +26,7 @@ export class HUDSandboxController extends BaseHUDPart {
                 </div>
                 
                 <div class="upgradesBelt plusMinus">
-                    <label>&rarr; Belt</label>
+                    <label>&rarr; Belts</label>
                     <button class="styledButton reset">⮂</button>
                     <button class="styledButton minus">-</button>
                     <button class="styledButton plus">+</button>
@@ -55,11 +55,14 @@ export class HUDSandboxController extends BaseHUDPart {
 
                 <div class="additionalOptions">
                     <div class="bigPlusMinus">
+                        <button class="styledButton levelOverride">Override</button>
+                        <button class="styledButton levelUp">Level up</button> 
+                    </div>
+                    <div class="bigPlusMinus">
                         <button class="styledButton bigMinus">-100 All</button>
                         <button class="styledButton bigPlus">+100 All</button> 
                     </div>
                     <button class="styledButton giveBlueprints">Fill blueprint shapes</button>
-                    <button class="styledButton levelOverride">Override level</button>
                 </div>
             </div>
         `
@@ -67,13 +70,15 @@ export class HUDSandboxController extends BaseHUDPart {
 
         const bind = (selector, handler) => this.trackClicks(this.element.querySelector(selector), handler);
 
-        bind(".giveBlueprints", this.giveBlueprints);
+        bind(".levelOverride", this.promptOverrideLevel);
+        bind(".levelUp", this.tryLevelUp)
         bind(".bigMinus", () => this.modifyAll(-100));
         bind(".bigPlus", () => this.modifyAll(100));
+        bind(".giveBlueprints", this.giveBlueprints);
+
         bind(".levelToggle .reset", this.resetLevel);
         bind(".levelToggle .minus", () => this.modifyLevel(-1));
         bind(".levelToggle .plus", () => this.modifyLevel(1));
-        bind(".levelOverride", this.promptOverrideLevel);
 
         bind(".upgradesBelt .reset", () => this.resetUpgrade("belt"));
         bind(".upgradesBelt .minus", () => this.modifyUpgrade("belt", -1));
@@ -188,7 +193,7 @@ export class HUDSandboxController extends BaseHUDPart {
         const dialog = new DialogWithForm({
             app: this.root.app,
             title: "Override Level",
-            desc: "Enter shape to override with:",
+            desc: "Enter a shape to override with:",
             formElements: [signalValueInput],
             buttons: ["cancel:bad:escape", "ok:good:enter"],
             closeButton: false,
@@ -212,6 +217,12 @@ export class HUDSandboxController extends BaseHUDPart {
             "Overrode level to " + hubGoals.currentGoal.definition.getHash(),
             enumNotificationType.upgrade
         );
+    }
+
+    tryLevelUp() {
+        if (!this.root.hubGoals.isEndOfDemoReached()) {
+            this.root.hubGoals.onGoalCompleted();
+        }
     }
 
     initialize() {

--- a/src/js/game/hud/parts/sandbox_controller.js
+++ b/src/js/game/hud/parts/sandbox_controller.js
@@ -45,8 +45,11 @@ export class HUDSandboxController extends BaseHUDPart {
                 </div>
 
                 <div class="additionalOptions">
+                    <div class="bigPlusMinus">
+                        <button class="styledButton bigMinus">-100 All</button>
+                        <button class="styledButton bigPlus">+100 All</button> 
+                    </div>
                     <button class="styledButton giveBlueprints">Fill blueprint shapes</button>
-                    <button class="styledButton maxOutAll">Max out all</button>
                 </div>
             </div>
         `
@@ -55,7 +58,8 @@ export class HUDSandboxController extends BaseHUDPart {
         const bind = (selector, handler) => this.trackClicks(this.element.querySelector(selector), handler);
 
         bind(".giveBlueprints", this.giveBlueprints);
-        bind(".maxOutAll", this.maxOutAll);
+        bind(".bigMinus", () => this.modifyAll(-100));
+        bind(".bigPlus", () => this.modifyAll(100));
         bind(".levelToggle .minus", () => this.modifyLevel(-1));
         bind(".levelToggle .plus", () => this.modifyLevel(1));
 
@@ -80,11 +84,11 @@ export class HUDSandboxController extends BaseHUDPart {
         this.root.hubGoals.storedShapes[shape] += 1e9;
     }
 
-    maxOutAll() {
-        this.modifyUpgrade("belt", 100);
-        this.modifyUpgrade("miner", 100);
-        this.modifyUpgrade("processors", 100);
-        this.modifyUpgrade("painting", 100);
+    modifyAll(amount) {
+        this.modifyUpgrade("belt", amount);
+        this.modifyUpgrade("miner", amount);
+        this.modifyUpgrade("processors", amount);
+        this.modifyUpgrade("painting", amount);
     }
 
     modifyUpgrade(id, amount) {


### PR DESCRIPTION
Adds controls to the sandbox controller for:
* Decreasing all upgrades by 100
* Leveling up normally
* Temporarily changing the current goal shape
* Skipping/resetting to and switching between the first freeplay level and first level
* Skipping/resetting to and switching between the last and first upgrade levels, individually for each upgrade

There are also minor formatting revisions to the sandbox controller.

![image](https://user-images.githubusercontent.com/69981203/96798533-b3725900-13c6-11eb-82d1-35d63f74d280.png)
