### PR TITLE
Fix windmill shape generation for more diverse windmill resources on the map

### DIFF
--- a/src/js/game/map_chunk.js
+++ b/src/js/game/map_chunk.js
@@ -238,10 +238,9 @@ export class MapChunk {
                 }
             } else {
                 // Turn subshape at 2 random positions into a random type that is not windmill
-                let quad1 = rng.nextIntRange(0,4);
-                let quad2 = rng.nextIntRange(0,3);
-                if (quad2 >= quad1)
-                {
+                let quad1 = rng.nextIntRange(0, 4);
+                let quad2 = rng.nextIntRange(0, 3);
+                if (quad2 >= quad1) {
                     ++quad2;
                 }
                 subShapes[quad1] = this.internalGenerateRandomSubShape(rng, weights);

--- a/src/js/game/map_chunk.js
+++ b/src/js/game/map_chunk.js
@@ -198,36 +198,35 @@ export class MapChunk {
             weights[enumSubShape.windmill] = 0;
         }
 
-        if (distanceToOriginInChunks < 10) {
-            // Initial chunk patches always have the same shape
-            const subShape = this.internalGenerateRandomSubShape(rng, weights);
-            subShapes = [subShape, subShape, subShape, subShape];
-        } else if (distanceToOriginInChunks < 15) {
-            // Later patches can also have mixed ones
-            const subShapeA = this.internalGenerateRandomSubShape(rng, weights);
-            const subShapeB = this.internalGenerateRandomSubShape(rng, weights);
-            subShapes = [subShapeA, subShapeA, subShapeB, subShapeB];
-        } else {
-            // Finally there is a mix of everything
-            subShapes = [
-                this.internalGenerateRandomSubShape(rng, weights),
-                this.internalGenerateRandomSubShape(rng, weights),
-                this.internalGenerateRandomSubShape(rng, weights),
-                this.internalGenerateRandomSubShape(rng, weights),
-            ];
-        }
-
         // Makes sure windmills never spawn as whole
-        let windmillCount = 0;
-        for (let i = 0; i < subShapes.length; ++i) {
-            if (subShapes[i] === enumSubShape.windmill) {
-                ++windmillCount;
+        let windmillCount;
+        do {
+            windmillCount = 0;
+            if (distanceToOriginInChunks < 10) {
+                // Initial chunk patches always have the same shape
+                weights[enumSubShape.windmill] = 0; // no whole windmills
+                const subShape = this.internalGenerateRandomSubShape(rng, weights);
+                subShapes = [subShape, subShape, subShape, subShape];
+            } else if (distanceToOriginInChunks < 15) {
+                // Later patches can also have mixed ones
+                const subShapeA = this.internalGenerateRandomSubShape(rng, weights);
+                const subShapeB = this.internalGenerateRandomSubShape(rng, weights);
+                subShapes = [subShapeA, subShapeA, subShapeB, subShapeB];
+            } else {
+                // Finally there is a mix of everything
+                subShapes = [
+                    this.internalGenerateRandomSubShape(rng, weights),
+                    this.internalGenerateRandomSubShape(rng, weights),
+                    this.internalGenerateRandomSubShape(rng, weights),
+                    this.internalGenerateRandomSubShape(rng, weights),
+                ];
             }
-        }
-        if (windmillCount > 2) {
-            this.internalGenerateShapePatch(rng, shapePatchSize, distanceToOriginInChunks);
-            return;
-        }
+            for (let i = 0; i < subShapes.length; ++i) {
+                if (subShapes[i] === enumSubShape.windmill) {
+                    ++windmillCount;
+                }
+            }
+        } while (windmillCount > 2);
 
         const definition = this.root.shapeDefinitionMgr.getDefinitionFromSimpleShapes(subShapes);
         this.internalGeneratePatch(

--- a/src/js/game/map_chunk.js
+++ b/src/js/game/map_chunk.js
@@ -224,9 +224,9 @@ export class MapChunk {
                 ++windmillCount;
             }
         }
-        if (windmillCount > 1) {
-            subShapes[0] = enumSubShape.rect;
-            subShapes[1] = enumSubShape.rect;
+        if (windmillCount > 2) {
+            this.internalGenerateShapePatch(rng, shapePatchSize, distanceToOriginInChunks);
+            return;
         }
 
         const definition = this.root.shapeDefinitionMgr.getDefinitionFromSimpleShapes(subShapes);

--- a/src/js/game/map_chunk.js
+++ b/src/js/game/map_chunk.js
@@ -195,7 +195,7 @@ export class MapChunk {
         if (distanceToOriginInChunks < 7) {
             // Initial chunks can not spawn the good stuff
             weights[enumSubShape.star] = 0;
-            weights[enumSubShape.windmill] = 0; 
+            weights[enumSubShape.windmill] = 0;
         }
 
         if (distanceToOriginInChunks < 10) {
@@ -213,7 +213,7 @@ export class MapChunk {
                 this.internalGenerateRandomSubShape(rng, weights),
                 this.internalGenerateRandomSubShape(rng, weights),
                 this.internalGenerateRandomSubShape(rng, weights),
-                this.internalGenerateRandomSubShape(rng, weights)
+                this.internalGenerateRandomSubShape(rng, weights),
             ];
         }
 
@@ -238,10 +238,10 @@ export class MapChunk {
                 }
             } else {
                 // Turn subshape at 2 random positions into a random type that is not windmill
-                let quad1 = rng.nextIntRange(0,3);
-                let quad2 = rng.nextIntRange(0,2);
-                if (quad2 >= quad1) 
-                { 
+                let quad1 = rng.nextIntRange(0,4);
+                let quad2 = rng.nextIntRange(0,3);
+                if (quad2 >= quad1)
+                {
                     ++quad2;
                 }
                 subShapes[quad1] = this.internalGenerateRandomSubShape(rng, weights);


### PR DESCRIPTION
Going from a lot of these: 
![image](https://user-images.githubusercontent.com/29737689/97203012-a2558d80-17b4-11eb-8b93-6df3dfdf5ea3.png)
To more of these:
![image](https://user-images.githubusercontent.com/29737689/97203259-dcbf2a80-17b4-11eb-96bf-4180375018f3.png)
![image](https://user-images.githubusercontent.com/29737689/97203297-e5affc00-17b4-11eb-9476-b58d100e7606.png)

This will slightly increase the number of windmill sub shapes on the map.

Signed-off-by: noctilucentgames <noctilucentgames@gmail.com>