### PR TITLE
Hide wires grid when using the "Disable Grid" setting

### DIFF
--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -117,7 +117,8 @@ export class HUDWiresOverlay extends BaseHUDPart {
             return;
         }
 
-        if (!this.cachedPatternBackground) {
+        const hasTileGrid = !this.root.app.settings.getAllSettings().disableTileGrid;
+        if (hasTileGrid && !this.cachedPatternBackground) {
             this.cachedPatternBackground = parameters.context.createPattern(this.tilePatternCanvas, "repeat");
         }
 
@@ -132,7 +133,9 @@ export class HUDWiresOverlay extends BaseHUDPart {
         parameters.context.globalCompositeOperation = "source-over";
 
         parameters.context.scale(scaleFactor, scaleFactor);
-        parameters.context.fillStyle = this.cachedPatternBackground;
+        parameters.context.fillStyle = hasTileGrid
+            ? this.cachedPatternBackground
+            : "rgba(78, 137, 125, 0.75)";
         parameters.context.fillRect(
             bounds.x / scaleFactor,
             bounds.y / scaleFactor,


### PR DESCRIPTION
When using the "Disable Grid" setting, the wires layer grid is still visible. This is changed in this PR by replacing the repeated tile image pattern with a single color. The color is the average of the colors in the tile image and has the same transparency. The grainy look of the layer is lost.

<details><summary>"Disable Grid" OFF on left, ON on right</summary>

![wireslayer](https://user-images.githubusercontent.com/69981203/99161830-b574c280-26bb-11eb-927a-a78777186636.png)
</details>
<details><summary>With buildings (confusing <b>SPOILER</b> for level 26 solution)</summary>

![wireslayerbetter](https://user-images.githubusercontent.com/69981203/99161839-dccb8f80-26bb-11eb-84ad-c550a10f2c83.png)
</details>
