### PR TITLE
Require LMB to place blueprints

### DIFF
--- a/src/js/game/hud/parts/blueprint_placer.js
+++ b/src/js/game/hud/parts/blueprint_placer.js
@@ -110,22 +110,24 @@ export class HUDBlueprintPlacer extends BaseHUDPart {
             }
         }
 
-        const blueprint = this.currentBlueprint.get();
-        if (!blueprint) {
-            return;
-        }
+        if (button === enumMouseButton.left) {
+            const blueprint = this.currentBlueprint.get();
+            if (!blueprint) {
+                return;
+            }
 
-        if (!blueprint.canAfford(this.root)) {
-            this.root.soundProxy.playUiError();
-            return;
-        }
+            if (!blueprint.canAfford(this.root)) {
+                this.root.soundProxy.playUiError();
+                return;
+            }
 
-        const worldPos = this.root.camera.screenToWorld(pos);
-        const tile = worldPos.toTileSpace();
-        if (blueprint.tryPlace(this.root, tile)) {
-            const cost = blueprint.getCost();
-            this.root.hubGoals.takeShapeByKey(this.root.gameMode.getBlueprintShapeKey(), cost);
-            this.root.soundProxy.playUi(SOUNDS.placeBuilding);
+            const worldPos = this.root.camera.screenToWorld(pos);
+            const tile = worldPos.toTileSpace();
+            if (blueprint.tryPlace(this.root, tile)) {
+                const cost = blueprint.getCost();
+                this.root.hubGoals.takeShapeByKey(this.root.gameMode.getBlueprintShapeKey(), cost);
+                this.root.soundProxy.playUi(SOUNDS.placeBuilding);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #693. It may be preferred to check for which mouse buttons are bound to a relevant functionality, but I think it makes more sense to just have it bound to LMB exclusively.