### PR TITLE
Add support for a buffered second item to be ejected

### DIFF
--- a/src/js/game/buildings/painter.js
+++ b/src/js/game/buildings/painter.js
@@ -182,7 +182,7 @@ export class MetaPainterBuilding extends MetaBuilding {
                 ]);
 
                 entity.components.ItemEjector.setSlots([
-                    { pos: new Vector(1, 0), direction: enumDirection.right },
+                    { pos: new Vector(1, 0), direction: enumDirection.right, buffered: true },
                 ]);
 
                 entity.components.ItemProcessor.type = enumItemProcessorTypes.painterDouble;

--- a/src/js/game/components/item_ejector.js
+++ b/src/js/game/components/item_ejector.js
@@ -63,7 +63,7 @@ export class ItemEjectorComponent extends Component {
                 direction: slot.direction,
                 item: null,
                 progress: 0,
-                buffered: slot.buffered,
+                buffered: !!slot.buffered,
                 nextItem: null,
                 cachedDestSlot: null,
                 cachedTargetEntity: null,

--- a/src/js/game/components/item_ejector.js
+++ b/src/js/game/components/item_ejector.js
@@ -12,7 +12,8 @@ import { typeItemSingleton } from "../item_resolver";
  *    direction: enumDirection,
  *    item: BaseItem,
  *    progress: number?,
- *    nextItem?: BaseItem,
+ *    buffered: boolean,
+ *    nextItem: BaseItem,
  *    cachedDestSlot?: import("./item_acceptor").ItemAcceptorLocatedSlot,
  *    cachedBeltPath?: BeltPath,
  *    cachedTargetEntity?: Entity
@@ -62,7 +63,8 @@ export class ItemEjectorComponent extends Component {
                 direction: slot.direction,
                 item: null,
                 progress: 0,
-                nextItem: slot.buffered ? null : undefined,
+                buffered: slot.buffered,
+                nextItem: null,
                 cachedDestSlot: null,
                 cachedTargetEntity: null,
             });
@@ -99,7 +101,8 @@ export class ItemEjectorComponent extends Component {
      */
     canEjectOnSlot(slotIndex) {
         assert(slotIndex >= 0 && slotIndex < this.slots.length, "Invalid ejector slot: " + slotIndex);
-        return !this.slots[slotIndex].item || this.slots[slotIndex].nextItem === null;
+        const slot = this.slots[slotIndex];
+        return !slot.item || (slot.buffered && !slot.nextItem);
     }
 
     /**
@@ -142,11 +145,11 @@ export class ItemEjectorComponent extends Component {
     takeSlotItem(slotIndex) {
         const slot = this.slots[slotIndex];
         const item = slot.item;
-        if (slot.nextItem === undefined) {
-            slot.item = null;
-        } else {
+        if (slot.buffered) {
             slot.item = slot.nextItem;
             slot.nextItem = null;
+        } else {
+            slot.item = null;
         }
         slot.progress = 0.0;
         return item;

--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -182,7 +182,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                 if (destPath) {
                     // Try passing the item over
                     if (destPath.tryAcceptItem(item)) {
-                        sourceSlot.item = null;
+                        sourceEjectorComp.takeSlotItem(j);
                     }
 
                     // Always stop here, since there can *either* be a belt path *or*
@@ -209,7 +209,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                                 item
                             );
                         }
-                        sourceSlot.item = null;
+                        sourceEjectorComp.takeSlotItem(j);
                         continue;
                     }
                 }


### PR DESCRIPTION
This allows the double painter to start the next paint job immediately,
thus eliminating the reason it ran slower than specified.

Fixes #842

---

This came about because i noticed that the double painter seems to be slower than specified because it waits for one of the shapes to be ejected before it starts taking in and painting the next ones.

Looking at GitHub, I found that others had tried to fix the slowdown by messing with the timing of the next paint job, but that didn't seem right to me - so I went for fixing the underlying problem instead, the waiting it does.

I envision this conceptually as the double painter having enough space in its output stage to fit both of the painted items, which is similar to how the other buildings work - they take in the next item(s) while the previous one(s) are ejected.

A small tier-1 test savefile that consistently ran too slow before (~1.8 items/sec with visible belt gaps), runs consistently at full speed (2 items/sec, no gaps) with this change in place.

Most of the implementation is in the common item ejector component, so I considered making it more generic and supporting more than one extra output item, but I figured that would be overkill since it isn't required for the double painter, and would probably make it take more CPU time.