### PR TITLE
Fix processor charge handling to avoid losing time

### DIFF
--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -74,12 +74,28 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
             const processorComp = entity.components.ItemProcessor;
             const ejectorComp = entity.components.ItemEjector;
 
-            const currentCharge = processorComp.ongoingCharges[0];
+            for (let chargeIndex = 0; true; chargeIndex++) {
 
-            if (currentCharge) {
+                // Check if we have an open queue spot and can start a new charge
+                if (processorComp.ongoingCharges.length < MAX_QUEUED_CHARGES) {
+                    if (this.canProcess(entity)) {
+                        this.startNewCharge(entity);
+                    }
+                }
+
+                if (chargeIndex >= processorComp.ongoingCharges.length) {
+                    break;
+                }
+
+                const currentCharge = processorComp.ongoingCharges[chargeIndex];
+
                 // Process next charge
                 if (currentCharge.remainingTime > 0.0) {
                     currentCharge.remainingTime -= this.root.dynamicTickrate.deltaSeconds;
+                    if (currentCharge.remainingTime > 0.0) {
+                        // This charge is not finished, so don't process the next one
+                        break;
+                    }
                     if (currentCharge.remainingTime < 0.0) {
                         // Add bonus time, this is the time we spent too much
                         processorComp.bonusTime += -currentCharge.remainingTime;
@@ -87,7 +103,7 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
                 }
 
                 // Check if it finished
-                if (currentCharge.remainingTime <= 0.0) {
+                if (chargeIndex === 0 && currentCharge.remainingTime <= 0.0) {
                     const itemsToEject = currentCharge.items;
 
                     // Go over all items and try to eject them
@@ -128,14 +144,8 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
                     // If the charge was entirely emptied to the outputs, start the next charge
                     if (itemsToEject.length === 0) {
                         processorComp.ongoingCharges.shift();
+                        chargeIndex--;
                     }
-                }
-            }
-
-            // Check if we have an empty queue and can start a new charge
-            if (processorComp.ongoingCharges.length < MAX_QUEUED_CHARGES) {
-                if (this.canProcess(entity)) {
-                    this.startNewCharge(entity);
                 }
             }
         }

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -91,7 +91,8 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
 
                 // Process next charge
                 if (currentCharge.remainingTime > 0.0) {
-                    currentCharge.remainingTime -= this.root.dynamicTickrate.deltaSeconds;
+                    currentCharge.remainingTime -= this.root.dynamicTickrate.deltaSeconds + processorComp.bonusTime;
+                    processorComp.bonusTime = 0;
                     if (currentCharge.remainingTime > 0.0) {
                         // This charge is not finished, so don't process the next one
                         break;
@@ -302,15 +303,10 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
 
         // Queue Charge
         const baseSpeed = this.root.hubGoals.getProcessorBaseSpeed(processorComp.type);
-        const originalTime = 1 / baseSpeed;
 
-        const bonusTimeToApply = Math.min(originalTime, processorComp.bonusTime);
-        const timeToProcess = originalTime - bonusTimeToApply;
-
-        processorComp.bonusTime -= bonusTimeToApply;
         processorComp.ongoingCharges.push({
             items: outItems,
-            remainingTime: timeToProcess,
+            remainingTime: 1 / baseSpeed,
         });
     }
 


### PR DESCRIPTION
This changes the item processor's charge handling code so that it doesn't wait for processed items to finish ejecting before it starts processing the next charge, as discussed in PR #995.

It also fixes the handling of bonus time so that it is applied to the next charge that is processed, instead of to the next charge that is added. (This is not the same charge when a charge is added before the current one is finished processing.)

It does not attempt to fix the case of bonus time being applied to a charge that is added significantly later, as that was not considered a big issue and a simple fix might also affect a charge that happens on the very next tick, which I don't think would be quite right. So I decided to leave that for later.

Fixes #842
Closes #995