### PR TITLE
Update base-zh-CN.yaml

### DIFF
--- a/translations/base-zh-CN.yaml
+++ b/translations/base-zh-CN.yaml
@@ -59,7 +59,7 @@ global:
         xDaysAgo: <x>天前
         secondsShort: <seconds>秒
         minutesAndSecondsShort: <minutes>分 <seconds>秒
-        hoursAndMinutesShort: <hours>时 <minutes>秒
+        hoursAndMinutesShort: <hours>时 <minutes>分
         xMinutes: <x>分钟
     keys:
         tab: TAB


### PR DESCRIPTION
Previously it represents hours and seconds, instead of hours and minutes. (If you compare this with minutesAndSecondsShort you can tell)