### PR TITLE
Error entity_manager.js ->removeDynamicComponent line 126

### DIFF
--- a/src/js/game/entity_manager.js
+++ b/src/js/game/entity_manager.js
@@ -123,7 +123,7 @@ export class EntityManager extends BasicSerializableObject {
      */
     removeDynamicComponent(entity, component) {
         entity.removeComponent(component, true);
-        const componentId = /** @type {typeof Component} */ (component.constructor).getId();
+        const componentId = component.getId();
 
         fastArrayDeleteValue(this.componentToEntity[componentId], entity);
         this.root.signals.entityComponentRemoved.dispatch(entity);


### PR DESCRIPTION
Fixed the error on line 126. 
Was: 
`        const componentId = /** @type {typeof Component} */ (component.constructor).getId();`
Is:
`        const componentId = component.getId();`

In the function component should be a type of component and not an instance.