### PR TITLE
Fix building preview I/O arrows being affected by wires

### DIFF
--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -510,12 +510,15 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
                 let isBlocked = false;
                 let isConnected = false;
 
-                // Find all entities which are on that tile
-                const sourceEntities = this.root.map.getLayersContentsMultipleXY(sourceTile.x, sourceTile.y);
+                // Find entity which is on that tile
+                const sourceEntity = this.root.map.getLayerContentXY(
+                    sourceTile.x,
+                    sourceTile.y,
+                    this.fakeEntity.layer
+                );
 
-                // Check for every entity:
-                for (let i = 0; i < sourceEntities.length; ++i) {
-                    const sourceEntity = sourceEntities[i];
+                // Check for the entity:
+                if (sourceEntity) {
                     const sourceEjector = sourceEntity.components.ItemEjector;
                     const sourceBeltComp = sourceEntity.components.Belt;
                     const sourceStaticComp = sourceEntity.components.StaticMapEntity;
@@ -569,15 +572,15 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
             let isBlocked = false;
             let isConnected = false;
 
-            // Find all entities which are on that tile
-            const destEntities = this.root.map.getLayersContentsMultipleXY(
+            // Find entity which is on that tile
+            const destEntity = this.root.map.getLayerContentXY(
                 ejectorSlotWsTile.x,
-                ejectorSlotWsTile.y
+                ejectorSlotWsTile.y,
+                this.fakeEntity.layer
             );
 
-            // Check for every entity:
-            for (let i = 0; i < destEntities.length; ++i) {
-                const destEntity = destEntities[i];
+            // Check for the entity:
+            if (destEntity) {
                 const destAcceptor = destEntity.components.ItemAcceptor;
                 const destStaticComp = destEntity.components.StaticMapEntity;
                 const destMiner = destEntity.components.Miner;


### PR DESCRIPTION
When checking whether a building preview's inputs/outputs are obstructed, buildings in both layers are checked. This means that if there is a wires building next to an input/output, the game wrongly thinks that the input/output is blocked.

This is fixed by only checking the buildings in the same layer as the building preview.
<details><summary>Example of bug</summary>

![image](https://user-images.githubusercontent.com/69981203/103058076-d952e000-4566-11eb-8188-118d7171fcf1.png)
</details><details><summary>Fixed version</summary>

![image](https://user-images.githubusercontent.com/69981203/103058211-41092b00-4567-11eb-8662-3d70b35a0e78.png)
</details>

Fixes #648
