### PR TITLE
#596 Better Markers

### DIFF
--- a/src/css/ingame_hud/waypoints.scss
+++ b/src/css/ingame_hud/waypoints.scss
@@ -103,6 +103,14 @@
         }
 
         &.shapeIcon {
+            .shapeIconText {
+                display: grid;
+                grid-template-columns: auto 1fr;
+                canvas {
+                    @include S(margin-right, 1px);
+                }
+            }
+
             canvas {
                 @include S(width, 15px);
                 @include S(height, 15px);

--- a/src/js/game/hud/parts/waypoints.js
+++ b/src/js/game/hud/parts/waypoints.js
@@ -271,7 +271,7 @@ export class HUDWaypoints extends BaseHUDPart {
 
     /**
      * Splits the waypoint label on its first whitespace.
-     * @param {string} waypoint label
+     * @param {string} label
      * @returns {[string, string]}
      */
     splitWaypointLabel(label) {


### PR DESCRIPTION
Implements the feature request #596.

The shape short key may be a prefix of the label, followed by a space and the rest of the text. In that case, both the shape and the text are rendered both in the world map and the waypoint list.

![Partial screenshot](https://user-images.githubusercontent.com/7260898/101291757-6f6ad480-380b-11eb-97c2-6547efd41327.png)
