### PR TITLE
Fix belt throughput bug

### DIFF
--- a/src/js/game/belt_path.js
+++ b/src/js/game/belt_path.js
@@ -1087,29 +1087,26 @@ export class BeltPath extends BasicSerializableObject {
 
             // If the last item can be ejected, eject it and reduce the spacing, because otherwise
             // we lose velocity
-            if (isFirstItemProcessed && nextDistanceAndItem[_nextDistance] < 1e-7) {
-                // Store how much velocity we "lost" because we bumped the item to the end of the
-                // belt but couldn't move it any farther. We need this to tell the item acceptor
-                // animation to start a tad later, so everything matches up. Yes I'm a perfectionist.
-                const excessVelocity = beltSpeed - clampedProgress;
-
+            if (isFirstItemProcessed) {
                 // Try to directly get rid of the item
-                if (this.tryHandOverItem(nextDistanceAndItem[_item], excessVelocity)) {
+                if (
+                    nextDistanceAndItem[_nextDistance] < 1e-7 &&
+                    this.tryHandOverItem(nextDistanceAndItem[_item], beltSpeed - clampedProgress)
+                ) {
                     this.items.pop();
 
                     this.numCompressedItemsAfterFirstItem = Math.max(
                         0,
                         this.numCompressedItemsAfterFirstItem - 1
                     );
+                } else {
+                    // Skip N null items after first items if we don't need to bump the next item
+                    lastItemProcessed -= this.numCompressedItemsAfterFirstItem;
                 }
+
+                isFirstItemProcessed = false;
             }
 
-            if (isFirstItemProcessed) {
-                // Skip N null items after first items
-                lastItemProcessed -= this.numCompressedItemsAfterFirstItem;
-            }
-
-            isFirstItemProcessed = false;
             this.spacingToFirstItem += clampedProgress;
             if (remainingVelocity < 1e-7) {
                 break;


### PR DESCRIPTION
This is a fix for this bug reported on Discord that has been bothering some people:
![image](https://user-images.githubusercontent.com/5150427/99917946-f75fc300-2cd0-11eb-8bb5-541f0defb62d.png)

The cause of the bug is the code for the "compressed items" optimization for belt paths. This is why the bug only appears when the belt gets "backed up" and then unblocked, because when a belt gets backed up it considers most items as "compressed" on the belt.

When the belt path offloads the first item of a compressed stack, the excess velocity that should be transferred to the next item actually gets thrown away because the rest of the compressed stack is skipped and no other candidates are found to transfer the excess velocity. Due to this there is a blockage for one tick and all items are compressed again, repeating the cycle and causing belt lines to become permanently slightly inefficient. By only skipping compressed items if an item _wasn't_ thrown away we can ensure all of the velocity is properly carried over all the time.