### PR TITLE
Visual improvement to ejector slots

### DIFF
--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -159,9 +159,14 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                     continue;
                 }
 
+                const maxProgress = Math.min(
+                    1.0,
+                    sourceSlot.cachedBeltPath ? sourceSlot.cachedBeltPath.spacingToFirstItem * 1.45 : 1.0
+                );
+
                 // Advance items on the slot
                 sourceSlot.progress = Math.min(
-                    1,
+                    maxProgress,
                     sourceSlot.progress +
                         progressGrowth *
                             this.root.hubGoals.getBeltBaseSpeed() *
@@ -169,11 +174,11 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                 );
 
                 if (G_IS_DEV && globalConfig.debug.disableEjectorProcessing) {
-                    sourceSlot.progress = 1.0;
+                    sourceSlot.progress = maxProgress;
                 }
 
                 // Check if we are still in the process of ejecting, can't proceed then
-                if (sourceSlot.progress < 1.0) {
+                if (sourceSlot.progress < maxProgress) {
                     continue;
                 }
 

--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -178,7 +178,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                 }
 
                 // Check if we are still in the process of ejecting, can't proceed then
-                if (sourceSlot.progress < maxProgress) {
+                if (sourceSlot.progress < 1.0) {
                     continue;
                 }
 

--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -166,7 +166,7 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                 if (destPath) {
                     maxProgress = Math.min(
                         1.0,
-                        sourceSlot.cachedBeltPath.spacingToFirstItem / globalConfig.itemSpacingOnBelts
+                        destPath.spacingToFirstItem / globalConfig.itemSpacingOnBelts
                     );
                 }
 

--- a/src/js/game/systems/item_ejector.js
+++ b/src/js/game/systems/item_ejector.js
@@ -159,10 +159,16 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                     continue;
                 }
 
-                const maxProgress = Math.min(
-                    1.0,
-                    sourceSlot.cachedBeltPath ? sourceSlot.cachedBeltPath.spacingToFirstItem * 1.45 : 1.0
-                );
+                let maxProgress = 1.0;
+
+                // Check if there's an item blocking the ejector
+                const destPath = sourceSlot.cachedBeltPath;
+                if (destPath) {
+                    maxProgress = Math.min(
+                        1.0,
+                        sourceSlot.cachedBeltPath.spacingToFirstItem / globalConfig.itemSpacingOnBelts
+                    );
+                }
 
                 // Advance items on the slot
                 sourceSlot.progress = Math.min(
@@ -183,7 +189,6 @@ export class ItemEjectorSystem extends GameSystemWithFilter {
                 }
 
                 // Check if we are ejecting to a belt path
-                const destPath = sourceSlot.cachedBeltPath;
                 if (destPath) {
                     // Try passing the item over
                     if (destPath.tryAcceptItem(item)) {


### PR DESCRIPTION
Currently if a lane is backed up and an ejector slot is waiting to output, the waiting item often shows overlapped with items on the belt, like this:
![image](https://user-images.githubusercontent.com/5150427/99918124-127f0280-2cd2-11eb-965b-300b3d87a112.png)


Coming from Factorio and other belt-factory games this is a bit unsatisfying, it looks like there's clutter on the belts or like something is backed up.

Belt paths keep a spacingToFirstItem property that tells us how much the waiting item can peek out. So we can use this to completely avoid clutter: 
![image](https://user-images.githubusercontent.com/5150427/99918127-1874e380-2cd2-11eb-97e5-e0dc830d8e10.png)
