### PR TITLE
Add basic gamepad keybindings

### DIFF
--- a/src/css/animations.scss
+++ b/src/css/animations.scss
@@ -1,4 +1,4 @@
-@each $num in ("changeAnimEven", "changeAnimOdd") {
+@each $animName in ("changeAnimEven", "changeAnimOdd") {
     @keyframes #{$animName} {
         0% {
             transform: scale(1, 1);

--- a/src/js/application.js
+++ b/src/js/application.js
@@ -366,6 +366,8 @@ export class Application {
 
         const time = performance.now();
 
+        this.inputMgr.processGamepadInputs();
+
         // Periodically check for resizes, this is expensive (takes 2-3ms so only do it once in a while!)
         if (!this.lastResizeCheck || time - this.lastResizeCheck > 1000) {
             this.checkResize();

--- a/src/js/core/input_distributor.js
+++ b/src/js/core/input_distributor.js
@@ -220,6 +220,24 @@ export class InputDistributor {
         }
     }
 
+    getGamepadAxes() {
+        if (this.connectedGamepadIndex === null) {
+            return {
+                x: 0,
+                y: 0,
+            };
+        }
+
+        const gamepad = navigator.getGamepads()[this.connectedGamepadIndex];
+
+        // Threshold 0.25 as the joysticks never return to exact 0
+        // power to 9 function to decrease the sensitivity, to be ~0.25 at 85%
+        return {
+            x: Math.abs(gamepad.axes[0]) < 0.25 ? 0 : gamepad.axes[0],
+            y: Math.abs(gamepad.axes[1]) < 0.25 ? 0 : gamepad.axes[1],
+        };
+    }
+
     /**
      * @param {Event} event
      */

--- a/src/js/core/input_distributor.js
+++ b/src/js/core/input_distributor.js
@@ -185,7 +185,7 @@ export class InputDistributor {
         const gamepad = navigator.getGamepads()[this.connectedGamepadIndex];
 
         for (const [index, button] of gamepad.buttons.entries()) {
-            const keyCode = 200 + index
+            const keyCode = 300 + index;
             const isInitial = !this.keysDown.has(keyCode);
 
             if (button.pressed) {

--- a/src/js/core/input_distributor.js
+++ b/src/js/core/input_distributor.js
@@ -196,7 +196,8 @@ export class InputDistributor {
             const keyCode = 300 + index;
             const isInitial = !this.keysDown.has(keyCode);
 
-            if (button.pressed) {
+            // Limit to initial presses only, otherwise it generates event every frame
+            if (button.pressed && isInitial) {
                 logger.debug(`gamepad button [${index}]: ${button.pressed ? "pressed" : ""}`);
                 this.keysDown.add(keyCode);
 

--- a/src/js/core/input_distributor.js
+++ b/src/js/core/input_distributor.js
@@ -152,7 +152,7 @@ export class InputDistributor {
 
         window.addEventListener("blur", this.handleBlur.bind(this));
 
-        window.addEventListener("gamepadconnected", this.handleGamepadConnected.bind(this))
+        window.addEventListener("gamepadconnected", this.handleGamepadConnected.bind(this));
     }
 
     forwardToReceiver(eventId, payload = null) {
@@ -179,7 +179,7 @@ export class InputDistributor {
 
     processGamepadInputs() {
         if (this.connectedGamepadIndex === null) {
-            return
+            return;
         }
 
         const gamepad = navigator.getGamepads()[this.connectedGamepadIndex];
@@ -189,7 +189,7 @@ export class InputDistributor {
             const isInitial = !this.keysDown.has(keyCode);
 
             if (button.pressed) {
-                logger.debug(`gamepad button [${index}]: ${button.pressed ? 'pressed' : ''}`)
+                logger.debug(`gamepad button [${index}]: ${button.pressed ? "pressed" : ""}`);
                 this.keysDown.add(keyCode);
 
                 this.forwardToReceiver("keydown", {
@@ -197,7 +197,7 @@ export class InputDistributor {
                     shift: 0,
                     alt: 0,
                     initial: isInitial,
-                })
+                });
             }
             if (!button.pressed && !isInitial) {
                 this.keysDown.delete(keyCode);
@@ -210,7 +210,6 @@ export class InputDistributor {
             }
         }
     }
-
 
     /**
      * @param {Event} event

--- a/src/js/core/input_distributor.js
+++ b/src/js/core/input_distributor.js
@@ -28,6 +28,7 @@ export class InputDistributor {
          */
         this.keysDown = new Set();
 
+        /** @type number */
         this.connectedGamepadIndex = null;
 
         this.bindToEvents();
@@ -153,6 +154,7 @@ export class InputDistributor {
         window.addEventListener("blur", this.handleBlur.bind(this));
 
         window.addEventListener("gamepadconnected", this.handleGamepadConnected.bind(this));
+        window.addEventListener("gamepaddisconnected", this.handleGamepadDisconnected.bind(this));
     }
 
     forwardToReceiver(eventId, payload = null) {
@@ -175,6 +177,12 @@ export class InputDistributor {
 
     handleGamepadConnected(event) {
         this.connectedGamepadIndex = event.gamepad.index;
+    }
+
+    handleGamepadDisconnected(event) {
+        if (event.gamepad.index === this.connectedGamepadIndex) {
+            this.connectedGamepadIndex = null;
+        }
     }
 
     processGamepadInputs() {

--- a/src/js/game/camera.js
+++ b/src/js/game/camera.js
@@ -778,6 +778,7 @@ export class Camera extends BasicSerializableObject {
             this.internalUpdateCentering(now, physicsStepSizeMs);
             this.internalUpdateShake(now, physicsStepSizeMs);
             this.internalUpdateKeyboardForce(now, physicsStepSizeMs);
+            this.internalUpdateGamepadForce(now, physicsStepSizeMs);
         }
         this.clampZoomLevel();
     }
@@ -1006,6 +1007,26 @@ export class Camera extends BasicSerializableObject {
 
             this.center.x += moveAmount * forceX * movementSpeed;
             this.center.y += moveAmount * forceY * movementSpeed;
+        }
+    }
+
+    /**
+     * Updates the gamepad axis forces
+     * @param {number} now
+     * @param {number} dt Delta time
+     */
+    internalUpdateGamepadForce(now, dt) {
+        const inputMgr = this.root.app.inputMgr;
+
+        if (inputMgr.connectedGamepadIndex !== null && !this.currentlyMoving && this.desiredCenter == null) {
+            const limitingDimension = Math.min(this.root.gameWidth, this.root.gameHeight);
+
+            const moveAmount = ((limitingDimension / 2048) * dt) / this.zoomLevel;
+
+            let { x, y } = inputMgr.getGamepadAxes();
+
+            this.center.x += moveAmount * x * 2;
+            this.center.y += moveAmount * y * 2;
         }
     }
 }

--- a/src/js/game/hud/parts/base_toolbar.js
+++ b/src/js/game/hud/parts/base_toolbar.js
@@ -150,6 +150,10 @@ export class HUDBaseToolbar extends BaseHUDPart {
         }
     }
 
+    isBuildingSelected() {
+        return Object.entries(this.buildingHandles).some(([_, handle]) => handle.selected)
+    }
+
     /**
      * Cycles through all buildings
      */
@@ -161,22 +165,25 @@ export class HUDBaseToolbar extends BaseHUDPart {
 
         let newBuildingFound = false;
         let newIndex = this.lastSelectedIndex;
-        const direction = this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateInverseModifier).pressed
-            ? -1
-            : 1;
+        if (this.isBuildingSelected()) {
+            const direction = this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateInverseModifier).pressed
+                ? -1
+                : 1;
 
-        for (let i = 0; i <= this.primaryBuildings.length; ++i) {
-            newIndex = safeModulo(newIndex + direction, this.primaryBuildings.length);
-            const metaBuilding = gMetaBuildingRegistry.findByClass(this.primaryBuildings[newIndex]);
-            const handle = this.buildingHandles[metaBuilding.id];
-            if (!handle.selected && handle.unlocked) {
-                newBuildingFound = true;
-                break;
+            for (let i = 0; i <= this.primaryBuildings.length; ++i) {
+                newIndex = safeModulo(newIndex + direction, this.primaryBuildings.length);
+                const metaBuilding = gMetaBuildingRegistry.findByClass(this.primaryBuildings[newIndex]);
+                const handle = this.buildingHandles[metaBuilding.id];
+                if (!handle.selected && handle.unlocked) {
+                    newBuildingFound = true;
+                    break;
+                }
+            }
+            if (!newBuildingFound) {
+                return;
             }
         }
-        if (!newBuildingFound) {
-            return;
-        }
+
         const metaBuildingClass = this.primaryBuildings[newIndex];
         const metaBuilding = gMetaBuildingRegistry.findByClass(metaBuildingClass);
         this.selectBuildingForPlacement(metaBuilding);

--- a/src/js/game/hud/parts/base_toolbar.js
+++ b/src/js/game/hud/parts/base_toolbar.js
@@ -151,7 +151,7 @@ export class HUDBaseToolbar extends BaseHUDPart {
     }
 
     isBuildingSelected() {
-        return Object.entries(this.buildingHandles).some(([_, handle]) => handle.selected)
+        return Object.entries(this.buildingHandles).some(([_, handle]) => handle.selected);
     }
 
     /**
@@ -166,7 +166,8 @@ export class HUDBaseToolbar extends BaseHUDPart {
         let newBuildingFound = false;
         let newIndex = this.lastSelectedIndex;
         if (this.isBuildingSelected()) {
-            const direction = this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateInverseModifier).pressed
+            const direction = this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateInverseModifier)
+                .pressed
                 ? -1
                 : 1;
 

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -117,6 +117,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         keyActionMapper.getBinding(KEYMAPPINGS.general.back).add(this.abortPlacement, this);
         keyActionMapper.getBinding(KEYMAPPINGS.placement.pipette).add(this.startPipette, this);
         this.root.gameState.inputReciever.keyup.add(this.checkForDirectionLockSwitch, this);
+        keyActionMapper.getBinding(KEYMAPPINGS.placement.placeBuilding).add(this.tryPlaceCurrentBuildingAtCursor, this)
 
         // BINDINGS TO GAME EVENTS
         this.root.hud.signals.buildingsSelectedForCopy.add(this.abortPlacement, this);
@@ -130,6 +131,23 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         this.root.camera.downPreHandler.add(this.onMouseDown, this);
         this.root.camera.movePreHandler.add(this.onMouseMove, this);
         this.root.camera.upPostHandler.add(this.onMouseUp, this);
+    }
+
+    tryPlaceCurrentBuildingAtCursor() {
+        if (!this.currentMetaBuilding.get()) {
+            return;
+        }
+
+        const mousePosition = this.root.app.mousePosition;
+        if (!mousePosition) {
+            // Not on screen
+            return;
+        }
+
+        const worldPos = this.root.camera.screenToWorld(mousePosition);
+        const mouseTile = worldPos.toTileSpace();
+
+        this.tryPlaceCurrentBuildingAt(mouseTile);
     }
 
     /**

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -117,7 +117,9 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         keyActionMapper.getBinding(KEYMAPPINGS.general.back).add(this.abortPlacement, this);
         keyActionMapper.getBinding(KEYMAPPINGS.placement.pipette).add(this.startPipette, this);
         this.root.gameState.inputReciever.keyup.add(this.checkForDirectionLockSwitch, this);
-        keyActionMapper.getBinding(KEYMAPPINGS.placement.placeBuilding).add(this.tryPlaceCurrentBuildingAtCursor, this);
+        keyActionMapper
+            .getBinding(KEYMAPPINGS.placement.placeBuilding)
+            .add(this.tryPlaceCurrentBuildingAtCursor, this);
         keyActionMapper.getBinding(KEYMAPPINGS.placement.delete).add(this.tryDeleteBelowCursor, this);
 
         // BINDINGS TO GAME EVENTS

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -117,10 +117,8 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         keyActionMapper.getBinding(KEYMAPPINGS.general.back).add(this.abortPlacement, this);
         keyActionMapper.getBinding(KEYMAPPINGS.placement.pipette).add(this.startPipette, this);
         this.root.gameState.inputReciever.keyup.add(this.checkForDirectionLockSwitch, this);
-        keyActionMapper
-            .getBinding(KEYMAPPINGS.placement.placeBuilding)
-            .add(this.tryPlaceCurrentBuildingAtCursor, this);
-        keyActionMapper.getBinding(KEYMAPPINGS.placement.delete).add(this.tryDeleteBelowCursor, this);
+        this.root.gameState.inputReciever.keydown.add(this.onKeyDown, this);
+        this.root.gameState.inputReciever.keyup.add(this.onKeyUp, this);
 
         // BINDINGS TO GAME EVENTS
         this.root.hud.signals.buildingsSelectedForCopy.add(this.abortPlacement, this);
@@ -136,29 +134,44 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         this.root.camera.upPostHandler.add(this.onMouseUp, this);
     }
 
-    tryPlaceCurrentBuildingAtCursor() {
-        if (!this.currentMetaBuilding.get()) {
+    onKeyDown({ keyCode }) {
+        if (keyCode === this.root.keyMapper.getBinding(KEYMAPPINGS.placement.placeBuilding).keyCode) {
+            const mousePosition = this.root.app.mousePosition;
+            if (!mousePosition) {
+                // Not on screen
+                return;
+            }
+
+            this.onMouseDown(mousePosition, enumMouseButton.left);
             return;
         }
 
-        const mousePosition = this.root.app.mousePosition;
-        if (!mousePosition) {
-            // Not on screen
+        if (keyCode === this.root.keyMapper.getBinding(KEYMAPPINGS.placement.delete).keyCode) {
+            const mousePosition = this.root.app.mousePosition;
+            if (!mousePosition) {
+                // Not on screen
+                return;
+            }
+
+            if (this.currentMetaBuilding.get()) {
+                return;
+            }
+
+            this.onMouseDown(mousePosition, enumMouseButton.right);
             return;
         }
-
-        const worldPos = this.root.camera.screenToWorld(mousePosition);
-        const mouseTile = worldPos.toTileSpace();
-
-        this.tryPlaceCurrentBuildingAt(mouseTile);
     }
 
-    tryDeleteBelowCursor() {
-        if (this.currentMetaBuilding.get()) {
+    onKeyUp({ keyCode }) {
+        if (keyCode === this.root.keyMapper.getBinding(KEYMAPPINGS.placement.placeBuilding).keyCode) {
+            this.onMouseUp();
             return;
         }
 
-        this.deleteBelowCursor();
+        if (keyCode === this.root.keyMapper.getBinding(KEYMAPPINGS.placement.delete).keyCode) {
+            this.onMouseUp();
+            return;
+        }
     }
 
     /**

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -117,7 +117,8 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         keyActionMapper.getBinding(KEYMAPPINGS.general.back).add(this.abortPlacement, this);
         keyActionMapper.getBinding(KEYMAPPINGS.placement.pipette).add(this.startPipette, this);
         this.root.gameState.inputReciever.keyup.add(this.checkForDirectionLockSwitch, this);
-        keyActionMapper.getBinding(KEYMAPPINGS.placement.placeBuilding).add(this.tryPlaceCurrentBuildingAtCursor, this)
+        keyActionMapper.getBinding(KEYMAPPINGS.placement.placeBuilding).add(this.tryPlaceCurrentBuildingAtCursor, this);
+        keyActionMapper.getBinding(KEYMAPPINGS.placement.delete).add(this.tryDeleteBelowCursor, this);
 
         // BINDINGS TO GAME EVENTS
         this.root.hud.signals.buildingsSelectedForCopy.add(this.abortPlacement, this);
@@ -148,6 +149,14 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         const mouseTile = worldPos.toTileSpace();
 
         this.tryPlaceCurrentBuildingAt(mouseTile);
+    }
+
+    tryDeleteBelowCursor() {
+        if (this.currentMetaBuilding.get()) {
+            return;
+        }
+
+        this.deleteBelowCursor();
     }
 
     /**

--- a/src/js/game/hud/parts/keybinding_overlay.js
+++ b/src/js/game/hud/parts/keybinding_overlay.js
@@ -195,7 +195,7 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
             {
                 // Place building
                 label: T.ingame.keybindingsOverlay.placeBuilding,
-                keys: [KEYCODE_LMB],
+                keys: [k.placement.placeBuilding],
                 condition: () => this.anyPlacementActive,
             },
 

--- a/src/js/game/hud/parts/keybinding_overlay.js
+++ b/src/js/game/hud/parts/keybinding_overlay.js
@@ -173,7 +173,7 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
             {
                 // Delete with right click
                 label: T.ingame.keybindingsOverlay.delete,
-                keys: [KEYCODE_RMB],
+                keys: [KEYCODE_RMB, DIVIDER_TOKEN, k.placement.delete],
                 condition: () =>
                     !this.anyPlacementActive && !this.mapOverviewActive && !this.anythingSelectedOnMap,
             },
@@ -195,7 +195,7 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
             {
                 // Place building
                 label: T.ingame.keybindingsOverlay.placeBuilding,
-                keys: [k.placement.placeBuilding],
+                keys: [KEYCODE_LMB, DIVIDER_TOKEN, k.placement.placeBuilding],
                 condition: () => this.anyPlacementActive,
             },
 
@@ -299,7 +299,7 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
                         break;
                     default:
                         html += `<code class="keybinding">${getStringForKeyCode(
-                            mapper.getBinding(/** @type {KeyCode} */ (key)).keyCode
+                            mapper.getBinding(/** @type {KeyCode} */(key)).keyCode
                         )}</code>`;
                 }
             }

--- a/src/js/game/hud/parts/keybinding_overlay.js
+++ b/src/js/game/hud/parts/keybinding_overlay.js
@@ -299,7 +299,7 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
                         break;
                     default:
                         html += `<code class="keybinding">${getStringForKeyCode(
-                            mapper.getBinding(/** @type {KeyCode} */(key)).keyCode
+                            mapper.getBinding(/** @type {KeyCode} */ (key)).keyCode
                         )}</code>`;
                 }
             }

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -83,6 +83,7 @@ export const KEYMAPPINGS = {
 
     placement: {
         placeBuilding: { keyCode: KEYCODE_LMB },
+        delete: { keyCode: KEYCODE_RMB },
         pipette: { keyCode: key("Q") },
         rotateWhilePlacing: { keyCode: key("R") },
         rotateInverseModifier: { keyCode: 16 }, // SHIFT

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -11,6 +11,10 @@ function key(str) {
     return str.toUpperCase().charCodeAt(0);
 }
 
+export const KEYCODE_LMB = 1;
+export const KEYCODE_MMB = 2;
+export const KEYCODE_RMB = 3;
+
 export const KEYMAPPINGS = {
     general: {
         confirm: { keyCode: 13 }, // enter
@@ -78,6 +82,7 @@ export const KEYMAPPINGS = {
     },
 
     placement: {
+        placeBuilding: { keyCode: KEYCODE_LMB },
         pipette: { keyCode: key("Q") },
         rotateWhilePlacing: { keyCode: key("R") },
         rotateInverseModifier: { keyCode: 16 }, // SHIFT
@@ -111,10 +116,6 @@ for (const categoryId in KEYMAPPINGS) {
         KEYMAPPINGS[categoryId][mappingId].id = mappingId;
     }
 }
-
-export const KEYCODE_LMB = 1;
-export const KEYCODE_MMB = 2;
-export const KEYCODE_RMB = 3;
 
 /**
  * Returns a keycode -> string
@@ -261,6 +262,32 @@ export function getStringForKeyCode(code) {
             return "]";
         case 222:
             return "'";
+
+        // Xbox Gamepad
+        case 300:
+            return "🎮 A";
+        case 301:
+            return "🎮 B";
+        case 302:
+            return "🎮 X";
+        case 303:
+            return "🎮 Y";
+        case 304:
+            return "🎮 LB";
+        case 305:
+            return "🎮 RB";
+        case 306:
+            return "🎮 LT";
+        case 307:
+            return "🎮 RT";
+        case 312:
+            return "🎮 ⬆";
+        case 313:
+            return "🎮 ⬇";
+        case 314:
+            return "🎮 ⬅";
+        case 315:
+            return "🎮 ➡";
     }
 
     return (48 <= code && code <= 57) || (65 <= code && code <= 90)

--- a/src/js/states/keybindings.js
+++ b/src/js/states/keybindings.js
@@ -117,7 +117,7 @@ export class KeybindingsState extends TextualGameState {
             this.updateKeybindings();
         });
 
-        dialog.inputReciever.backButton.add(() => { });
+        dialog.inputReciever.backButton.add(() => {});
         this.dialogs.internalShowDialog(dialog);
 
         this.app.sound.playUiSound(SOUNDS.dialogOk);

--- a/src/js/states/keybindings.js
+++ b/src/js/states/keybindings.js
@@ -99,7 +99,7 @@ export class KeybindingsState extends TextualGameState {
                 event.preventDefault();
             }
 
-            if (event.target && event.target.tagName === "BUTTON" && keyCode === 1) {
+            if (event && event.target && event.target.tagName === "BUTTON" && keyCode === 1) {
                 return;
             }
 
@@ -117,7 +117,7 @@ export class KeybindingsState extends TextualGameState {
             this.updateKeybindings();
         });
 
-        dialog.inputReciever.backButton.add(() => {});
+        dialog.inputReciever.backButton.add(() => { });
         this.dialogs.internalShowDialog(dialog);
 
         this.app.sound.playUiSound(SOUNDS.dialogOk);

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -1181,6 +1181,7 @@ keybindings:
     placementDisableAutoOrientation: Disable automatic orientation
     placeMultiple: Stay in placement mode
     placeInverse: Invert automatic belt orientation
+    delete: Delete Building
 
 about:
   title: About this Game

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -21,1247 +21,1247 @@
 
 ---
 steamPage:
-  # This is the short text appearing on the steam page
-  shortText: shapez.io is a game about building factories to automate the creation and processing of increasingly complex shapes across an infinitely expanding map.
+    # This is the short text appearing on the steam page
+    shortText: shapez.io is a game about building factories to automate the creation and processing of increasingly complex shapes across an infinitely expanding map.
 
-  # This is the text shown above the Discord link
-  discordLinkShort: Official Discord
+    # This is the text shown above the Discord link
+    discordLinkShort: Official Discord
 
-  intro: >-
-    Do you like automation games? Then you are in the right place!
+    intro: >-
+        Do you like automation games? Then you are in the right place!
 
-    shapez.io is a relaxed game in which you have to build factories for the automated production of geometric shapes. As the level increases, the shapes become more and more complex, and you
-    have to spread out on the infinite map.
+        shapez.io is a relaxed game in which you have to build factories for the automated production of geometric shapes. As the level increases, the shapes become more and more complex, and you
+        have to spread out on the infinite map.
 
-    And as if that wasn't enough, you also have to produce exponentially more to satisfy the demands - the only thing that helps is scaling! While you only have to process shapes at the
-    beginning, you will later have to color them - by extracting and mixing colors!
+        And as if that wasn't enough, you also have to produce exponentially more to satisfy the demands - the only thing that helps is scaling! While you only have to process shapes at the
+        beginning, you will later have to color them - by extracting and mixing colors!
 
-    Buying the game on Steam gives you access to the full version, but you can also play a demo at shapez.io first and decide later!
+        Buying the game on Steam gives you access to the full version, but you can also play a demo at shapez.io first and decide later!
 
-  title_advantages: Standalone Advantages
-  advantages:
-    - <b>12 New Levels</b> for a total of 26 levels
-    - <b>18 New Buildings</b> for a fully automated factory!
-    - <b>Unlimited Upgrade Tiers</b> for many hours of fun!
-    - <b>Wires Update</b> for an entirely new dimension!
-    - <b>Dark Mode</b>!
-    - Unlimited Savegames
-    - Unlimited Markers
-    - Support me! ❤️
+    title_advantages: Standalone Advantages
+    advantages:
+        - <b>12 New Levels</b> for a total of 26 levels
+        - <b>18 New Buildings</b> for a fully automated factory!
+        - <b>Unlimited Upgrade Tiers</b> for many hours of fun!
+        - <b>Wires Update</b> for an entirely new dimension!
+        - <b>Dark Mode</b>!
+        - Unlimited Savegames
+        - Unlimited Markers
+        - Support me! ❤️
 
-  title_future: Planned Content
-  planned:
-    - Blueprint Library
-    - Steam Achievements
-    - Puzzle Mode
-    - Minimap
-    - Mods
-    - Sandbox mode
-    - ... and a lot more!
+    title_future: Planned Content
+    planned:
+        - Blueprint Library
+        - Steam Achievements
+        - Puzzle Mode
+        - Minimap
+        - Mods
+        - Sandbox mode
+        - ... and a lot more!
 
-  title_open_source: This game is open source!
-  text_open_source: >-
-    Anybody can contribute, I'm actively involved in the community and attempt to review all suggestions and take feedback into consideration where possible.
+    title_open_source: This game is open source!
+    text_open_source: >-
+        Anybody can contribute, I'm actively involved in the community and attempt to review all suggestions and take feedback into consideration where possible.
 
-    Be sure to check out my trello board for the full roadmap!
+        Be sure to check out my trello board for the full roadmap!
 
-  title_links: Links
+    title_links: Links
 
-  links:
-    discord: Official Discord
-    roadmap: Roadmap
-    subreddit: Subreddit
-    source_code: Source code (GitHub)
-    translate: Help translate
+    links:
+        discord: Official Discord
+        roadmap: Roadmap
+        subreddit: Subreddit
+        source_code: Source code (GitHub)
+        translate: Help translate
 
 global:
-  loading: Loading
-  error: Error
+    loading: Loading
+    error: Error
 
-  # How big numbers are rendered, e.g. "10,000"
-  thousandsDivider: ","
+    # How big numbers are rendered, e.g. "10,000"
+    thousandsDivider: ","
 
-  # What symbol to use to separate the integer part from the fractional part of a number, e.g. "0.4"
-  decimalSeparator: "."
+    # What symbol to use to separate the integer part from the fractional part of a number, e.g. "0.4"
+    decimalSeparator: "."
 
-  # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
-  suffix:
-    thousands: k
-    millions: M
-    billions: B
-    trillions: T
+    # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
+    suffix:
+        thousands: k
+        millions: M
+        billions: B
+        trillions: T
 
-  # Shown for infinitely big numbers
-  infinite: inf
+    # Shown for infinitely big numbers
+    infinite: inf
 
-  time:
-    # Used for formatting past time dates
-    oneSecondAgo: one second ago
-    xSecondsAgo: <x> seconds ago
-    oneMinuteAgo: one minute ago
-    xMinutesAgo: <x> minutes ago
-    oneHourAgo: one hour ago
-    xHoursAgo: <x> hours ago
-    oneDayAgo: one day ago
-    xDaysAgo: <x> days ago
+    time:
+        # Used for formatting past time dates
+        oneSecondAgo: one second ago
+        xSecondsAgo: <x> seconds ago
+        oneMinuteAgo: one minute ago
+        xMinutesAgo: <x> minutes ago
+        oneHourAgo: one hour ago
+        xHoursAgo: <x> hours ago
+        oneDayAgo: one day ago
+        xDaysAgo: <x> days ago
 
-    # Short formats for times, e.g. '5h 23m'
-    secondsShort: <seconds>s
-    minutesAndSecondsShort: <minutes>m <seconds>s
-    hoursAndMinutesShort: <hours>h <minutes>m
+        # Short formats for times, e.g. '5h 23m'
+        secondsShort: <seconds>s
+        minutesAndSecondsShort: <minutes>m <seconds>s
+        hoursAndMinutesShort: <hours>h <minutes>m
 
-    xMinutes: <x> minutes
+        xMinutes: <x> minutes
 
-  keys:
-    tab: TAB
-    control: CTRL
-    alt: ALT
-    escape: ESC
-    shift: SHIFT
-    space: SPACE
+    keys:
+        tab: TAB
+        control: CTRL
+        alt: ALT
+        escape: ESC
+        shift: SHIFT
+        space: SPACE
 
 demoBanners:
-  # This is the "advertisement" shown in the main menu and other various places
-  title: Demo Version
-  intro: >-
-    Get the full game to unlock all features and content!
+    # This is the "advertisement" shown in the main menu and other various places
+    title: Demo Version
+    intro: >-
+        Get the full game to unlock all features and content!
 
 mainMenu:
-  play: Play
-  continue: Continue
-  newGame: New Game
-  changelog: Changelog
-  subreddit: Reddit
-  importSavegame: Import
-  openSourceHint: This game is open source!
-  discordLink: Official Discord Server
-  helpTranslate: Help translate!
-  madeBy: Made by <author-link>
+    play: Play
+    continue: Continue
+    newGame: New Game
+    changelog: Changelog
+    subreddit: Reddit
+    importSavegame: Import
+    openSourceHint: This game is open source!
+    discordLink: Official Discord Server
+    helpTranslate: Help translate!
+    madeBy: Made by <author-link>
 
-  # This is shown when using firefox and other browsers which are not supported.
-  browserWarning: >-
-    Sorry, but the game is known to run slowly on your browser! Get the standalone version or download Google Chrome for the full experience.
+    # This is shown when using firefox and other browsers which are not supported.
+    browserWarning: >-
+        Sorry, but the game is known to run slowly on your browser! Get the standalone version or download Google Chrome for the full experience.
 
-  savegameLevel: Level <x>
-  savegameLevelUnknown: Unknown Level
-  savegameUnnamed: Unnamed
+    savegameLevel: Level <x>
+    savegameLevelUnknown: Unknown Level
+    savegameUnnamed: Unnamed
 
 dialogs:
-  buttons:
-    ok: OK
-    delete: Delete
-    cancel: Cancel
-    later: Later
-    restart: Restart
-    reset: Reset
-    getStandalone: Get Standalone
-    deleteGame: I know what I am doing
-    viewUpdate: View Update
-    showUpgrades: Show Upgrades
-    showKeybindings: Show Keybindings
+    buttons:
+        ok: OK
+        delete: Delete
+        cancel: Cancel
+        later: Later
+        restart: Restart
+        reset: Reset
+        getStandalone: Get Standalone
+        deleteGame: I know what I am doing
+        viewUpdate: View Update
+        showUpgrades: Show Upgrades
+        showKeybindings: Show Keybindings
 
-  importSavegameError:
-    title: Import Error
-    text: >-
-      Failed to import your savegame:
+    importSavegameError:
+        title: Import Error
+        text: >-
+            Failed to import your savegame:
 
-  importSavegameSuccess:
-    title: Savegame Imported
-    text: >-
-      Your savegame has been successfully imported.
+    importSavegameSuccess:
+        title: Savegame Imported
+        text: >-
+            Your savegame has been successfully imported.
 
-  gameLoadFailure:
-    title: Game is broken
-    text: >-
-      Failed to load your savegame:
+    gameLoadFailure:
+        title: Game is broken
+        text: >-
+            Failed to load your savegame:
 
-  confirmSavegameDelete:
-    title: Confirm deletion
-    text: >-
-      Are you sure you want to delete the following game?<br><br>
-      '<savegameName>' at level <savegameLevel><br><br>
-      This can not be undone!
+    confirmSavegameDelete:
+        title: Confirm deletion
+        text: >-
+            Are you sure you want to delete the following game?<br><br>
+            '<savegameName>' at level <savegameLevel><br><br>
+            This can not be undone!
 
-  savegameDeletionError:
-    title: Failed to delete
-    text: >-
-      Failed to delete the savegame:
+    savegameDeletionError:
+        title: Failed to delete
+        text: >-
+            Failed to delete the savegame:
 
-  restartRequired:
-    title: Restart required
-    text: >-
-      You need to restart the game to apply the settings.
+    restartRequired:
+        title: Restart required
+        text: >-
+            You need to restart the game to apply the settings.
 
-  editKeybinding:
-    title: Change Keybinding
-    desc: Press the key or mouse button you want to assign, or escape to cancel.
+    editKeybinding:
+        title: Change Keybinding
+        desc: Press the key or mouse button you want to assign, or escape to cancel.
 
-  resetKeybindingsConfirmation:
-    title: Reset keybindings
-    desc: This will reset all keybindings to their default values. Please confirm.
+    resetKeybindingsConfirmation:
+        title: Reset keybindings
+        desc: This will reset all keybindings to their default values. Please confirm.
 
-  keybindingsResetOk:
-    title: Keybindings reset
-    desc: All keybindings have been reset to their defaults values!
+    keybindingsResetOk:
+        title: Keybindings reset
+        desc: All keybindings have been reset to their defaults values!
 
-  featureRestriction:
-    title: Demo Version
-    desc: You tried to access a feature (<feature>) which is not available in the demo. Consider getting the standalone version for the full experience!
+    featureRestriction:
+        title: Demo Version
+        desc: You tried to access a feature (<feature>) which is not available in the demo. Consider getting the standalone version for the full experience!
 
-  oneSavegameLimit:
-    title: Limited savegames
-    desc: You can only have one savegame at a time in the demo version. Please remove the existing one or get the standalone version!
+    oneSavegameLimit:
+        title: Limited savegames
+        desc: You can only have one savegame at a time in the demo version. Please remove the existing one or get the standalone version!
 
-  updateSummary:
-    title: New update!
-    desc: >-
-      Here are the changes since you last played:
+    updateSummary:
+        title: New update!
+        desc: >-
+            Here are the changes since you last played:
 
-  upgradesIntroduction:
-    title: Unlock Upgrades
-    desc: >-
-      All shapes you produce can be used to unlock upgrades - <strong>don't destroy your old factories!</strong>
-      The upgrades tab can be found on the top right corner of the screen.
+    upgradesIntroduction:
+        title: Unlock Upgrades
+        desc: >-
+            All shapes you produce can be used to unlock upgrades - <strong>don't destroy your old factories!</strong>
+            The upgrades tab can be found on the top right corner of the screen.
 
-  massDeleteConfirm:
-    title: Confirm delete
-    desc: >-
-      You are deleting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
+    massDeleteConfirm:
+        title: Confirm delete
+        desc: >-
+            You are deleting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
 
-  massCutConfirm:
-    title: Confirm cut
-    desc: >-
-      You are cutting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
+    massCutConfirm:
+        title: Confirm cut
+        desc: >-
+            You are cutting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
 
-  massCutInsufficientConfirm:
-    title: Confirm cut
-    desc: >-
-      You can not afford to paste this area! Are you sure you want to cut it?
+    massCutInsufficientConfirm:
+        title: Confirm cut
+        desc: >-
+            You can not afford to paste this area! Are you sure you want to cut it?
 
-  blueprintsNotUnlocked:
-    title: Not unlocked yet
-    desc: >-
-      Complete level 12 to unlock Blueprints!
+    blueprintsNotUnlocked:
+        title: Not unlocked yet
+        desc: >-
+            Complete level 12 to unlock Blueprints!
 
-  keybindingsIntroduction:
-    title: Useful keybindings
-    desc: >-
-      This game has a lot of keybindings which make it easier to build big factories.
-      Here are a few, but be sure to <strong>check out the keybindings</strong>!<br><br>
-      <code class='keybinding'>CTRL</code> + Drag: Select an area.<br>
-      <code class='keybinding'>SHIFT</code>: Hold to place multiple of one building.<br>
-      <code class='keybinding'>ALT</code>: Invert orientation of placed belts.<br>
+    keybindingsIntroduction:
+        title: Useful keybindings
+        desc: >-
+            This game has a lot of keybindings which make it easier to build big factories.
+            Here are a few, but be sure to <strong>check out the keybindings</strong>!<br><br>
+            <code class='keybinding'>CTRL</code> + Drag: Select an area.<br>
+            <code class='keybinding'>SHIFT</code>: Hold to place multiple of one building.<br>
+            <code class='keybinding'>ALT</code>: Invert orientation of placed belts.<br>
 
-  createMarker:
-    title: New Marker
-    titleEdit: Edit Marker
-    desc: Give it a meaningful name, you can also include a <strong>short key</strong> of a shape (Which you can generate <link>here</link>)
+    createMarker:
+        title: New Marker
+        titleEdit: Edit Marker
+        desc: Give it a meaningful name, you can also include a <strong>short key</strong> of a shape (Which you can generate <link>here</link>)
 
-  editSignal:
-    title: Set Signal
-    descItems: >-
-      Choose a pre-defined item:
-    descShortKey: ... or enter the <strong>short key</strong> of a shape (Which you can generate <link>here</link>)
+    editSignal:
+        title: Set Signal
+        descItems: >-
+            Choose a pre-defined item:
+        descShortKey: ... or enter the <strong>short key</strong> of a shape (Which you can generate <link>here</link>)
 
-  markerDemoLimit:
-    desc: You can only create two custom markers in the demo. Get the standalone for unlimited markers!
+    markerDemoLimit:
+        desc: You can only create two custom markers in the demo. Get the standalone for unlimited markers!
 
-  exportScreenshotWarning:
-    title: Export screenshot
-    desc: You requested to export your base as a screenshot. Please note that this will be quite slow for a bigger base and could potentially crash your game!
+    exportScreenshotWarning:
+        title: Export screenshot
+        desc: You requested to export your base as a screenshot. Please note that this will be quite slow for a bigger base and could potentially crash your game!
 
-  renameSavegame:
-    title: Rename Savegame
-    desc: You can rename your savegame here.
+    renameSavegame:
+        title: Rename Savegame
+        desc: You can rename your savegame here.
 
-  tutorialVideoAvailable:
-    title: Tutorial Available
-    desc: There is a tutorial video available for this level! Would you like to watch it?
+    tutorialVideoAvailable:
+        title: Tutorial Available
+        desc: There is a tutorial video available for this level! Would you like to watch it?
 
-  tutorialVideoAvailableForeignLanguage:
-    title: Tutorial Available
-    desc: There is a tutorial video available for this level, but it is only available in English. Would you like to watch it?
+    tutorialVideoAvailableForeignLanguage:
+        title: Tutorial Available
+        desc: There is a tutorial video available for this level, but it is only available in English. Would you like to watch it?
 
 ingame:
-  # This is shown in the top left corner and displays useful keybindings in
-  # every situation
-  keybindingsOverlay:
-    moveMap: Move
-    selectBuildings: Select area
-    stopPlacement: Stop placement
-    rotateBuilding: Rotate building
-    placeMultiple: Place multiple
-    reverseOrientation: Reverse orientation
-    disableAutoOrientation: Disable auto-orientation
-    toggleHud: Toggle HUD
-    placeBuilding: Place building
-    createMarker: Create marker
-    delete: Delete
-    pasteLastBlueprint: Paste last blueprint
-    lockBeltDirection: Enable belt planner
-    plannerSwitchSide: Flip planner side
-    cutSelection: Cut
-    copySelection: Copy
-    clearSelection: Clear selection
-    pipette: Pipette
-    switchLayers: Switch layers
+    # This is shown in the top left corner and displays useful keybindings in
+    # every situation
+    keybindingsOverlay:
+        moveMap: Move
+        selectBuildings: Select area
+        stopPlacement: Stop placement
+        rotateBuilding: Rotate building
+        placeMultiple: Place multiple
+        reverseOrientation: Reverse orientation
+        disableAutoOrientation: Disable auto-orientation
+        toggleHud: Toggle HUD
+        placeBuilding: Place building
+        createMarker: Create marker
+        delete: Delete
+        pasteLastBlueprint: Paste last blueprint
+        lockBeltDirection: Enable belt planner
+        plannerSwitchSide: Flip planner side
+        cutSelection: Cut
+        copySelection: Copy
+        clearSelection: Clear selection
+        pipette: Pipette
+        switchLayers: Switch layers
 
-  # Names of the colors, used for the color blind mode
-  colors:
-    red: Red
-    green: Green
-    blue: Blue
-    yellow: Yellow
-    purple: Magenta
-    cyan: Cyan
-    white: White
-    black: Black
-    uncolored: Gray
+    # Names of the colors, used for the color blind mode
+    colors:
+        red: Red
+        green: Green
+        blue: Blue
+        yellow: Yellow
+        purple: Magenta
+        cyan: Cyan
+        white: White
+        black: Black
+        uncolored: Gray
 
-  # Everything related to placing buildings (I.e. as soon as you selected a building
-  # from the toolbar)
-  buildingPlacement:
-    # Buildings can have different variants which are unlocked at later levels,
-    # and this is the hint shown when there are multiple variants available.
-    cycleBuildingVariants: Press <key> to cycle variants.
+    # Everything related to placing buildings (I.e. as soon as you selected a building
+    # from the toolbar)
+    buildingPlacement:
+        # Buildings can have different variants which are unlocked at later levels,
+        # and this is the hint shown when there are multiple variants available.
+        cycleBuildingVariants: Press <key> to cycle variants.
 
-    # Shows the hotkey in the ui, e.g. "Hotkey: Q"
-    hotkeyLabel: >-
-      Hotkey: <key>
+        # Shows the hotkey in the ui, e.g. "Hotkey: Q"
+        hotkeyLabel: >-
+            Hotkey: <key>
 
-    infoTexts:
-      speed: Speed
-      range: Range
-      storage: Capacity
-      oneItemPerSecond: 1 item / second
-      itemsPerSecond: <x> items / s
-      itemsPerSecondDouble: (x2)
+        infoTexts:
+            speed: Speed
+            range: Range
+            storage: Capacity
+            oneItemPerSecond: 1 item / second
+            itemsPerSecond: <x> items / s
+            itemsPerSecondDouble: (x2)
 
-      tiles: <x> tiles
+            tiles: <x> tiles
 
-  # The notification when completing a level
-  levelCompleteNotification:
-    # <level> is replaced by the actual level, so this gets 'Level 03' for example.
-    levelTitle: Level <level>
-    completed: Completed
-    unlockText: Unlocked <reward>!
-    buttonNextLevel: Next Level
+    # The notification when completing a level
+    levelCompleteNotification:
+        # <level> is replaced by the actual level, so this gets 'Level 03' for example.
+        levelTitle: Level <level>
+        completed: Completed
+        unlockText: Unlocked <reward>!
+        buttonNextLevel: Next Level
 
-  # Notifications on the lower right
-  notifications:
-    newUpgrade: A new upgrade is available!
-    gameSaved: Your game has been saved.
-    freeplayLevelComplete: Level <level> has been completed!
+    # Notifications on the lower right
+    notifications:
+        newUpgrade: A new upgrade is available!
+        gameSaved: Your game has been saved.
+        freeplayLevelComplete: Level <level> has been completed!
 
-  # The "Upgrades" window
-  shop:
-    title: Upgrades
-    buttonUnlock: Upgrade
+    # The "Upgrades" window
+    shop:
+        title: Upgrades
+        buttonUnlock: Upgrade
 
-    # Gets replaced to e.g. "Tier IX"
-    tier: Tier <x>
+        # Gets replaced to e.g. "Tier IX"
+        tier: Tier <x>
 
-    maximumLevel: MAXIMUM LEVEL (Speed x<currentMult>)
+        maximumLevel: MAXIMUM LEVEL (Speed x<currentMult>)
 
-  # The "Statistics" window
-  statistics:
-    title: Statistics
-    dataSources:
-      stored:
-        title: Stored
-        description: All shapes stored within the Hub.
-      produced:
-        title: Produced
-        description: All shapes produced within your factory, including intermediate products.
-      delivered:
-        title: Delivered
-        description: Shapes which are being delivered to the Hub.
-    noShapesProduced: No shapes have been produced so far.
+    # The "Statistics" window
+    statistics:
+        title: Statistics
+        dataSources:
+            stored:
+                title: Stored
+                description: All shapes stored within the Hub.
+            produced:
+                title: Produced
+                description: All shapes produced within your factory, including intermediate products.
+            delivered:
+                title: Delivered
+                description: Shapes which are being delivered to the Hub.
+        noShapesProduced: No shapes have been produced so far.
 
-    # Displays the shapes per second, e.g. '523 / s'
-    shapesDisplayUnits:
-      second: <shapes> / s
-      minute: <shapes> / m
-      hour: <shapes> / h
+        # Displays the shapes per second, e.g. '523 / s'
+        shapesDisplayUnits:
+            second: <shapes> / s
+            minute: <shapes> / m
+            hour: <shapes> / h
 
-  # Settings menu, when you press "ESC"
-  settingsMenu:
-    playtime: Playtime
-    buildingsPlaced: Buildings
-    beltsPlaced: Belts
+    # Settings menu, when you press "ESC"
+    settingsMenu:
+        playtime: Playtime
+        buildingsPlaced: Buildings
+        beltsPlaced: Belts
 
-  # Bottom left tutorial hints
-  tutorialHints:
-    title: Need help?
-    showHint: Show hint
-    hideHint: Close
+    # Bottom left tutorial hints
+    tutorialHints:
+        title: Need help?
+        showHint: Show hint
+        hideHint: Close
 
-  # When placing a blueprint
-  blueprintPlacer:
-    cost: Cost
+    # When placing a blueprint
+    blueprintPlacer:
+        cost: Cost
 
-  # Map markers
-  waypoints:
-    waypoints: Markers
-    hub: HUB
-    description: >-
-      Left-click a marker to jump to it, right-click to delete it.<br><br>Press <keybinding> to create a marker from the current view, or <strong>right-click</strong> to create a marker at the
-      selected location.
-    creationSuccessNotification: Marker has been created.
+    # Map markers
+    waypoints:
+        waypoints: Markers
+        hub: HUB
+        description: >-
+            Left-click a marker to jump to it, right-click to delete it.<br><br>Press <keybinding> to create a marker from the current view, or <strong>right-click</strong> to create a marker at the
+            selected location.
+        creationSuccessNotification: Marker has been created.
 
-  # Shape viewer
-  shapeViewer:
-    title: Layers
-    empty: Empty
-    copyKey: Copy Key
+    # Shape viewer
+    shapeViewer:
+        title: Layers
+        empty: Empty
+        copyKey: Copy Key
 
-  # Interactive tutorial
-  interactiveTutorial:
-    title: Tutorial
-    hints:
-      1_1_extractor: Place an <strong>extractor</strong> on top of a <strong>circle shape</strong> to extract it!
-      1_2_conveyor: >-
-        Connect the extractor with a <strong>conveyor belt</strong> to your hub!<br><br>Tip: <strong>Click and drag</strong> the belt with your mouse!
+    # Interactive tutorial
+    interactiveTutorial:
+        title: Tutorial
+        hints:
+            1_1_extractor: Place an <strong>extractor</strong> on top of a <strong>circle shape</strong> to extract it!
+            1_2_conveyor: >-
+                Connect the extractor with a <strong>conveyor belt</strong> to your hub!<br><br>Tip: <strong>Click and drag</strong> the belt with your mouse!
 
-      1_3_expand: >-
-        This is <strong>NOT</strong> an idle game! Build more extractors and belts to finish the goal quicker.<br><br>Tip: Hold <strong>SHIFT</strong> to place multiple extractors, and use
-        <strong>R</strong> to rotate them.
+            1_3_expand: >-
+                This is <strong>NOT</strong> an idle game! Build more extractors and belts to finish the goal quicker.<br><br>Tip: Hold <strong>SHIFT</strong> to place multiple extractors, and use
+                <strong>R</strong> to rotate them.
 
-      2_1_place_cutter: >-
-        Now place a <strong>Cutter</strong> to cut the circles in two halves!<br><br>
-        PS: The cutter always cuts from <strong>top to bottom</strong> regardless of its orientation.
+            2_1_place_cutter: >-
+                Now place a <strong>Cutter</strong> to cut the circles in two halves!<br><br>
+                PS: The cutter always cuts from <strong>top to bottom</strong> regardless of its orientation.
 
-      2_2_place_trash: >-
-        The cutter can <strong>clog and stall</strong>!<br><br>
-        Use a <strong>trash</strong> to get rid of the currently (!) not needed waste.
+            2_2_place_trash: >-
+                The cutter can <strong>clog and stall</strong>!<br><br>
+                Use a <strong>trash</strong> to get rid of the currently (!) not needed waste.
 
-      2_3_more_cutters: >-
-        Good job! Now place <strong>2 more cutters</strong> to speed up this slow process!<br><br>
-        PS: Use the <strong>0-9 hotkeys</strong> to access buildings faster!
+            2_3_more_cutters: >-
+                Good job! Now place <strong>2 more cutters</strong> to speed up this slow process!<br><br>
+                PS: Use the <strong>0-9 hotkeys</strong> to access buildings faster!
 
-      3_1_rectangles: >-
-        Now let's extract some rectangles! <strong>Build 4 extractors</strong> and connect them to the hub.<br><br>
-        PS: Hold <strong>SHIFT</strong> while dragging a belt to activate the belt planner!
+            3_1_rectangles: >-
+                Now let's extract some rectangles! <strong>Build 4 extractors</strong> and connect them to the hub.<br><br>
+                PS: Hold <strong>SHIFT</strong> while dragging a belt to activate the belt planner!
 
-      21_1_place_quad_painter: >-
-        Place the <strong>quad painter</strong> and get some <strong>circles</strong>, <strong>white</strong> and <strong>red</strong> color!
+            21_1_place_quad_painter: >-
+                Place the <strong>quad painter</strong> and get some <strong>circles</strong>, <strong>white</strong> and <strong>red</strong> color!
 
-      21_2_switch_to_wires: >-
-        Switch to the wires layer by pressing <strong>E</strong>!<br><br>
-        Then <strong>connect all four inputs</strong> of the painter with cables!
+            21_2_switch_to_wires: >-
+                Switch to the wires layer by pressing <strong>E</strong>!<br><br>
+                Then <strong>connect all four inputs</strong> of the painter with cables!
 
-      21_3_place_button: >-
-        Awesome! Now place a <strong>Switch</strong> and connect it with wires!
+            21_3_place_button: >-
+                Awesome! Now place a <strong>Switch</strong> and connect it with wires!
 
-      21_4_press_button: >-
-        Press the switch to make it <strong>emit a truthy signal</strong> and thus activate the painter.<br><br>
-        PS: You don't have to connect all inputs! Try wiring only two.
+            21_4_press_button: >-
+                Press the switch to make it <strong>emit a truthy signal</strong> and thus activate the painter.<br><br>
+                PS: You don't have to connect all inputs! Try wiring only two.
 
-  # Connected miners
-  connectedMiners:
-    one_miner: 1 Extractor
-    n_miners: <amount> Extractors
-    limited_items: Limited to <max_throughput>
+    # Connected miners
+    connectedMiners:
+        one_miner: 1 Extractor
+        n_miners: <amount> Extractors
+        limited_items: Limited to <max_throughput>
 
-  # Pops up in the demo every few minutes
-  watermark:
-    title: Demo version
-    desc: Click here to see the advantages of the standalone version!
-    get_on_steam: Get on Steam
+    # Pops up in the demo every few minutes
+    watermark:
+        title: Demo version
+        desc: Click here to see the advantages of the standalone version!
+        get_on_steam: Get on Steam
 
-  standaloneAdvantages:
-    title: Get the full version!
-    no_thanks: No, thanks!
+    standaloneAdvantages:
+        title: Get the full version!
+        no_thanks: No, thanks!
 
-    points:
-      levels:
-        title: 12 New Levels
-        desc: For a total of 26 levels!
+        points:
+            levels:
+                title: 12 New Levels
+                desc: For a total of 26 levels!
 
-      buildings:
-        title: 18 New Buildings
-        desc: Fully automate your factory!
+            buildings:
+                title: 18 New Buildings
+                desc: Fully automate your factory!
 
-      savegames:
-        title: ∞ Savegames
-        desc: As many as your heart desires!
+            savegames:
+                title: ∞ Savegames
+                desc: As many as your heart desires!
 
-      upgrades:
-        title: ∞ Upgrade Tiers
-        desc: This demo version has only 5!
+            upgrades:
+                title: ∞ Upgrade Tiers
+                desc: This demo version has only 5!
 
-      markers:
-        title: ∞ Markers
-        desc: Never get lost in your factory!
+            markers:
+                title: ∞ Markers
+                desc: Never get lost in your factory!
 
-      wires:
-        title: Wires
-        desc: An entirely new dimension!
+            wires:
+                title: Wires
+                desc: An entirely new dimension!
 
-      darkmode:
-        title: Dark Mode
-        desc: Stop hurting your eyes!
+            darkmode:
+                title: Dark Mode
+                desc: Stop hurting your eyes!
 
-      support:
-        title: Support me
-        desc: I develop the game in my spare time!
+            support:
+                title: Support me
+                desc: I develop the game in my spare time!
 
 # All shop upgrades
 shopUpgrades:
-  belt:
-    name: Belts, Distributor & Tunnels
-    description: Speed x<currentMult> → x<newMult>
-  miner:
-    name: Extraction
-    description: Speed x<currentMult> → x<newMult>
-  processors:
-    name: Cutting, Rotating & Stacking
-    description: Speed x<currentMult> → x<newMult>
-  painting:
-    name: Mixing & Painting
-    description: Speed x<currentMult> → x<newMult>
+    belt:
+        name: Belts, Distributor & Tunnels
+        description: Speed x<currentMult> → x<newMult>
+    miner:
+        name: Extraction
+        description: Speed x<currentMult> → x<newMult>
+    processors:
+        name: Cutting, Rotating & Stacking
+        description: Speed x<currentMult> → x<newMult>
+    painting:
+        name: Mixing & Painting
+        description: Speed x<currentMult> → x<newMult>
 
 # Buildings and their name / description
 buildings:
-  hub:
-    deliver: Deliver
-    toUnlock: to unlock
-    levelShortcut: LVL
-    endOfDemo: End of Demo
+    hub:
+        deliver: Deliver
+        toUnlock: to unlock
+        levelShortcut: LVL
+        endOfDemo: End of Demo
 
-  belt:
-    default:
-      name: &belt Conveyor Belt
-      description: Transports items, hold and drag to place multiple.
+    belt:
+        default:
+            name: &belt Conveyor Belt
+            description: Transports items, hold and drag to place multiple.
 
-  # Internal name for the Extractor
-  miner:
-    default:
-      name: &miner Extractor
-      description: Place over a shape or color to extract it.
+    # Internal name for the Extractor
+    miner:
+        default:
+            name: &miner Extractor
+            description: Place over a shape or color to extract it.
 
-    chainable:
-      name: Extractor (Chain)
-      description: Place over a shape or color to extract it. Can be chained.
+        chainable:
+            name: Extractor (Chain)
+            description: Place over a shape or color to extract it. Can be chained.
 
-  # Internal name for the Tunnel
-  underground_belt:
-    default:
-      name: &underground_belt Tunnel
-      description: Allows you to tunnel resources under buildings and belts.
+    # Internal name for the Tunnel
+    underground_belt:
+        default:
+            name: &underground_belt Tunnel
+            description: Allows you to tunnel resources under buildings and belts.
 
-    tier2:
-      name: Tunnel Tier II
-      description: Allows you to tunnel resources under buildings and belts.
+        tier2:
+            name: Tunnel Tier II
+            description: Allows you to tunnel resources under buildings and belts.
 
-  # Balancer
-  balancer:
-    default:
-      name: &balancer Balancer
-      description: Multifunctional - Evenly distributes all inputs onto all outputs.
+    # Balancer
+    balancer:
+        default:
+            name: &balancer Balancer
+            description: Multifunctional - Evenly distributes all inputs onto all outputs.
 
-    merger:
-      name: Merger (compact)
-      description: Merges two conveyor belts into one.
+        merger:
+            name: Merger (compact)
+            description: Merges two conveyor belts into one.
 
-    merger-inverse:
-      name: Merger (compact)
-      description: Merges two conveyor belts into one.
+        merger-inverse:
+            name: Merger (compact)
+            description: Merges two conveyor belts into one.
 
-    splitter:
-      name: Splitter (compact)
-      description: Splits one conveyor belt into two.
+        splitter:
+            name: Splitter (compact)
+            description: Splits one conveyor belt into two.
 
-    splitter-inverse:
-      name: Splitter (compact)
-      description: Splits one conveyor belt into two.
+        splitter-inverse:
+            name: Splitter (compact)
+            description: Splits one conveyor belt into two.
 
-  cutter:
-    default:
-      name: &cutter Cutter
-      description: Cuts shapes from top to bottom and outputs both halves. <strong>If you use only one part, be sure to destroy the other part or it will clog and stall!</strong>
-    quad:
-      name: Cutter (Quad)
-      description: Cuts shapes into four parts. <strong>If you use only one part, be sure to destroy the other parts or it will clog and stall!</strong>
-
-  rotater:
-    default:
-      name: &rotater Rotator
-      description: Rotates shapes clockwise by 90 degrees.
-    ccw:
-      name: Rotator (CCW)
-      description: Rotates shapes counter-clockwise by 90 degrees.
-    rotate180:
-      name: Rotator (180°)
-      description: Rotates shapes by 180 degrees.
-
-  stacker:
-    default:
-      name: &stacker Stacker
-      description: Combines its inputs, on the same layer if possible, otherwise the right input is stacked on top of the left input.
-
-  mixer:
-    default:
-      name: &mixer Color Mixer
-      description: Mixes two colors using additive blending.
-
-  painter:
-    default:
-      name: &painter Painter
-      description: &painter_desc Paints the whole shape on the left input with the color from the top input.
-
-    mirrored:
-      name: *painter
-      description: Paints the whole shape on the left input with the color from the bottom input.
-
-    double:
-      name: Painter (Double)
-      description: Colors the shapes on the left inputs with the color from the top input.
-
-    quad:
-      name: Painter (Quad)
-      description: Allows you to color each quadrant of the shape individually. Only slots with a <strong>truthy signal</strong> on the wires layer will be painted!
-
-  trash:
-    default:
-      name: &trash Trash
-      description: Accepts inputs from all sides and destroys them. Forever.
-
-  storage:
-    default:
-      name: &storage Storage
-      description: Stores excess items, up to a given capacity. Prioritizes the left output and can be used as an overflow gate.
-
-  wire:
-    default:
-      name: &wire Wire
-      description: &wire_desc Transfers signals, which can be items, colours or booleans (1 or 0). Differently-coloured wires do not connect to each other.
-
-    second:
-      name: *wire
-      description: *wire_desc
-
-  wire_tunnel:
-    default:
-      name: &wire_tunnel Wire Crossing
-      description: Allows two wires to cross without connecting to each other.
-
-  constant_signal:
-    default:
-      name: &constant_signal Constant Signal
-      description: Emits a constant signal, which can be either a shape, color or boolean (1 or 0).
-
-  lever:
-    default:
-      name: &lever Switch
-      description: Can be toggled to emit a boolean signal (1 or 0) on the wires layer, which can then be used to control components, for example an item filter.
-
-  logic_gate:
-    default:
-      name: AND Gate
-      description: Emits a boolean "1" if both inputs are truthy. (Truthy means shape, color or boolean "1")
-    not:
-      name: NOT Gate
-      description: Emits a boolean "1" if the input is not truthy. (Truthy means shape, color or boolean "1")
-    xor:
-      name: XOR Gate
-      description: Emits a boolean "1" if one of the inputs is truthy, but not both. (Truthy means shape, color or boolean "1")
-    or:
-      name: OR Gate
-      description: Emits a boolean "1" if one of the inputs is truthy. (Truthy means shape, color or boolean "1")
-
-  transistor:
-    default:
-      name: &transistor Transistor
-      description: &transistor_desc Forwards the bottom input if the side input is truthy (a shape, color or "1").
-
-    mirrored:
-      name: *transistor
-      description: *transistor_desc
-
-  filter:
-    default:
-      name: &filter Filter
-      description: Connect a signal to route all matching items to the top and the remaining to the right. Can be controlled with boolean signals too.
-
-  display:
-    default:
-      name: &display Display
-      description: Connect a signal to show it on the display - It can be a shape, color or boolean.
-
-  reader:
-    default:
-      name: &reader Belt Reader
-      description: Allows to measure the average belt throughput. Outputs the last read item on the wires layer (once unlocked).
-
-  analyzer:
-    default:
-      name: &analyzer Shape Analyzer
-      description: Analyzes the top right quadrant of the lowest layer of the shape and returns its shape and color.
-
-  comparator:
-    default:
-      name: &comparator Compare
-      description: Returns boolean "1" if both signals are exactly equal. Can compare shapes, colors and booleans.
-
-  virtual_processor:
-    default:
-      name: &virtual_processor Virtual Cutter
-      description: Virtually cuts the shape into two halves.
+    cutter:
+        default:
+            name: &cutter Cutter
+            description: Cuts shapes from top to bottom and outputs both halves. <strong>If you use only one part, be sure to destroy the other part or it will clog and stall!</strong>
+        quad:
+            name: Cutter (Quad)
+            description: Cuts shapes into four parts. <strong>If you use only one part, be sure to destroy the other parts or it will clog and stall!</strong>
 
     rotater:
-      name: Virtual Rotator
-      description: Virtually rotates the shape clockwise.
-
-    unstacker:
-      name: Virtual Unstacker
-      description: Virtually extracts the topmost layer to the right output and the remaining ones to the left.
+        default:
+            name: &rotater Rotator
+            description: Rotates shapes clockwise by 90 degrees.
+        ccw:
+            name: Rotator (CCW)
+            description: Rotates shapes counter-clockwise by 90 degrees.
+        rotate180:
+            name: Rotator (180°)
+            description: Rotates shapes by 180 degrees.
 
     stacker:
-      name: Virtual Stacker
-      description: Virtually stacks the right shape onto the left.
+        default:
+            name: &stacker Stacker
+            description: Combines its inputs, on the same layer if possible, otherwise the right input is stacked on top of the left input.
+
+    mixer:
+        default:
+            name: &mixer Color Mixer
+            description: Mixes two colors using additive blending.
 
     painter:
-      name: Virtual Painter
-      description: Virtually paints the shape from the bottom input with the color on the right input.
+        default:
+            name: &painter Painter
+            description: &painter_desc Paints the whole shape on the left input with the color from the top input.
 
-  item_producer:
-    default:
-      name: Item Producer
-      description: Available in sandbox mode only, outputs the given signal from the wires layer on the regular layer.
+        mirrored:
+            name: *painter
+            description: Paints the whole shape on the left input with the color from the bottom input.
+
+        double:
+            name: Painter (Double)
+            description: Colors the shapes on the left inputs with the color from the top input.
+
+        quad:
+            name: Painter (Quad)
+            description: Allows you to color each quadrant of the shape individually. Only slots with a <strong>truthy signal</strong> on the wires layer will be painted!
+
+    trash:
+        default:
+            name: &trash Trash
+            description: Accepts inputs from all sides and destroys them. Forever.
+
+    storage:
+        default:
+            name: &storage Storage
+            description: Stores excess items, up to a given capacity. Prioritizes the left output and can be used as an overflow gate.
+
+    wire:
+        default:
+            name: &wire Wire
+            description: &wire_desc Transfers signals, which can be items, colours or booleans (1 or 0). Differently-coloured wires do not connect to each other.
+
+        second:
+            name: *wire
+            description: *wire_desc
+
+    wire_tunnel:
+        default:
+            name: &wire_tunnel Wire Crossing
+            description: Allows two wires to cross without connecting to each other.
+
+    constant_signal:
+        default:
+            name: &constant_signal Constant Signal
+            description: Emits a constant signal, which can be either a shape, color or boolean (1 or 0).
+
+    lever:
+        default:
+            name: &lever Switch
+            description: Can be toggled to emit a boolean signal (1 or 0) on the wires layer, which can then be used to control components, for example an item filter.
+
+    logic_gate:
+        default:
+            name: AND Gate
+            description: Emits a boolean "1" if both inputs are truthy. (Truthy means shape, color or boolean "1")
+        not:
+            name: NOT Gate
+            description: Emits a boolean "1" if the input is not truthy. (Truthy means shape, color or boolean "1")
+        xor:
+            name: XOR Gate
+            description: Emits a boolean "1" if one of the inputs is truthy, but not both. (Truthy means shape, color or boolean "1")
+        or:
+            name: OR Gate
+            description: Emits a boolean "1" if one of the inputs is truthy. (Truthy means shape, color or boolean "1")
+
+    transistor:
+        default:
+            name: &transistor Transistor
+            description: &transistor_desc Forwards the bottom input if the side input is truthy (a shape, color or "1").
+
+        mirrored:
+            name: *transistor
+            description: *transistor_desc
+
+    filter:
+        default:
+            name: &filter Filter
+            description: Connect a signal to route all matching items to the top and the remaining to the right. Can be controlled with boolean signals too.
+
+    display:
+        default:
+            name: &display Display
+            description: Connect a signal to show it on the display - It can be a shape, color or boolean.
+
+    reader:
+        default:
+            name: &reader Belt Reader
+            description: Allows to measure the average belt throughput. Outputs the last read item on the wires layer (once unlocked).
+
+    analyzer:
+        default:
+            name: &analyzer Shape Analyzer
+            description: Analyzes the top right quadrant of the lowest layer of the shape and returns its shape and color.
+
+    comparator:
+        default:
+            name: &comparator Compare
+            description: Returns boolean "1" if both signals are exactly equal. Can compare shapes, colors and booleans.
+
+    virtual_processor:
+        default:
+            name: &virtual_processor Virtual Cutter
+            description: Virtually cuts the shape into two halves.
+
+        rotater:
+            name: Virtual Rotator
+            description: Virtually rotates the shape clockwise.
+
+        unstacker:
+            name: Virtual Unstacker
+            description: Virtually extracts the topmost layer to the right output and the remaining ones to the left.
+
+        stacker:
+            name: Virtual Stacker
+            description: Virtually stacks the right shape onto the left.
+
+        painter:
+            name: Virtual Painter
+            description: Virtually paints the shape from the bottom input with the color on the right input.
+
+    item_producer:
+        default:
+            name: Item Producer
+            description: Available in sandbox mode only, outputs the given signal from the wires layer on the regular layer.
 
 storyRewards:
-  # Those are the rewards gained from completing the store
-  reward_cutter_and_trash:
-    title: Cutting Shapes
-    desc: >-
-      You just unlocked the <strong>cutter</strong>, which cuts shapes in half from top to bottom <strong>regardless of its orientation</strong>!<br><br>Be sure to get rid of the waste, or
-      otherwise <strong>it will clog and stall</strong> - For this purpose I have given you the <strong>trash</strong>, which destroys everything you put into it!
+    # Those are the rewards gained from completing the store
+    reward_cutter_and_trash:
+        title: Cutting Shapes
+        desc: >-
+            You just unlocked the <strong>cutter</strong>, which cuts shapes in half from top to bottom <strong>regardless of its orientation</strong>!<br><br>Be sure to get rid of the waste, or
+            otherwise <strong>it will clog and stall</strong> - For this purpose I have given you the <strong>trash</strong>, which destroys everything you put into it!
 
-  reward_rotater:
-    title: Rotating
-    desc: The <strong>rotator</strong> has been unlocked! It rotates shapes clockwise by 90 degrees.
+    reward_rotater:
+        title: Rotating
+        desc: The <strong>rotator</strong> has been unlocked! It rotates shapes clockwise by 90 degrees.
 
-  reward_painter:
-    title: Painting
-    desc: >-
-      The <strong>painter</strong> has been unlocked - Extract some color veins (just as you do with shapes) and combine it with a shape in the painter to color them!<br><br>PS: If you are
-      colorblind, there is a <strong>colorblind mode</strong> in the settings!
+    reward_painter:
+        title: Painting
+        desc: >-
+            The <strong>painter</strong> has been unlocked - Extract some color veins (just as you do with shapes) and combine it with a shape in the painter to color them!<br><br>PS: If you are
+            colorblind, there is a <strong>colorblind mode</strong> in the settings!
 
-  reward_mixer:
-    title: Color Mixing
-    desc: The <strong>mixer</strong> has been unlocked - It mixes two colors using <strong>additive blending</strong>!
+    reward_mixer:
+        title: Color Mixing
+        desc: The <strong>mixer</strong> has been unlocked - It mixes two colors using <strong>additive blending</strong>!
 
-  reward_stacker:
-    title: Stacker
-    desc: >-
-      You can now combine shapes with the <strong>stacker</strong>! Both inputs are combined, and if they can be put next to each other, they will be <strong>fused</strong>. If not, the right
-      input is <strong>stacked on top</strong> of the left input!
+    reward_stacker:
+        title: Stacker
+        desc: >-
+            You can now combine shapes with the <strong>stacker</strong>! Both inputs are combined, and if they can be put next to each other, they will be <strong>fused</strong>. If not, the right
+            input is <strong>stacked on top</strong> of the left input!
 
-  reward_balancer:
-    title: Balancer
-    desc: The multifunctional <strong>balancer</strong> has been unlocked - It can be used to build bigger factories by <strong>splitting and merging items</strong> onto multiple belts!
+    reward_balancer:
+        title: Balancer
+        desc: The multifunctional <strong>balancer</strong> has been unlocked - It can be used to build bigger factories by <strong>splitting and merging items</strong> onto multiple belts!
 
-  reward_tunnel:
-    title: Tunnel
-    desc: The <strong>tunnel</strong> has been unlocked - You can now tunnel items below belts and buildings with it!
+    reward_tunnel:
+        title: Tunnel
+        desc: The <strong>tunnel</strong> has been unlocked - You can now tunnel items below belts and buildings with it!
 
-  reward_rotater_ccw:
-    title: CCW Rotating
-    desc: >-
-      You have unlocked a variant of the <strong>rotator</strong> - It allows you to rotate shapes counter-clockwise! To build it, select the rotator and
-      <strong>press 'T' to cycle through its variants</strong>!
+    reward_rotater_ccw:
+        title: CCW Rotating
+        desc: >-
+            You have unlocked a variant of the <strong>rotator</strong> - It allows you to rotate shapes counter-clockwise! To build it, select the rotator and
+            <strong>press 'T' to cycle through its variants</strong>!
 
-  reward_miner_chainable:
-    title: Chaining Extractor
-    desc: >-
-      You have unlocked the <strong>chained extractor</strong>! It can <strong>forward its resources</strong> to other extractors so you can more efficiently extract resources!<br><br>
-      PS: The old extractor has been replaced in your toolbar now!
+    reward_miner_chainable:
+        title: Chaining Extractor
+        desc: >-
+            You have unlocked the <strong>chained extractor</strong>! It can <strong>forward its resources</strong> to other extractors so you can more efficiently extract resources!<br><br>
+            PS: The old extractor has been replaced in your toolbar now!
 
-  reward_underground_belt_tier_2:
-    title: Tunnel Tier II
-    desc: You have unlocked a new variant of the <strong>tunnel</strong> - It has a <strong>bigger range</strong>, and you can also mix-n-match those tunnels now!
+    reward_underground_belt_tier_2:
+        title: Tunnel Tier II
+        desc: You have unlocked a new variant of the <strong>tunnel</strong> - It has a <strong>bigger range</strong>, and you can also mix-n-match those tunnels now!
 
-  reward_merger:
-    title: Compact Merger
-    desc: >-
-      You have unlocked a <strong>merger</strong> variant of the <strong>balancer</strong> - It accepts two inputs and merges them into one belt!
+    reward_merger:
+        title: Compact Merger
+        desc: >-
+            You have unlocked a <strong>merger</strong> variant of the <strong>balancer</strong> - It accepts two inputs and merges them into one belt!
 
-  reward_splitter:
-    title: Compact Splitter
-    desc: >-
-      You have unlocked a <strong>splitter</strong> variant of the <strong>balancer</strong> - It accepts one input and splits them into two!
+    reward_splitter:
+        title: Compact Splitter
+        desc: >-
+            You have unlocked a <strong>splitter</strong> variant of the <strong>balancer</strong> - It accepts one input and splits them into two!
 
-  reward_belt_reader:
-    title: Belt reader
-    desc: >-
-      You have now unlocked the <strong>belt reader</strong>! It allows you to measure the throughput of a belt.<br><br>And wait until you unlock wires - then it gets really useful!
+    reward_belt_reader:
+        title: Belt reader
+        desc: >-
+            You have now unlocked the <strong>belt reader</strong>! It allows you to measure the throughput of a belt.<br><br>And wait until you unlock wires - then it gets really useful!
 
-  reward_cutter_quad:
-    title: Quad Cutter
-    desc: You have unlocked a variant of the <strong>cutter</strong> - It allows you to cut shapes in <strong>four parts</strong> instead of just two!
+    reward_cutter_quad:
+        title: Quad Cutter
+        desc: You have unlocked a variant of the <strong>cutter</strong> - It allows you to cut shapes in <strong>four parts</strong> instead of just two!
 
-  reward_painter_double:
-    title: Double Painting
-    desc: >-
-      You have unlocked a variant of the <strong>painter</strong> - It works similar to the regular painter but processes <strong>two shapes at once</strong>, consuming just one color
-      instead of two!
+    reward_painter_double:
+        title: Double Painting
+        desc: >-
+            You have unlocked a variant of the <strong>painter</strong> - It works similar to the regular painter but processes <strong>two shapes at once</strong>, consuming just one color
+            instead of two!
 
-  reward_storage:
-    title: Storage
-    desc: >-
-      You have unlocked the <strong>storage</strong> building - It allows you to store items up to a given capacity!<br><br>
-      It priorities the left output, so you can also use it as an <strong>overflow gate</strong>!
+    reward_storage:
+        title: Storage
+        desc: >-
+            You have unlocked the <strong>storage</strong> building - It allows you to store items up to a given capacity!<br><br>
+            It priorities the left output, so you can also use it as an <strong>overflow gate</strong>!
 
-  reward_blueprints:
-    title: Blueprints
-    desc: >-
-      You can now <strong>copy and paste</strong> parts of your factory! Select an area (Hold CTRL, then drag with your mouse), and press 'C' to copy it.<br><br>Pasting it is
-      <strong>not free</strong>, you need to produce <strong>blueprint shapes</strong> to afford it! (Those you just delivered).
+    reward_blueprints:
+        title: Blueprints
+        desc: >-
+            You can now <strong>copy and paste</strong> parts of your factory! Select an area (Hold CTRL, then drag with your mouse), and press 'C' to copy it.<br><br>Pasting it is
+            <strong>not free</strong>, you need to produce <strong>blueprint shapes</strong> to afford it! (Those you just delivered).
 
-  reward_rotater_180:
-    title: Rotator (180°)
-    desc: You just unlocked the 180 degrees <strong>rotator</strong>! - It allows you to rotate a shape by 180 degrees (Surprise! :D)
+    reward_rotater_180:
+        title: Rotator (180°)
+        desc: You just unlocked the 180 degrees <strong>rotator</strong>! - It allows you to rotate a shape by 180 degrees (Surprise! :D)
 
-  reward_wires_painter_and_levers:
-    title: >-
-      Wires & Quad Painter
-    desc: >-
-      You just unlocked the <strong>Wires Layer</strong>: It is a separate layer on top of the regular layer and introduces a lot of new mechanics!<br><br>
-      For the beginning I unlocked you the <strong>Quad Painter</strong> - Connect the slots you would like to paint with on the wires layer!<br><br>
-      To switch to the wires layer, press <strong>E</strong>. <br><br>
-      PS: <strong>Enable hints</strong> in the settings to activate the wires tutorial!
+    reward_wires_painter_and_levers:
+        title: >-
+            Wires & Quad Painter
+        desc: >-
+            You just unlocked the <strong>Wires Layer</strong>: It is a separate layer on top of the regular layer and introduces a lot of new mechanics!<br><br>
+            For the beginning I unlocked you the <strong>Quad Painter</strong> - Connect the slots you would like to paint with on the wires layer!<br><br>
+            To switch to the wires layer, press <strong>E</strong>. <br><br>
+            PS: <strong>Enable hints</strong> in the settings to activate the wires tutorial!
 
-  reward_filter:
-    title: >-
-      Item Filter
-    desc: >-
-      You unlocked the <strong>Item Filter</strong>! It will route items either to the top or the right output depending on whether they match the signal from the wires layer or not.<br><br>
-      You can also pass in a boolean signal (1 or 0) to entirely activate or disable it.
+    reward_filter:
+        title: >-
+            Item Filter
+        desc: >-
+            You unlocked the <strong>Item Filter</strong>! It will route items either to the top or the right output depending on whether they match the signal from the wires layer or not.<br><br>
+            You can also pass in a boolean signal (1 or 0) to entirely activate or disable it.
 
-  reward_display:
-    title: Display
-    desc: >-
-      You have unlocked the <strong>Display</strong> - Connect a signal on the wires layer to visualize it!<br><br>
-      PS: Did you notice the belt reader and storage output their last read item? Try showing it on a display!
+    reward_display:
+        title: Display
+        desc: >-
+            You have unlocked the <strong>Display</strong> - Connect a signal on the wires layer to visualize it!<br><br>
+            PS: Did you notice the belt reader and storage output their last read item? Try showing it on a display!
 
-  reward_constant_signal:
-    title: Constant Signal
-    desc: >-
-      You unlocked the <strong>constant signal</strong> building on the wires layer! This is useful to connect it to <strong>item filters</strong> for example.<br><br>
-      The constant signal can emit a <strong>shape</strong>, <strong>color</strong> or <strong>boolean</strong> (1 or 0).
+    reward_constant_signal:
+        title: Constant Signal
+        desc: >-
+            You unlocked the <strong>constant signal</strong> building on the wires layer! This is useful to connect it to <strong>item filters</strong> for example.<br><br>
+            The constant signal can emit a <strong>shape</strong>, <strong>color</strong> or <strong>boolean</strong> (1 or 0).
 
-  reward_logic_gates:
-    title: Logic Gates
-    desc: >-
-      You unlocked <strong>logic gates</strong>! You don't have to be excited about this, but it's actually super cool!<br><br>
-      With logic gates you can now compute AND, OR, XOR and NOT operations.<br><br>
-      As a bonus on top I also just gave you a <strong>transistor</strong>!
+    reward_logic_gates:
+        title: Logic Gates
+        desc: >-
+            You unlocked <strong>logic gates</strong>! You don't have to be excited about this, but it's actually super cool!<br><br>
+            With logic gates you can now compute AND, OR, XOR and NOT operations.<br><br>
+            As a bonus on top I also just gave you a <strong>transistor</strong>!
 
-  reward_virtual_processing:
-    title: Virtual Processing
-    desc: >-
-      I just gave a whole bunch of new buildings which allow you to <strong>simulate the processing of shapes</strong>!<br><br>
-      You can now simulate a cutter, rotator, stacker and more on the wires layer!
-      With this you now have three options to continue the game:<br><br>
-      - Build an <strong>automated machine</strong> to create any possible shape requested by the HUB (I recommend to try it!).<br><br>
-      - Build something cool with wires.<br><br>
-      - Continue to play normally.<br><br>
-      Whatever you choose, remember to have fun!
+    reward_virtual_processing:
+        title: Virtual Processing
+        desc: >-
+            I just gave a whole bunch of new buildings which allow you to <strong>simulate the processing of shapes</strong>!<br><br>
+            You can now simulate a cutter, rotator, stacker and more on the wires layer!
+            With this you now have three options to continue the game:<br><br>
+            - Build an <strong>automated machine</strong> to create any possible shape requested by the HUB (I recommend to try it!).<br><br>
+            - Build something cool with wires.<br><br>
+            - Continue to play normally.<br><br>
+            Whatever you choose, remember to have fun!
 
-  # Special reward, which is shown when there is no reward actually
-  no_reward:
-    title: Next level
-    desc: >-
-      This level gave you no reward, but the next one will! <br><br> PS: Better not destroy your existing factory - You'll need <strong>all</strong> those shapes later to
-      <strong>unlock upgrades</strong>!
+    # Special reward, which is shown when there is no reward actually
+    no_reward:
+        title: Next level
+        desc: >-
+            This level gave you no reward, but the next one will! <br><br> PS: Better not destroy your existing factory - You'll need <strong>all</strong> those shapes later to
+            <strong>unlock upgrades</strong>!
 
-  no_reward_freeplay:
-    title: Next level
-    desc: >-
-      Congratulations!
+    no_reward_freeplay:
+        title: Next level
+        desc: >-
+            Congratulations!
 
-  reward_freeplay:
-    title: Freeplay
-    desc: >-
-      You did it! You unlocked the <strong>free-play mode</strong>! This means that shapes are now <strong>randomly</strong> generated!<br><br>
-      Since the hub will require a <strong>throughput</strong> from now on, I highly recommend to build a machine which automatically delivers the requested shape!<br><br>
-      The HUB outputs the requested shape on the wires layer, so all you have to do is to analyze it and automatically configure your factory based on that.
+    reward_freeplay:
+        title: Freeplay
+        desc: >-
+            You did it! You unlocked the <strong>free-play mode</strong>! This means that shapes are now <strong>randomly</strong> generated!<br><br>
+            Since the hub will require a <strong>throughput</strong> from now on, I highly recommend to build a machine which automatically delivers the requested shape!<br><br>
+            The HUB outputs the requested shape on the wires layer, so all you have to do is to analyze it and automatically configure your factory based on that.
 
-  reward_demo_end:
-    title: End of Demo
-    desc: >-
-      You have reached the end of the demo version!
+    reward_demo_end:
+        title: End of Demo
+        desc: >-
+            You have reached the end of the demo version!
 
 settings:
-  title: Settings
-  categories:
-    general: General
-    userInterface: User Interface
-    advanced: Advanced
-    performance: Performance
+    title: Settings
+    categories:
+        general: General
+        userInterface: User Interface
+        advanced: Advanced
+        performance: Performance
 
-  versionBadges:
-    dev: Development
-    staging: Staging
-    prod: Production
-  buildDate: Built <at-date>
+    versionBadges:
+        dev: Development
+        staging: Staging
+        prod: Production
+    buildDate: Built <at-date>
 
-  rangeSliderPercentage: <amount> %
+    rangeSliderPercentage: <amount> %
 
-  labels:
-    uiScale:
-      title: Interface scale
-      description: >-
-        Changes the size of the user interface. The interface will still scale based on your device's resolution, but this setting controls the amount of scaling.
-      scales:
-        super_small: Super small
-        small: Small
-        regular: Regular
-        large: Large
-        huge: Huge
+    labels:
+        uiScale:
+            title: Interface scale
+            description: >-
+                Changes the size of the user interface. The interface will still scale based on your device's resolution, but this setting controls the amount of scaling.
+            scales:
+                super_small: Super small
+                small: Small
+                regular: Regular
+                large: Large
+                huge: Huge
 
-    autosaveInterval:
-      title: Autosave Interval
-      description: >-
-        Controls how often the game saves automatically. You can also disable it entirely here.
+        autosaveInterval:
+            title: Autosave Interval
+            description: >-
+                Controls how often the game saves automatically. You can also disable it entirely here.
 
-      intervals:
-        one_minute: 1 Minute
-        two_minutes: 2 Minutes
-        five_minutes: 5 Minutes
-        ten_minutes: 10 Minutes
-        twenty_minutes: 20 Minutes
-        disabled: Disabled
+            intervals:
+                one_minute: 1 Minute
+                two_minutes: 2 Minutes
+                five_minutes: 5 Minutes
+                ten_minutes: 10 Minutes
+                twenty_minutes: 20 Minutes
+                disabled: Disabled
 
-    scrollWheelSensitivity:
-      title: Zoom sensitivity
-      description: >-
-        Changes how sensitive the zoom is (Either mouse wheel or trackpad).
-      sensitivity:
-        super_slow: Super slow
-        slow: Slow
-        regular: Regular
-        fast: Fast
-        super_fast: Super fast
+        scrollWheelSensitivity:
+            title: Zoom sensitivity
+            description: >-
+                Changes how sensitive the zoom is (Either mouse wheel or trackpad).
+            sensitivity:
+                super_slow: Super slow
+                slow: Slow
+                regular: Regular
+                fast: Fast
+                super_fast: Super fast
 
-    movementSpeed:
-      title: Movement speed
-      description: >-
-        Changes how fast the view moves when using the keyboard or moving the mouse to the screen borders.
-      speeds:
-        super_slow: Super slow
-        slow: Slow
-        regular: Regular
-        fast: Fast
-        super_fast: Super Fast
-        extremely_fast: Extremely Fast
+        movementSpeed:
+            title: Movement speed
+            description: >-
+                Changes how fast the view moves when using the keyboard or moving the mouse to the screen borders.
+            speeds:
+                super_slow: Super slow
+                slow: Slow
+                regular: Regular
+                fast: Fast
+                super_fast: Super Fast
+                extremely_fast: Extremely Fast
 
-    language:
-      title: Language
-      description: >-
-        Change the language. All translations are user-contributed and might be incomplete!
+        language:
+            title: Language
+            description: >-
+                Change the language. All translations are user-contributed and might be incomplete!
 
-    enableColorBlindHelper:
-      title: Color Blind Mode
-      description: >-
-        Enables various tools which allow you to play the game if you are color blind.
+        enableColorBlindHelper:
+            title: Color Blind Mode
+            description: >-
+                Enables various tools which allow you to play the game if you are color blind.
 
-    fullscreen:
-      title: Fullscreen
-      description: >-
-        It is recommended to play the game in fullscreen to get the best experience. Only available in the standalone.
+        fullscreen:
+            title: Fullscreen
+            description: >-
+                It is recommended to play the game in fullscreen to get the best experience. Only available in the standalone.
 
-    soundsMuted:
-      title: Mute Sounds
-      description: >-
-        If enabled, mutes all sound effects.
+        soundsMuted:
+            title: Mute Sounds
+            description: >-
+                If enabled, mutes all sound effects.
 
-    musicMuted:
-      title: Mute Music
-      description: >-
-        If enabled, mutes all music.
+        musicMuted:
+            title: Mute Music
+            description: >-
+                If enabled, mutes all music.
 
-    soundVolume:
-      title: Sound Volume
-      description: >-
-        Set the volume for sound effects
+        soundVolume:
+            title: Sound Volume
+            description: >-
+                Set the volume for sound effects
 
-    musicVolume:
-      title: Music Volume
-      description: >-
-        Set the volume for music
+        musicVolume:
+            title: Music Volume
+            description: >-
+                Set the volume for music
 
-    theme:
-      title: Game theme
-      description: >-
-        Choose the game theme (light / dark).
-      themes:
-        dark: Dark
-        light: Light
+        theme:
+            title: Game theme
+            description: >-
+                Choose the game theme (light / dark).
+            themes:
+                dark: Dark
+                light: Light
 
-    refreshRate:
-      title: Tick Rate
-      description: >-
-        This determines how many game ticks happen per second. In general, a higher tick rate means better precision but also worse performance. On lower tickrates, the throughput may not be
-        exact.
+        refreshRate:
+            title: Tick Rate
+            description: >-
+                This determines how many game ticks happen per second. In general, a higher tick rate means better precision but also worse performance. On lower tickrates, the throughput may not be
+                exact.
 
-    alwaysMultiplace:
-      title: Multiplace
-      description: >-
-        If enabled, all buildings will stay selected after placement until you cancel it. This is equivalent to constantly holding SHIFT.
+        alwaysMultiplace:
+            title: Multiplace
+            description: >-
+                If enabled, all buildings will stay selected after placement until you cancel it. This is equivalent to constantly holding SHIFT.
 
-    offerHints:
-      title: Hints & Tutorials
-      description: >-
-        Whether to offer hints and tutorials while playing. Also hides certain UI elements up to a given level to make it easier to get into the game.
+        offerHints:
+            title: Hints & Tutorials
+            description: >-
+                Whether to offer hints and tutorials while playing. Also hides certain UI elements up to a given level to make it easier to get into the game.
 
-    enableTunnelSmartplace:
-      title: Smart Tunnels
-      description: >-
-        When enabled, placing tunnels will automatically remove unnecessary belts. This also enables you to drag tunnels and excess tunnels will get removed.
+        enableTunnelSmartplace:
+            title: Smart Tunnels
+            description: >-
+                When enabled, placing tunnels will automatically remove unnecessary belts. This also enables you to drag tunnels and excess tunnels will get removed.
 
-    vignette:
-      title: Vignette
-      description: >-
-        Enables the vignette, which darkens the screen corners and makes text easier to read.
+        vignette:
+            title: Vignette
+            description: >-
+                Enables the vignette, which darkens the screen corners and makes text easier to read.
 
-    rotationByBuilding:
-      title: Rotation by building type
-      description: >-
-        Each building type remembers the rotation you last set it to individually. This may be more comfortable if you frequently switch between placing different building types.
+        rotationByBuilding:
+            title: Rotation by building type
+            description: >-
+                Each building type remembers the rotation you last set it to individually. This may be more comfortable if you frequently switch between placing different building types.
 
-    compactBuildingInfo:
-      title: Compact Building Infos
-      description: >-
-        Shortens info boxes for buildings by only showing their ratios. Otherwise a description and image is shown.
+        compactBuildingInfo:
+            title: Compact Building Infos
+            description: >-
+                Shortens info boxes for buildings by only showing their ratios. Otherwise a description and image is shown.
 
-    disableCutDeleteWarnings:
-      title: Disable Cut/Delete Warnings
-      description: >-
-        Disables the warning dialogues brought up when cutting/deleting more than 100 entities.
+        disableCutDeleteWarnings:
+            title: Disable Cut/Delete Warnings
+            description: >-
+                Disables the warning dialogues brought up when cutting/deleting more than 100 entities.
 
-    lowQualityMapResources:
-      title: Low Quality Map Resources
-      description: >-
-        Simplifies the rendering of resources on the map when zoomed in to improve performance.
-        It even looks cleaner, so be sure to try it out!
+        lowQualityMapResources:
+            title: Low Quality Map Resources
+            description: >-
+                Simplifies the rendering of resources on the map when zoomed in to improve performance.
+                It even looks cleaner, so be sure to try it out!
 
-    disableTileGrid:
-      title: Disable Grid
-      description: >-
-        Disabling the tile grid can help with the performance. This also makes the game look cleaner!
+        disableTileGrid:
+            title: Disable Grid
+            description: >-
+                Disabling the tile grid can help with the performance. This also makes the game look cleaner!
 
-    clearCursorOnDeleteWhilePlacing:
-      title: Clear Cursor on Right Click
-      description: >-
-        Enabled by default, clears the cursor whenever you right click while you have a building selected for placement. If disabled, you can delete buildings by right-clicking while placing
-        a building.
+        clearCursorOnDeleteWhilePlacing:
+            title: Clear Cursor on Right Click
+            description: >-
+                Enabled by default, clears the cursor whenever you right click while you have a building selected for placement. If disabled, you can delete buildings by right-clicking while placing
+                a building.
 
-    lowQualityTextures:
-      title: Low quality textures (Ugly)
-      description: >-
-        Uses low quality textures to save performance. This will make the game look very ugly!
+        lowQualityTextures:
+            title: Low quality textures (Ugly)
+            description: >-
+                Uses low quality textures to save performance. This will make the game look very ugly!
 
-    displayChunkBorders:
-      title: Display Chunk Borders
-      description: >-
-        The game is divided into chunks of 16x16 tiles, if this setting is enabled the borders of each chunk are displayed.
+        displayChunkBorders:
+            title: Display Chunk Borders
+            description: >-
+                The game is divided into chunks of 16x16 tiles, if this setting is enabled the borders of each chunk are displayed.
 
-    pickMinerOnPatch:
-      title: Select extractor on resource patch
-      description: >-
-        Enabled by default, selects the extractor if you use the pipette when hovering a resource patch.
+        pickMinerOnPatch:
+            title: Select extractor on resource patch
+            description: >-
+                Enabled by default, selects the extractor if you use the pipette when hovering a resource patch.
 
-    simplifiedBelts:
-      title: Simplified Belts (Ugly)
-      description: >-
-        Does not render belt items except when hovering the belt to save performance. I do not recommend to play with this setting if you do not absolutely need the performance.
+        simplifiedBelts:
+            title: Simplified Belts (Ugly)
+            description: >-
+                Does not render belt items except when hovering the belt to save performance. I do not recommend to play with this setting if you do not absolutely need the performance.
 
-    enableMousePan:
-      title: Screen Edge Panning
-      description: >-
-        Allows panning the map by moving the cursor to the edges of the screen. The scroll speed depends on the Movement Speed setting.
+        enableMousePan:
+            title: Screen Edge Panning
+            description: >-
+                Allows panning the map by moving the cursor to the edges of the screen. The scroll speed depends on the Movement Speed setting.
 
-    zoomToCursor:
-      title: Zoom towards Cursor
-      description: >-
-        If activated the zoom will happen in the direction of your mouse position, otherwise in the middle of the screen.
+        zoomToCursor:
+            title: Zoom towards Cursor
+            description: >-
+                If activated the zoom will happen in the direction of your mouse position, otherwise in the middle of the screen.
 
-    mapResourcesScale:
-      title: Map Resources Size
-      description: >-
-        Controls the size of the shapes on the map overview (when zooming out).
+        mapResourcesScale:
+            title: Map Resources Size
+            description: >-
+                Controls the size of the shapes on the map overview (when zooming out).
 
 keybindings:
-  title: Keybindings
-  hint: >-
-    Tip: Be sure to make use of CTRL, SHIFT and ALT! They enable different placement options.
+    title: Keybindings
+    hint: >-
+        Tip: Be sure to make use of CTRL, SHIFT and ALT! They enable different placement options.
 
-  resetKeybindings: Reset
+    resetKeybindings: Reset
 
-  categoryLabels:
-    general: Application
-    ingame: Game
-    navigation: Navigating
-    placement: Placement
-    massSelect: Mass Select
-    buildings: Building Shortcuts
-    placementModifiers: Placement Modifiers
+    categoryLabels:
+        general: Application
+        ingame: Game
+        navigation: Navigating
+        placement: Placement
+        massSelect: Mass Select
+        buildings: Building Shortcuts
+        placementModifiers: Placement Modifiers
 
-  mappings:
-    confirm: Confirm
-    back: Back
-    mapMoveUp: Move Up
-    mapMoveRight: Move Right
-    mapMoveDown: Move Down
-    mapMoveLeft: Move Left
-    mapMoveFaster: Move Faster
-    centerMap: Center Map
+    mappings:
+        confirm: Confirm
+        back: Back
+        mapMoveUp: Move Up
+        mapMoveRight: Move Right
+        mapMoveDown: Move Down
+        mapMoveLeft: Move Left
+        mapMoveFaster: Move Faster
+        centerMap: Center Map
 
-    mapZoomIn: Zoom in
-    mapZoomOut: Zoom out
-    createMarker: Create Marker
+        mapZoomIn: Zoom in
+        mapZoomOut: Zoom out
+        createMarker: Create Marker
 
-    menuOpenShop: Upgrades
-    menuOpenStats: Statistics
-    menuClose: Close Menu
+        menuOpenShop: Upgrades
+        menuOpenStats: Statistics
+        menuClose: Close Menu
 
-    toggleHud: Toggle HUD
-    toggleFPSInfo: Toggle FPS and Debug Info
-    switchLayers: Switch layers
-    exportScreenshot: Export whole Base as Image
+        toggleHud: Toggle HUD
+        toggleFPSInfo: Toggle FPS and Debug Info
+        switchLayers: Switch layers
+        exportScreenshot: Export whole Base as Image
 
-    # --- Do not translate the values in this section
-    belt: *belt
-    balancer: *balancer
-    underground_belt: *underground_belt
-    miner: *miner
-    cutter: *cutter
-    rotater: *rotater
-    stacker: *stacker
-    mixer: *mixer
-    painter: *painter
-    trash: *trash
-    storage: *storage
-    wire: *wire
-    constant_signal: *constant_signal
-    logic_gate: Logic Gate
-    lever: *lever
-    filter: *filter
-    wire_tunnel: *wire_tunnel
-    display: *display
-    reader: *reader
-    virtual_processor: *virtual_processor
-    transistor: *transistor
-    analyzer: *analyzer
-    comparator: *comparator
-    item_producer: Item Producer (Sandbox)
-    # ---
+        # --- Do not translate the values in this section
+        belt: *belt
+        balancer: *balancer
+        underground_belt: *underground_belt
+        miner: *miner
+        cutter: *cutter
+        rotater: *rotater
+        stacker: *stacker
+        mixer: *mixer
+        painter: *painter
+        trash: *trash
+        storage: *storage
+        wire: *wire
+        constant_signal: *constant_signal
+        logic_gate: Logic Gate
+        lever: *lever
+        filter: *filter
+        wire_tunnel: *wire_tunnel
+        display: *display
+        reader: *reader
+        virtual_processor: *virtual_processor
+        transistor: *transistor
+        analyzer: *analyzer
+        comparator: *comparator
+        item_producer: Item Producer (Sandbox)
+        # ---
 
-    pipette: Pipette
-    rotateWhilePlacing: Rotate
-    rotateInverseModifier: >-
-      Modifier: Rotate CCW instead
-    cycleBuildingVariants: Cycle Variants
-    confirmMassDelete: Delete area
-    pasteLastBlueprint: Paste last blueprint
-    cycleBuildings: Cycle Buildings
-    lockBeltDirection: Enable belt planner
-    switchDirectionLockSide: >-
-      Planner: Switch side
-    copyWireValue: >-
-      Wires: Copy value below cursor
-    massSelectStart: Hold and drag to start
-    massSelectSelectMultiple: Select multiple areas
-    massSelectCopy: Copy area
-    massSelectCut: Cut area
+        pipette: Pipette
+        rotateWhilePlacing: Rotate
+        rotateInverseModifier: >-
+            Modifier: Rotate CCW instead
+        cycleBuildingVariants: Cycle Variants
+        confirmMassDelete: Delete area
+        pasteLastBlueprint: Paste last blueprint
+        cycleBuildings: Cycle Buildings
+        lockBeltDirection: Enable belt planner
+        switchDirectionLockSide: >-
+            Planner: Switch side
+        copyWireValue: >-
+            Wires: Copy value below cursor
+        massSelectStart: Hold and drag to start
+        massSelectSelectMultiple: Select multiple areas
+        massSelectCopy: Copy area
+        massSelectCut: Cut area
 
-    placeBuilding: Place Building
-    placementDisableAutoOrientation: Disable automatic orientation
-    placeMultiple: Stay in placement mode
-    placeInverse: Invert automatic belt orientation
-    delete: Delete Building
+        placementDisableAutoOrientation: Disable automatic orientation
+        placeMultiple: Stay in placement mode
+        placeInverse: Invert automatic belt orientation
+        placeBuilding: Place Building
+        delete: Delete Building
 
 about:
-  title: About this Game
-  body: >-
-    This game is open source and developed by <a href="https://github.com/tobspr" target="_blank">Tobias Springer</a> (this is me).<br><br>
+    title: About this Game
+    body: >-
+        This game is open source and developed by <a href="https://github.com/tobspr" target="_blank">Tobias Springer</a> (this is me).<br><br>
 
-    If you want to contribute, check out <a href="<githublink>" target="_blank">shapez.io on GitHub</a>.<br><br>
+        If you want to contribute, check out <a href="<githublink>" target="_blank">shapez.io on GitHub</a>.<br><br>
 
-    This game wouldn't have been possible without the great Discord community around my games - You should really join the <a href="<discordlink>" target="_blank">Discord server</a>!<br><br>
+        This game wouldn't have been possible without the great Discord community around my games - You should really join the <a href="<discordlink>" target="_blank">Discord server</a>!<br><br>
 
-    The soundtrack was made by <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsen</a> - He's awesome.<br><br>
+        The soundtrack was made by <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsen</a> - He's awesome.<br><br>
 
-    Finally, huge thanks to my best friend <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Without our Factorio sessions, this game would never have existed.
+        Finally, huge thanks to my best friend <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Without our Factorio sessions, this game would never have existed.
 
 changelog:
-  title: Changelog
+    title: Changelog
 
 demo:
-  features:
-    restoringGames: Restoring savegames
-    importingGames: Importing savegames
-    oneGameLimit: Limited to one savegame
-    customizeKeybindings: Customizing Keybindings
-    exportingBase: Exporting whole Base as Image
+    features:
+        restoringGames: Restoring savegames
+        importingGames: Importing savegames
+        oneGameLimit: Limited to one savegame
+        customizeKeybindings: Customizing Keybindings
+        exportingBase: Exporting whole Base as Image
 
-  settingNotAvailable: Not available in the demo.
+    settingNotAvailable: Not available in the demo.
 
 tips:
-  - The hub will accept any input, not just the current shape!
-  - Make sure your factories are modular - it will pay out!
-  - Don't build too close to the hub, or it will be a mess!
-  - If stacking does not work, try switching the inputs.
-  - You can toggle the belt planner direction by pressing <b>R</b>.
-  - Holding <b>CTRL</b> allows dragging of belts without auto-orientation.
-  - Ratios stay the same, as long as all upgrades are on the same Tier.
-  - Serial execution is more efficient than parallel.
-  - You will unlock more variants of buildings later in the game!
-  - You can use <b>T</b> to switch between different variants.
-  - Symmetry is key!
-  - You can weave different tiers of tunnels.
-  - Try to build compact factories - it will pay out!
-  - The painter has a mirrored variant which you can select with <b>T</b>
-  - Having the right building ratios will maximize efficiency.
-  - At maximum level, 5 extractors will fill a single belt.
-  - Don't forget about tunnels!
-  - You don't need to divide up items evenly for full efficiency.
-  - Holding <b>SHIFT</b> will activate the belt planner, letting you place long lines of belts easily.
-  - Cutters always cut vertically, regardless of their orientation.
-  - The storage buffer prioritises the left output.
-  - Invest time to build repeatable designs - it's worth it!
-  - Holding <b>SHIFT</b> lets you place multiple buildings at a time.
-  - You can hold <b>ALT</b> to invert the direction of placed belts.
-  - Efficiency is key!
-  - Shape patches that are further away from the hub are more complex.
-  - Machines have a limited speed, divide them up for maximum efficiency.
-  - Use balancers to maximize your efficiency.
-  - Organization is important. Try not to cross conveyors too much.
-  - Plan in advance, or it will be a mess!
-  - Don't remove your old factories! You'll need them to unlock upgrades.
-  - Try beating level 20 or 26 on your own before seeking for help!
-  - Don't complicate things, try to stay simple and you'll go far.
-  - You may need to reuse factories later in the game. Build your factories to be reusable.
-  - Sometimes, you can find a needed shape in the map without creating it with stackers.
-  - Full windmills/pinwheels can never spawn naturally.
-  - Color your shapes before cutting for maximum efficiency.
-  - With modules, space is merely a perception; a concern for mortal men.
-  - Make a separate blueprint factory. They're important for modules.
-  - Have a closer look at the color mixer, and your questions will be answered.
-  - Use <b>CTRL</b> + Click to select an area.
-  - Building too close to the hub can get in the way of later projects.
-  - The pin icon next to each shape in the upgrade list pins it to the screen.
-  - Mix all three primary colors to make white!
-  - You have an infinite map. Don't cramp your factory, expand!
-  - Also try Factorio! It's my favorite game.
-  - The quad cutter cuts clockwise, starting from the top right.
-  - You can download your savegames in the main menu!
-  - This game has a lot of useful keybindings! Be sure to check out the settings page.
-  - This game has a lot of settings, be sure to check them out!
-  - Your hub marker has a small compass that shows which direction it is in!
-  - To clear belts, cut the area and then paste it at the same location.
-  - Press F4 to show your FPS and Tick Rate.
-  - Press F4 twice to show the tile of your mouse and camera.
-  - You can click a pinned shape on the left side to unpin it.
+    - The hub will accept any input, not just the current shape!
+    - Make sure your factories are modular - it will pay out!
+    - Don't build too close to the hub, or it will be a mess!
+    - If stacking does not work, try switching the inputs.
+    - You can toggle the belt planner direction by pressing <b>R</b>.
+    - Holding <b>CTRL</b> allows dragging of belts without auto-orientation.
+    - Ratios stay the same, as long as all upgrades are on the same Tier.
+    - Serial execution is more efficient than parallel.
+    - You will unlock more variants of buildings later in the game!
+    - You can use <b>T</b> to switch between different variants.
+    - Symmetry is key!
+    - You can weave different tiers of tunnels.
+    - Try to build compact factories - it will pay out!
+    - The painter has a mirrored variant which you can select with <b>T</b>
+    - Having the right building ratios will maximize efficiency.
+    - At maximum level, 5 extractors will fill a single belt.
+    - Don't forget about tunnels!
+    - You don't need to divide up items evenly for full efficiency.
+    - Holding <b>SHIFT</b> will activate the belt planner, letting you place long lines of belts easily.
+    - Cutters always cut vertically, regardless of their orientation.
+    - The storage buffer prioritises the left output.
+    - Invest time to build repeatable designs - it's worth it!
+    - Holding <b>SHIFT</b> lets you place multiple buildings at a time.
+    - You can hold <b>ALT</b> to invert the direction of placed belts.
+    - Efficiency is key!
+    - Shape patches that are further away from the hub are more complex.
+    - Machines have a limited speed, divide them up for maximum efficiency.
+    - Use balancers to maximize your efficiency.
+    - Organization is important. Try not to cross conveyors too much.
+    - Plan in advance, or it will be a mess!
+    - Don't remove your old factories! You'll need them to unlock upgrades.
+    - Try beating level 20 or 26 on your own before seeking for help!
+    - Don't complicate things, try to stay simple and you'll go far.
+    - You may need to reuse factories later in the game. Build your factories to be reusable.
+    - Sometimes, you can find a needed shape in the map without creating it with stackers.
+    - Full windmills/pinwheels can never spawn naturally.
+    - Color your shapes before cutting for maximum efficiency.
+    - With modules, space is merely a perception; a concern for mortal men.
+    - Make a separate blueprint factory. They're important for modules.
+    - Have a closer look at the color mixer, and your questions will be answered.
+    - Use <b>CTRL</b> + Click to select an area.
+    - Building too close to the hub can get in the way of later projects.
+    - The pin icon next to each shape in the upgrade list pins it to the screen.
+    - Mix all three primary colors to make white!
+    - You have an infinite map. Don't cramp your factory, expand!
+    - Also try Factorio! It's my favorite game.
+    - The quad cutter cuts clockwise, starting from the top right.
+    - You can download your savegames in the main menu!
+    - This game has a lot of useful keybindings! Be sure to check out the settings page.
+    - This game has a lot of settings, be sure to check them out!
+    - Your hub marker has a small compass that shows which direction it is in!
+    - To clear belts, cut the area and then paste it at the same location.
+    - Press F4 to show your FPS and Tick Rate.
+    - Press F4 twice to show the tile of your mouse and camera.
+    - You can click a pinned shape on the left side to unpin it.

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -21,1245 +21,1246 @@
 
 ---
 steamPage:
-    # This is the short text appearing on the steam page
-    shortText: shapez.io is a game about building factories to automate the creation and processing of increasingly complex shapes across an infinitely expanding map.
+  # This is the short text appearing on the steam page
+  shortText: shapez.io is a game about building factories to automate the creation and processing of increasingly complex shapes across an infinitely expanding map.
 
-    # This is the text shown above the Discord link
-    discordLinkShort: Official Discord
+  # This is the text shown above the Discord link
+  discordLinkShort: Official Discord
 
-    intro: >-
-        Do you like automation games? Then you are in the right place!
+  intro: >-
+    Do you like automation games? Then you are in the right place!
 
-        shapez.io is a relaxed game in which you have to build factories for the automated production of geometric shapes. As the level increases, the shapes become more and more complex, and you
-        have to spread out on the infinite map.
+    shapez.io is a relaxed game in which you have to build factories for the automated production of geometric shapes. As the level increases, the shapes become more and more complex, and you
+    have to spread out on the infinite map.
 
-        And as if that wasn't enough, you also have to produce exponentially more to satisfy the demands - the only thing that helps is scaling! While you only have to process shapes at the
-        beginning, you will later have to color them - by extracting and mixing colors!
+    And as if that wasn't enough, you also have to produce exponentially more to satisfy the demands - the only thing that helps is scaling! While you only have to process shapes at the
+    beginning, you will later have to color them - by extracting and mixing colors!
 
-        Buying the game on Steam gives you access to the full version, but you can also play a demo at shapez.io first and decide later!
+    Buying the game on Steam gives you access to the full version, but you can also play a demo at shapez.io first and decide later!
 
-    title_advantages: Standalone Advantages
-    advantages:
-        - <b>12 New Levels</b> for a total of 26 levels
-        - <b>18 New Buildings</b> for a fully automated factory!
-        - <b>Unlimited Upgrade Tiers</b> for many hours of fun!
-        - <b>Wires Update</b> for an entirely new dimension!
-        - <b>Dark Mode</b>!
-        - Unlimited Savegames
-        - Unlimited Markers
-        - Support me! ❤️
+  title_advantages: Standalone Advantages
+  advantages:
+    - <b>12 New Levels</b> for a total of 26 levels
+    - <b>18 New Buildings</b> for a fully automated factory!
+    - <b>Unlimited Upgrade Tiers</b> for many hours of fun!
+    - <b>Wires Update</b> for an entirely new dimension!
+    - <b>Dark Mode</b>!
+    - Unlimited Savegames
+    - Unlimited Markers
+    - Support me! ❤️
 
-    title_future: Planned Content
-    planned:
-        - Blueprint Library
-        - Steam Achievements
-        - Puzzle Mode
-        - Minimap
-        - Mods
-        - Sandbox mode
-        - ... and a lot more!
+  title_future: Planned Content
+  planned:
+    - Blueprint Library
+    - Steam Achievements
+    - Puzzle Mode
+    - Minimap
+    - Mods
+    - Sandbox mode
+    - ... and a lot more!
 
-    title_open_source: This game is open source!
-    text_open_source: >-
-        Anybody can contribute, I'm actively involved in the community and attempt to review all suggestions and take feedback into consideration where possible.
+  title_open_source: This game is open source!
+  text_open_source: >-
+    Anybody can contribute, I'm actively involved in the community and attempt to review all suggestions and take feedback into consideration where possible.
 
-        Be sure to check out my trello board for the full roadmap!
+    Be sure to check out my trello board for the full roadmap!
 
-    title_links: Links
+  title_links: Links
 
-    links:
-        discord: Official Discord
-        roadmap: Roadmap
-        subreddit: Subreddit
-        source_code: Source code (GitHub)
-        translate: Help translate
+  links:
+    discord: Official Discord
+    roadmap: Roadmap
+    subreddit: Subreddit
+    source_code: Source code (GitHub)
+    translate: Help translate
 
 global:
-    loading: Loading
-    error: Error
+  loading: Loading
+  error: Error
 
-    # How big numbers are rendered, e.g. "10,000"
-    thousandsDivider: ","
+  # How big numbers are rendered, e.g. "10,000"
+  thousandsDivider: ","
 
-    # What symbol to use to separate the integer part from the fractional part of a number, e.g. "0.4"
-    decimalSeparator: "."
+  # What symbol to use to separate the integer part from the fractional part of a number, e.g. "0.4"
+  decimalSeparator: "."
 
-    # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
-    suffix:
-        thousands: k
-        millions: M
-        billions: B
-        trillions: T
+  # The suffix for large numbers, e.g. 1.3k, 400.2M, etc.
+  suffix:
+    thousands: k
+    millions: M
+    billions: B
+    trillions: T
 
-    # Shown for infinitely big numbers
-    infinite: inf
+  # Shown for infinitely big numbers
+  infinite: inf
 
-    time:
-        # Used for formatting past time dates
-        oneSecondAgo: one second ago
-        xSecondsAgo: <x> seconds ago
-        oneMinuteAgo: one minute ago
-        xMinutesAgo: <x> minutes ago
-        oneHourAgo: one hour ago
-        xHoursAgo: <x> hours ago
-        oneDayAgo: one day ago
-        xDaysAgo: <x> days ago
+  time:
+    # Used for formatting past time dates
+    oneSecondAgo: one second ago
+    xSecondsAgo: <x> seconds ago
+    oneMinuteAgo: one minute ago
+    xMinutesAgo: <x> minutes ago
+    oneHourAgo: one hour ago
+    xHoursAgo: <x> hours ago
+    oneDayAgo: one day ago
+    xDaysAgo: <x> days ago
 
-        # Short formats for times, e.g. '5h 23m'
-        secondsShort: <seconds>s
-        minutesAndSecondsShort: <minutes>m <seconds>s
-        hoursAndMinutesShort: <hours>h <minutes>m
+    # Short formats for times, e.g. '5h 23m'
+    secondsShort: <seconds>s
+    minutesAndSecondsShort: <minutes>m <seconds>s
+    hoursAndMinutesShort: <hours>h <minutes>m
 
-        xMinutes: <x> minutes
+    xMinutes: <x> minutes
 
-    keys:
-        tab: TAB
-        control: CTRL
-        alt: ALT
-        escape: ESC
-        shift: SHIFT
-        space: SPACE
+  keys:
+    tab: TAB
+    control: CTRL
+    alt: ALT
+    escape: ESC
+    shift: SHIFT
+    space: SPACE
 
 demoBanners:
-    # This is the "advertisement" shown in the main menu and other various places
-    title: Demo Version
-    intro: >-
-        Get the full game to unlock all features and content!
+  # This is the "advertisement" shown in the main menu and other various places
+  title: Demo Version
+  intro: >-
+    Get the full game to unlock all features and content!
 
 mainMenu:
-    play: Play
-    continue: Continue
-    newGame: New Game
-    changelog: Changelog
-    subreddit: Reddit
-    importSavegame: Import
-    openSourceHint: This game is open source!
-    discordLink: Official Discord Server
-    helpTranslate: Help translate!
-    madeBy: Made by <author-link>
+  play: Play
+  continue: Continue
+  newGame: New Game
+  changelog: Changelog
+  subreddit: Reddit
+  importSavegame: Import
+  openSourceHint: This game is open source!
+  discordLink: Official Discord Server
+  helpTranslate: Help translate!
+  madeBy: Made by <author-link>
 
-    # This is shown when using firefox and other browsers which are not supported.
-    browserWarning: >-
-        Sorry, but the game is known to run slowly on your browser! Get the standalone version or download Google Chrome for the full experience.
+  # This is shown when using firefox and other browsers which are not supported.
+  browserWarning: >-
+    Sorry, but the game is known to run slowly on your browser! Get the standalone version or download Google Chrome for the full experience.
 
-    savegameLevel: Level <x>
-    savegameLevelUnknown: Unknown Level
-    savegameUnnamed: Unnamed
+  savegameLevel: Level <x>
+  savegameLevelUnknown: Unknown Level
+  savegameUnnamed: Unnamed
 
 dialogs:
-    buttons:
-        ok: OK
-        delete: Delete
-        cancel: Cancel
-        later: Later
-        restart: Restart
-        reset: Reset
-        getStandalone: Get Standalone
-        deleteGame: I know what I am doing
-        viewUpdate: View Update
-        showUpgrades: Show Upgrades
-        showKeybindings: Show Keybindings
+  buttons:
+    ok: OK
+    delete: Delete
+    cancel: Cancel
+    later: Later
+    restart: Restart
+    reset: Reset
+    getStandalone: Get Standalone
+    deleteGame: I know what I am doing
+    viewUpdate: View Update
+    showUpgrades: Show Upgrades
+    showKeybindings: Show Keybindings
 
-    importSavegameError:
-        title: Import Error
-        text: >-
-            Failed to import your savegame:
+  importSavegameError:
+    title: Import Error
+    text: >-
+      Failed to import your savegame:
 
-    importSavegameSuccess:
-        title: Savegame Imported
-        text: >-
-            Your savegame has been successfully imported.
+  importSavegameSuccess:
+    title: Savegame Imported
+    text: >-
+      Your savegame has been successfully imported.
 
-    gameLoadFailure:
-        title: Game is broken
-        text: >-
-            Failed to load your savegame:
+  gameLoadFailure:
+    title: Game is broken
+    text: >-
+      Failed to load your savegame:
 
-    confirmSavegameDelete:
-        title: Confirm deletion
-        text: >-
-            Are you sure you want to delete the following game?<br><br>
-            '<savegameName>' at level <savegameLevel><br><br>
-            This can not be undone!
+  confirmSavegameDelete:
+    title: Confirm deletion
+    text: >-
+      Are you sure you want to delete the following game?<br><br>
+      '<savegameName>' at level <savegameLevel><br><br>
+      This can not be undone!
 
-    savegameDeletionError:
-        title: Failed to delete
-        text: >-
-            Failed to delete the savegame:
+  savegameDeletionError:
+    title: Failed to delete
+    text: >-
+      Failed to delete the savegame:
 
-    restartRequired:
-        title: Restart required
-        text: >-
-            You need to restart the game to apply the settings.
+  restartRequired:
+    title: Restart required
+    text: >-
+      You need to restart the game to apply the settings.
 
-    editKeybinding:
-        title: Change Keybinding
-        desc: Press the key or mouse button you want to assign, or escape to cancel.
+  editKeybinding:
+    title: Change Keybinding
+    desc: Press the key or mouse button you want to assign, or escape to cancel.
 
-    resetKeybindingsConfirmation:
-        title: Reset keybindings
-        desc: This will reset all keybindings to their default values. Please confirm.
+  resetKeybindingsConfirmation:
+    title: Reset keybindings
+    desc: This will reset all keybindings to their default values. Please confirm.
 
-    keybindingsResetOk:
-        title: Keybindings reset
-        desc: All keybindings have been reset to their defaults values!
+  keybindingsResetOk:
+    title: Keybindings reset
+    desc: All keybindings have been reset to their defaults values!
 
-    featureRestriction:
-        title: Demo Version
-        desc: You tried to access a feature (<feature>) which is not available in the demo. Consider getting the standalone version for the full experience!
+  featureRestriction:
+    title: Demo Version
+    desc: You tried to access a feature (<feature>) which is not available in the demo. Consider getting the standalone version for the full experience!
 
-    oneSavegameLimit:
-        title: Limited savegames
-        desc: You can only have one savegame at a time in the demo version. Please remove the existing one or get the standalone version!
+  oneSavegameLimit:
+    title: Limited savegames
+    desc: You can only have one savegame at a time in the demo version. Please remove the existing one or get the standalone version!
 
-    updateSummary:
-        title: New update!
-        desc: >-
-            Here are the changes since you last played:
+  updateSummary:
+    title: New update!
+    desc: >-
+      Here are the changes since you last played:
 
-    upgradesIntroduction:
-        title: Unlock Upgrades
-        desc: >-
-            All shapes you produce can be used to unlock upgrades - <strong>don't destroy your old factories!</strong>
-            The upgrades tab can be found on the top right corner of the screen.
+  upgradesIntroduction:
+    title: Unlock Upgrades
+    desc: >-
+      All shapes you produce can be used to unlock upgrades - <strong>don't destroy your old factories!</strong>
+      The upgrades tab can be found on the top right corner of the screen.
 
-    massDeleteConfirm:
-        title: Confirm delete
-        desc: >-
-            You are deleting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
+  massDeleteConfirm:
+    title: Confirm delete
+    desc: >-
+      You are deleting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
 
-    massCutConfirm:
-        title: Confirm cut
-        desc: >-
-            You are cutting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
+  massCutConfirm:
+    title: Confirm cut
+    desc: >-
+      You are cutting a lot of buildings (<count> to be exact)! Are you sure you want to do this?
 
-    massCutInsufficientConfirm:
-        title: Confirm cut
-        desc: >-
-            You can not afford to paste this area! Are you sure you want to cut it?
+  massCutInsufficientConfirm:
+    title: Confirm cut
+    desc: >-
+      You can not afford to paste this area! Are you sure you want to cut it?
 
-    blueprintsNotUnlocked:
-        title: Not unlocked yet
-        desc: >-
-            Complete level 12 to unlock Blueprints!
+  blueprintsNotUnlocked:
+    title: Not unlocked yet
+    desc: >-
+      Complete level 12 to unlock Blueprints!
 
-    keybindingsIntroduction:
-        title: Useful keybindings
-        desc: >-
-            This game has a lot of keybindings which make it easier to build big factories.
-            Here are a few, but be sure to <strong>check out the keybindings</strong>!<br><br>
-            <code class='keybinding'>CTRL</code> + Drag: Select an area.<br>
-            <code class='keybinding'>SHIFT</code>: Hold to place multiple of one building.<br>
-            <code class='keybinding'>ALT</code>: Invert orientation of placed belts.<br>
+  keybindingsIntroduction:
+    title: Useful keybindings
+    desc: >-
+      This game has a lot of keybindings which make it easier to build big factories.
+      Here are a few, but be sure to <strong>check out the keybindings</strong>!<br><br>
+      <code class='keybinding'>CTRL</code> + Drag: Select an area.<br>
+      <code class='keybinding'>SHIFT</code>: Hold to place multiple of one building.<br>
+      <code class='keybinding'>ALT</code>: Invert orientation of placed belts.<br>
 
-    createMarker:
-        title: New Marker
-        titleEdit: Edit Marker
-        desc: Give it a meaningful name, you can also include a <strong>short key</strong> of a shape (Which you can generate <link>here</link>)
+  createMarker:
+    title: New Marker
+    titleEdit: Edit Marker
+    desc: Give it a meaningful name, you can also include a <strong>short key</strong> of a shape (Which you can generate <link>here</link>)
 
-    editSignal:
-        title: Set Signal
-        descItems: >-
-            Choose a pre-defined item:
-        descShortKey: ... or enter the <strong>short key</strong> of a shape (Which you can generate <link>here</link>)
+  editSignal:
+    title: Set Signal
+    descItems: >-
+      Choose a pre-defined item:
+    descShortKey: ... or enter the <strong>short key</strong> of a shape (Which you can generate <link>here</link>)
 
-    markerDemoLimit:
-        desc: You can only create two custom markers in the demo. Get the standalone for unlimited markers!
+  markerDemoLimit:
+    desc: You can only create two custom markers in the demo. Get the standalone for unlimited markers!
 
-    exportScreenshotWarning:
-        title: Export screenshot
-        desc: You requested to export your base as a screenshot. Please note that this will be quite slow for a bigger base and could potentially crash your game!
+  exportScreenshotWarning:
+    title: Export screenshot
+    desc: You requested to export your base as a screenshot. Please note that this will be quite slow for a bigger base and could potentially crash your game!
 
-    renameSavegame:
-        title: Rename Savegame
-        desc: You can rename your savegame here.
+  renameSavegame:
+    title: Rename Savegame
+    desc: You can rename your savegame here.
 
-    tutorialVideoAvailable:
-        title: Tutorial Available
-        desc: There is a tutorial video available for this level! Would you like to watch it?
+  tutorialVideoAvailable:
+    title: Tutorial Available
+    desc: There is a tutorial video available for this level! Would you like to watch it?
 
-    tutorialVideoAvailableForeignLanguage:
-        title: Tutorial Available
-        desc: There is a tutorial video available for this level, but it is only available in English. Would you like to watch it?
+  tutorialVideoAvailableForeignLanguage:
+    title: Tutorial Available
+    desc: There is a tutorial video available for this level, but it is only available in English. Would you like to watch it?
 
 ingame:
-    # This is shown in the top left corner and displays useful keybindings in
-    # every situation
-    keybindingsOverlay:
-        moveMap: Move
-        selectBuildings: Select area
-        stopPlacement: Stop placement
-        rotateBuilding: Rotate building
-        placeMultiple: Place multiple
-        reverseOrientation: Reverse orientation
-        disableAutoOrientation: Disable auto-orientation
-        toggleHud: Toggle HUD
-        placeBuilding: Place building
-        createMarker: Create marker
-        delete: Delete
-        pasteLastBlueprint: Paste last blueprint
-        lockBeltDirection: Enable belt planner
-        plannerSwitchSide: Flip planner side
-        cutSelection: Cut
-        copySelection: Copy
-        clearSelection: Clear selection
-        pipette: Pipette
-        switchLayers: Switch layers
+  # This is shown in the top left corner and displays useful keybindings in
+  # every situation
+  keybindingsOverlay:
+    moveMap: Move
+    selectBuildings: Select area
+    stopPlacement: Stop placement
+    rotateBuilding: Rotate building
+    placeMultiple: Place multiple
+    reverseOrientation: Reverse orientation
+    disableAutoOrientation: Disable auto-orientation
+    toggleHud: Toggle HUD
+    placeBuilding: Place building
+    createMarker: Create marker
+    delete: Delete
+    pasteLastBlueprint: Paste last blueprint
+    lockBeltDirection: Enable belt planner
+    plannerSwitchSide: Flip planner side
+    cutSelection: Cut
+    copySelection: Copy
+    clearSelection: Clear selection
+    pipette: Pipette
+    switchLayers: Switch layers
 
-    # Names of the colors, used for the color blind mode
-    colors:
-        red: Red
-        green: Green
-        blue: Blue
-        yellow: Yellow
-        purple: Magenta
-        cyan: Cyan
-        white: White
-        black: Black
-        uncolored: Gray
+  # Names of the colors, used for the color blind mode
+  colors:
+    red: Red
+    green: Green
+    blue: Blue
+    yellow: Yellow
+    purple: Magenta
+    cyan: Cyan
+    white: White
+    black: Black
+    uncolored: Gray
 
-    # Everything related to placing buildings (I.e. as soon as you selected a building
-    # from the toolbar)
-    buildingPlacement:
-        # Buildings can have different variants which are unlocked at later levels,
-        # and this is the hint shown when there are multiple variants available.
-        cycleBuildingVariants: Press <key> to cycle variants.
+  # Everything related to placing buildings (I.e. as soon as you selected a building
+  # from the toolbar)
+  buildingPlacement:
+    # Buildings can have different variants which are unlocked at later levels,
+    # and this is the hint shown when there are multiple variants available.
+    cycleBuildingVariants: Press <key> to cycle variants.
 
-        # Shows the hotkey in the ui, e.g. "Hotkey: Q"
-        hotkeyLabel: >-
-            Hotkey: <key>
+    # Shows the hotkey in the ui, e.g. "Hotkey: Q"
+    hotkeyLabel: >-
+      Hotkey: <key>
 
-        infoTexts:
-            speed: Speed
-            range: Range
-            storage: Capacity
-            oneItemPerSecond: 1 item / second
-            itemsPerSecond: <x> items / s
-            itemsPerSecondDouble: (x2)
+    infoTexts:
+      speed: Speed
+      range: Range
+      storage: Capacity
+      oneItemPerSecond: 1 item / second
+      itemsPerSecond: <x> items / s
+      itemsPerSecondDouble: (x2)
 
-            tiles: <x> tiles
+      tiles: <x> tiles
 
-    # The notification when completing a level
-    levelCompleteNotification:
-        # <level> is replaced by the actual level, so this gets 'Level 03' for example.
-        levelTitle: Level <level>
-        completed: Completed
-        unlockText: Unlocked <reward>!
-        buttonNextLevel: Next Level
+  # The notification when completing a level
+  levelCompleteNotification:
+    # <level> is replaced by the actual level, so this gets 'Level 03' for example.
+    levelTitle: Level <level>
+    completed: Completed
+    unlockText: Unlocked <reward>!
+    buttonNextLevel: Next Level
 
-    # Notifications on the lower right
-    notifications:
-        newUpgrade: A new upgrade is available!
-        gameSaved: Your game has been saved.
-        freeplayLevelComplete: Level <level> has been completed!
+  # Notifications on the lower right
+  notifications:
+    newUpgrade: A new upgrade is available!
+    gameSaved: Your game has been saved.
+    freeplayLevelComplete: Level <level> has been completed!
 
-    # The "Upgrades" window
-    shop:
-        title: Upgrades
-        buttonUnlock: Upgrade
+  # The "Upgrades" window
+  shop:
+    title: Upgrades
+    buttonUnlock: Upgrade
 
-        # Gets replaced to e.g. "Tier IX"
-        tier: Tier <x>
+    # Gets replaced to e.g. "Tier IX"
+    tier: Tier <x>
 
-        maximumLevel: MAXIMUM LEVEL (Speed x<currentMult>)
+    maximumLevel: MAXIMUM LEVEL (Speed x<currentMult>)
 
-    # The "Statistics" window
-    statistics:
-        title: Statistics
-        dataSources:
-            stored:
-                title: Stored
-                description: All shapes stored within the Hub.
-            produced:
-                title: Produced
-                description: All shapes produced within your factory, including intermediate products.
-            delivered:
-                title: Delivered
-                description: Shapes which are being delivered to the Hub.
-        noShapesProduced: No shapes have been produced so far.
+  # The "Statistics" window
+  statistics:
+    title: Statistics
+    dataSources:
+      stored:
+        title: Stored
+        description: All shapes stored within the Hub.
+      produced:
+        title: Produced
+        description: All shapes produced within your factory, including intermediate products.
+      delivered:
+        title: Delivered
+        description: Shapes which are being delivered to the Hub.
+    noShapesProduced: No shapes have been produced so far.
 
-        # Displays the shapes per second, e.g. '523 / s'
-        shapesDisplayUnits:
-            second: <shapes> / s
-            minute: <shapes> / m
-            hour: <shapes> / h
+    # Displays the shapes per second, e.g. '523 / s'
+    shapesDisplayUnits:
+      second: <shapes> / s
+      minute: <shapes> / m
+      hour: <shapes> / h
 
-    # Settings menu, when you press "ESC"
-    settingsMenu:
-        playtime: Playtime
-        buildingsPlaced: Buildings
-        beltsPlaced: Belts
+  # Settings menu, when you press "ESC"
+  settingsMenu:
+    playtime: Playtime
+    buildingsPlaced: Buildings
+    beltsPlaced: Belts
 
-    # Bottom left tutorial hints
-    tutorialHints:
-        title: Need help?
-        showHint: Show hint
-        hideHint: Close
+  # Bottom left tutorial hints
+  tutorialHints:
+    title: Need help?
+    showHint: Show hint
+    hideHint: Close
 
-    # When placing a blueprint
-    blueprintPlacer:
-        cost: Cost
+  # When placing a blueprint
+  blueprintPlacer:
+    cost: Cost
 
-    # Map markers
-    waypoints:
-        waypoints: Markers
-        hub: HUB
-        description: >-
-            Left-click a marker to jump to it, right-click to delete it.<br><br>Press <keybinding> to create a marker from the current view, or <strong>right-click</strong> to create a marker at the
-            selected location.
-        creationSuccessNotification: Marker has been created.
+  # Map markers
+  waypoints:
+    waypoints: Markers
+    hub: HUB
+    description: >-
+      Left-click a marker to jump to it, right-click to delete it.<br><br>Press <keybinding> to create a marker from the current view, or <strong>right-click</strong> to create a marker at the
+      selected location.
+    creationSuccessNotification: Marker has been created.
 
-    # Shape viewer
-    shapeViewer:
-        title: Layers
-        empty: Empty
-        copyKey: Copy Key
+  # Shape viewer
+  shapeViewer:
+    title: Layers
+    empty: Empty
+    copyKey: Copy Key
 
-    # Interactive tutorial
-    interactiveTutorial:
-        title: Tutorial
-        hints:
-            1_1_extractor: Place an <strong>extractor</strong> on top of a <strong>circle shape</strong> to extract it!
-            1_2_conveyor: >-
-                Connect the extractor with a <strong>conveyor belt</strong> to your hub!<br><br>Tip: <strong>Click and drag</strong> the belt with your mouse!
+  # Interactive tutorial
+  interactiveTutorial:
+    title: Tutorial
+    hints:
+      1_1_extractor: Place an <strong>extractor</strong> on top of a <strong>circle shape</strong> to extract it!
+      1_2_conveyor: >-
+        Connect the extractor with a <strong>conveyor belt</strong> to your hub!<br><br>Tip: <strong>Click and drag</strong> the belt with your mouse!
 
-            1_3_expand: >-
-                This is <strong>NOT</strong> an idle game! Build more extractors and belts to finish the goal quicker.<br><br>Tip: Hold <strong>SHIFT</strong> to place multiple extractors, and use
-                <strong>R</strong> to rotate them.
+      1_3_expand: >-
+        This is <strong>NOT</strong> an idle game! Build more extractors and belts to finish the goal quicker.<br><br>Tip: Hold <strong>SHIFT</strong> to place multiple extractors, and use
+        <strong>R</strong> to rotate them.
 
-            2_1_place_cutter: >-
-                Now place a <strong>Cutter</strong> to cut the circles in two halves!<br><br>
-                PS: The cutter always cuts from <strong>top to bottom</strong> regardless of its orientation.
+      2_1_place_cutter: >-
+        Now place a <strong>Cutter</strong> to cut the circles in two halves!<br><br>
+        PS: The cutter always cuts from <strong>top to bottom</strong> regardless of its orientation.
 
-            2_2_place_trash: >-
-                The cutter can <strong>clog and stall</strong>!<br><br>
-                Use a <strong>trash</strong> to get rid of the currently (!) not needed waste.
+      2_2_place_trash: >-
+        The cutter can <strong>clog and stall</strong>!<br><br>
+        Use a <strong>trash</strong> to get rid of the currently (!) not needed waste.
 
-            2_3_more_cutters: >-
-                Good job! Now place <strong>2 more cutters</strong> to speed up this slow process!<br><br>
-                PS: Use the <strong>0-9 hotkeys</strong> to access buildings faster!
+      2_3_more_cutters: >-
+        Good job! Now place <strong>2 more cutters</strong> to speed up this slow process!<br><br>
+        PS: Use the <strong>0-9 hotkeys</strong> to access buildings faster!
 
-            3_1_rectangles: >-
-                Now let's extract some rectangles! <strong>Build 4 extractors</strong> and connect them to the hub.<br><br>
-                PS: Hold <strong>SHIFT</strong> while dragging a belt to activate the belt planner!
+      3_1_rectangles: >-
+        Now let's extract some rectangles! <strong>Build 4 extractors</strong> and connect them to the hub.<br><br>
+        PS: Hold <strong>SHIFT</strong> while dragging a belt to activate the belt planner!
 
-            21_1_place_quad_painter: >-
-                Place the <strong>quad painter</strong> and get some <strong>circles</strong>, <strong>white</strong> and <strong>red</strong> color!
+      21_1_place_quad_painter: >-
+        Place the <strong>quad painter</strong> and get some <strong>circles</strong>, <strong>white</strong> and <strong>red</strong> color!
 
-            21_2_switch_to_wires: >-
-                Switch to the wires layer by pressing <strong>E</strong>!<br><br>
-                Then <strong>connect all four inputs</strong> of the painter with cables!
+      21_2_switch_to_wires: >-
+        Switch to the wires layer by pressing <strong>E</strong>!<br><br>
+        Then <strong>connect all four inputs</strong> of the painter with cables!
 
-            21_3_place_button: >-
-                Awesome! Now place a <strong>Switch</strong> and connect it with wires!
+      21_3_place_button: >-
+        Awesome! Now place a <strong>Switch</strong> and connect it with wires!
 
-            21_4_press_button: >-
-                Press the switch to make it <strong>emit a truthy signal</strong> and thus activate the painter.<br><br>
-                PS: You don't have to connect all inputs! Try wiring only two.
+      21_4_press_button: >-
+        Press the switch to make it <strong>emit a truthy signal</strong> and thus activate the painter.<br><br>
+        PS: You don't have to connect all inputs! Try wiring only two.
 
-    # Connected miners
-    connectedMiners:
-        one_miner: 1 Extractor
-        n_miners: <amount> Extractors
-        limited_items: Limited to <max_throughput>
+  # Connected miners
+  connectedMiners:
+    one_miner: 1 Extractor
+    n_miners: <amount> Extractors
+    limited_items: Limited to <max_throughput>
 
-    # Pops up in the demo every few minutes
-    watermark:
-        title: Demo version
-        desc: Click here to see the advantages of the standalone version!
-        get_on_steam: Get on Steam
+  # Pops up in the demo every few minutes
+  watermark:
+    title: Demo version
+    desc: Click here to see the advantages of the standalone version!
+    get_on_steam: Get on Steam
 
-    standaloneAdvantages:
-        title: Get the full version!
-        no_thanks: No, thanks!
+  standaloneAdvantages:
+    title: Get the full version!
+    no_thanks: No, thanks!
 
-        points:
-            levels:
-                title: 12 New Levels
-                desc: For a total of 26 levels!
+    points:
+      levels:
+        title: 12 New Levels
+        desc: For a total of 26 levels!
 
-            buildings:
-                title: 18 New Buildings
-                desc: Fully automate your factory!
+      buildings:
+        title: 18 New Buildings
+        desc: Fully automate your factory!
 
-            savegames:
-                title: ∞ Savegames
-                desc: As many as your heart desires!
+      savegames:
+        title: ∞ Savegames
+        desc: As many as your heart desires!
 
-            upgrades:
-                title: ∞ Upgrade Tiers
-                desc: This demo version has only 5!
+      upgrades:
+        title: ∞ Upgrade Tiers
+        desc: This demo version has only 5!
 
-            markers:
-                title: ∞ Markers
-                desc: Never get lost in your factory!
+      markers:
+        title: ∞ Markers
+        desc: Never get lost in your factory!
 
-            wires:
-                title: Wires
-                desc: An entirely new dimension!
+      wires:
+        title: Wires
+        desc: An entirely new dimension!
 
-            darkmode:
-                title: Dark Mode
-                desc: Stop hurting your eyes!
+      darkmode:
+        title: Dark Mode
+        desc: Stop hurting your eyes!
 
-            support:
-                title: Support me
-                desc: I develop the game in my spare time!
+      support:
+        title: Support me
+        desc: I develop the game in my spare time!
 
 # All shop upgrades
 shopUpgrades:
-    belt:
-        name: Belts, Distributor & Tunnels
-        description: Speed x<currentMult> → x<newMult>
-    miner:
-        name: Extraction
-        description: Speed x<currentMult> → x<newMult>
-    processors:
-        name: Cutting, Rotating & Stacking
-        description: Speed x<currentMult> → x<newMult>
-    painting:
-        name: Mixing & Painting
-        description: Speed x<currentMult> → x<newMult>
+  belt:
+    name: Belts, Distributor & Tunnels
+    description: Speed x<currentMult> → x<newMult>
+  miner:
+    name: Extraction
+    description: Speed x<currentMult> → x<newMult>
+  processors:
+    name: Cutting, Rotating & Stacking
+    description: Speed x<currentMult> → x<newMult>
+  painting:
+    name: Mixing & Painting
+    description: Speed x<currentMult> → x<newMult>
 
 # Buildings and their name / description
 buildings:
-    hub:
-        deliver: Deliver
-        toUnlock: to unlock
-        levelShortcut: LVL
-        endOfDemo: End of Demo
+  hub:
+    deliver: Deliver
+    toUnlock: to unlock
+    levelShortcut: LVL
+    endOfDemo: End of Demo
 
-    belt:
-        default:
-            name: &belt Conveyor Belt
-            description: Transports items, hold and drag to place multiple.
+  belt:
+    default:
+      name: &belt Conveyor Belt
+      description: Transports items, hold and drag to place multiple.
 
-    # Internal name for the Extractor
-    miner:
-        default:
-            name: &miner Extractor
-            description: Place over a shape or color to extract it.
+  # Internal name for the Extractor
+  miner:
+    default:
+      name: &miner Extractor
+      description: Place over a shape or color to extract it.
 
-        chainable:
-            name: Extractor (Chain)
-            description: Place over a shape or color to extract it. Can be chained.
+    chainable:
+      name: Extractor (Chain)
+      description: Place over a shape or color to extract it. Can be chained.
 
-    # Internal name for the Tunnel
-    underground_belt:
-        default:
-            name: &underground_belt Tunnel
-            description: Allows you to tunnel resources under buildings and belts.
+  # Internal name for the Tunnel
+  underground_belt:
+    default:
+      name: &underground_belt Tunnel
+      description: Allows you to tunnel resources under buildings and belts.
 
-        tier2:
-            name: Tunnel Tier II
-            description: Allows you to tunnel resources under buildings and belts.
+    tier2:
+      name: Tunnel Tier II
+      description: Allows you to tunnel resources under buildings and belts.
 
-    # Balancer
-    balancer:
-        default:
-            name: &balancer Balancer
-            description: Multifunctional - Evenly distributes all inputs onto all outputs.
+  # Balancer
+  balancer:
+    default:
+      name: &balancer Balancer
+      description: Multifunctional - Evenly distributes all inputs onto all outputs.
 
-        merger:
-            name: Merger (compact)
-            description: Merges two conveyor belts into one.
+    merger:
+      name: Merger (compact)
+      description: Merges two conveyor belts into one.
 
-        merger-inverse:
-            name: Merger (compact)
-            description: Merges two conveyor belts into one.
+    merger-inverse:
+      name: Merger (compact)
+      description: Merges two conveyor belts into one.
 
-        splitter:
-            name: Splitter (compact)
-            description: Splits one conveyor belt into two.
+    splitter:
+      name: Splitter (compact)
+      description: Splits one conveyor belt into two.
 
-        splitter-inverse:
-            name: Splitter (compact)
-            description: Splits one conveyor belt into two.
+    splitter-inverse:
+      name: Splitter (compact)
+      description: Splits one conveyor belt into two.
 
-    cutter:
-        default:
-            name: &cutter Cutter
-            description: Cuts shapes from top to bottom and outputs both halves. <strong>If you use only one part, be sure to destroy the other part or it will clog and stall!</strong>
-        quad:
-            name: Cutter (Quad)
-            description: Cuts shapes into four parts. <strong>If you use only one part, be sure to destroy the other parts or it will clog and stall!</strong>
+  cutter:
+    default:
+      name: &cutter Cutter
+      description: Cuts shapes from top to bottom and outputs both halves. <strong>If you use only one part, be sure to destroy the other part or it will clog and stall!</strong>
+    quad:
+      name: Cutter (Quad)
+      description: Cuts shapes into four parts. <strong>If you use only one part, be sure to destroy the other parts or it will clog and stall!</strong>
+
+  rotater:
+    default:
+      name: &rotater Rotator
+      description: Rotates shapes clockwise by 90 degrees.
+    ccw:
+      name: Rotator (CCW)
+      description: Rotates shapes counter-clockwise by 90 degrees.
+    rotate180:
+      name: Rotator (180°)
+      description: Rotates shapes by 180 degrees.
+
+  stacker:
+    default:
+      name: &stacker Stacker
+      description: Combines its inputs, on the same layer if possible, otherwise the right input is stacked on top of the left input.
+
+  mixer:
+    default:
+      name: &mixer Color Mixer
+      description: Mixes two colors using additive blending.
+
+  painter:
+    default:
+      name: &painter Painter
+      description: &painter_desc Paints the whole shape on the left input with the color from the top input.
+
+    mirrored:
+      name: *painter
+      description: Paints the whole shape on the left input with the color from the bottom input.
+
+    double:
+      name: Painter (Double)
+      description: Colors the shapes on the left inputs with the color from the top input.
+
+    quad:
+      name: Painter (Quad)
+      description: Allows you to color each quadrant of the shape individually. Only slots with a <strong>truthy signal</strong> on the wires layer will be painted!
+
+  trash:
+    default:
+      name: &trash Trash
+      description: Accepts inputs from all sides and destroys them. Forever.
+
+  storage:
+    default:
+      name: &storage Storage
+      description: Stores excess items, up to a given capacity. Prioritizes the left output and can be used as an overflow gate.
+
+  wire:
+    default:
+      name: &wire Wire
+      description: &wire_desc Transfers signals, which can be items, colours or booleans (1 or 0). Differently-coloured wires do not connect to each other.
+
+    second:
+      name: *wire
+      description: *wire_desc
+
+  wire_tunnel:
+    default:
+      name: &wire_tunnel Wire Crossing
+      description: Allows two wires to cross without connecting to each other.
+
+  constant_signal:
+    default:
+      name: &constant_signal Constant Signal
+      description: Emits a constant signal, which can be either a shape, color or boolean (1 or 0).
+
+  lever:
+    default:
+      name: &lever Switch
+      description: Can be toggled to emit a boolean signal (1 or 0) on the wires layer, which can then be used to control components, for example an item filter.
+
+  logic_gate:
+    default:
+      name: AND Gate
+      description: Emits a boolean "1" if both inputs are truthy. (Truthy means shape, color or boolean "1")
+    not:
+      name: NOT Gate
+      description: Emits a boolean "1" if the input is not truthy. (Truthy means shape, color or boolean "1")
+    xor:
+      name: XOR Gate
+      description: Emits a boolean "1" if one of the inputs is truthy, but not both. (Truthy means shape, color or boolean "1")
+    or:
+      name: OR Gate
+      description: Emits a boolean "1" if one of the inputs is truthy. (Truthy means shape, color or boolean "1")
+
+  transistor:
+    default:
+      name: &transistor Transistor
+      description: &transistor_desc Forwards the bottom input if the side input is truthy (a shape, color or "1").
+
+    mirrored:
+      name: *transistor
+      description: *transistor_desc
+
+  filter:
+    default:
+      name: &filter Filter
+      description: Connect a signal to route all matching items to the top and the remaining to the right. Can be controlled with boolean signals too.
+
+  display:
+    default:
+      name: &display Display
+      description: Connect a signal to show it on the display - It can be a shape, color or boolean.
+
+  reader:
+    default:
+      name: &reader Belt Reader
+      description: Allows to measure the average belt throughput. Outputs the last read item on the wires layer (once unlocked).
+
+  analyzer:
+    default:
+      name: &analyzer Shape Analyzer
+      description: Analyzes the top right quadrant of the lowest layer of the shape and returns its shape and color.
+
+  comparator:
+    default:
+      name: &comparator Compare
+      description: Returns boolean "1" if both signals are exactly equal. Can compare shapes, colors and booleans.
+
+  virtual_processor:
+    default:
+      name: &virtual_processor Virtual Cutter
+      description: Virtually cuts the shape into two halves.
 
     rotater:
-        default:
-            name: &rotater Rotator
-            description: Rotates shapes clockwise by 90 degrees.
-        ccw:
-            name: Rotator (CCW)
-            description: Rotates shapes counter-clockwise by 90 degrees.
-        rotate180:
-            name: Rotator (180°)
-            description: Rotates shapes by 180 degrees.
+      name: Virtual Rotator
+      description: Virtually rotates the shape clockwise.
+
+    unstacker:
+      name: Virtual Unstacker
+      description: Virtually extracts the topmost layer to the right output and the remaining ones to the left.
 
     stacker:
-        default:
-            name: &stacker Stacker
-            description: Combines its inputs, on the same layer if possible, otherwise the right input is stacked on top of the left input.
-
-    mixer:
-        default:
-            name: &mixer Color Mixer
-            description: Mixes two colors using additive blending.
+      name: Virtual Stacker
+      description: Virtually stacks the right shape onto the left.
 
     painter:
-        default:
-            name: &painter Painter
-            description: &painter_desc Paints the whole shape on the left input with the color from the top input.
+      name: Virtual Painter
+      description: Virtually paints the shape from the bottom input with the color on the right input.
 
-        mirrored:
-            name: *painter
-            description: Paints the whole shape on the left input with the color from the bottom input.
-
-        double:
-            name: Painter (Double)
-            description: Colors the shapes on the left inputs with the color from the top input.
-
-        quad:
-            name: Painter (Quad)
-            description: Allows you to color each quadrant of the shape individually. Only slots with a <strong>truthy signal</strong> on the wires layer will be painted!
-
-    trash:
-        default:
-            name: &trash Trash
-            description: Accepts inputs from all sides and destroys them. Forever.
-
-    storage:
-        default:
-            name: &storage Storage
-            description: Stores excess items, up to a given capacity. Prioritizes the left output and can be used as an overflow gate.
-
-    wire:
-        default:
-            name: &wire Wire
-            description: &wire_desc Transfers signals, which can be items, colours or booleans (1 or 0). Differently-coloured wires do not connect to each other.
-
-        second:
-            name: *wire
-            description: *wire_desc
-
-    wire_tunnel:
-        default:
-            name: &wire_tunnel Wire Crossing
-            description: Allows two wires to cross without connecting to each other.
-
-    constant_signal:
-        default:
-            name: &constant_signal Constant Signal
-            description: Emits a constant signal, which can be either a shape, color or boolean (1 or 0).
-
-    lever:
-        default:
-            name: &lever Switch
-            description: Can be toggled to emit a boolean signal (1 or 0) on the wires layer, which can then be used to control components, for example an item filter.
-
-    logic_gate:
-        default:
-            name: AND Gate
-            description: Emits a boolean "1" if both inputs are truthy. (Truthy means shape, color or boolean "1")
-        not:
-            name: NOT Gate
-            description: Emits a boolean "1" if the input is not truthy. (Truthy means shape, color or boolean "1")
-        xor:
-            name: XOR Gate
-            description: Emits a boolean "1" if one of the inputs is truthy, but not both. (Truthy means shape, color or boolean "1")
-        or:
-            name: OR Gate
-            description: Emits a boolean "1" if one of the inputs is truthy. (Truthy means shape, color or boolean "1")
-
-    transistor:
-        default:
-            name: &transistor Transistor
-            description: &transistor_desc Forwards the bottom input if the side input is truthy (a shape, color or "1").
-
-        mirrored:
-            name: *transistor
-            description: *transistor_desc
-
-    filter:
-        default:
-            name: &filter Filter
-            description: Connect a signal to route all matching items to the top and the remaining to the right. Can be controlled with boolean signals too.
-
-    display:
-        default:
-            name: &display Display
-            description: Connect a signal to show it on the display - It can be a shape, color or boolean.
-
-    reader:
-        default:
-            name: &reader Belt Reader
-            description: Allows to measure the average belt throughput. Outputs the last read item on the wires layer (once unlocked).
-
-    analyzer:
-        default:
-            name: &analyzer Shape Analyzer
-            description: Analyzes the top right quadrant of the lowest layer of the shape and returns its shape and color.
-
-    comparator:
-        default:
-            name: &comparator Compare
-            description: Returns boolean "1" if both signals are exactly equal. Can compare shapes, colors and booleans.
-
-    virtual_processor:
-        default:
-            name: &virtual_processor Virtual Cutter
-            description: Virtually cuts the shape into two halves.
-
-        rotater:
-            name: Virtual Rotator
-            description: Virtually rotates the shape clockwise.
-
-        unstacker:
-            name: Virtual Unstacker
-            description: Virtually extracts the topmost layer to the right output and the remaining ones to the left.
-
-        stacker:
-            name: Virtual Stacker
-            description: Virtually stacks the right shape onto the left.
-
-        painter:
-            name: Virtual Painter
-            description: Virtually paints the shape from the bottom input with the color on the right input.
-
-    item_producer:
-        default:
-            name: Item Producer
-            description: Available in sandbox mode only, outputs the given signal from the wires layer on the regular layer.
+  item_producer:
+    default:
+      name: Item Producer
+      description: Available in sandbox mode only, outputs the given signal from the wires layer on the regular layer.
 
 storyRewards:
-    # Those are the rewards gained from completing the store
-    reward_cutter_and_trash:
-        title: Cutting Shapes
-        desc: >-
-            You just unlocked the <strong>cutter</strong>, which cuts shapes in half from top to bottom <strong>regardless of its orientation</strong>!<br><br>Be sure to get rid of the waste, or
-            otherwise <strong>it will clog and stall</strong> - For this purpose I have given you the <strong>trash</strong>, which destroys everything you put into it!
+  # Those are the rewards gained from completing the store
+  reward_cutter_and_trash:
+    title: Cutting Shapes
+    desc: >-
+      You just unlocked the <strong>cutter</strong>, which cuts shapes in half from top to bottom <strong>regardless of its orientation</strong>!<br><br>Be sure to get rid of the waste, or
+      otherwise <strong>it will clog and stall</strong> - For this purpose I have given you the <strong>trash</strong>, which destroys everything you put into it!
 
-    reward_rotater:
-        title: Rotating
-        desc: The <strong>rotator</strong> has been unlocked! It rotates shapes clockwise by 90 degrees.
+  reward_rotater:
+    title: Rotating
+    desc: The <strong>rotator</strong> has been unlocked! It rotates shapes clockwise by 90 degrees.
 
-    reward_painter:
-        title: Painting
-        desc: >-
-            The <strong>painter</strong> has been unlocked - Extract some color veins (just as you do with shapes) and combine it with a shape in the painter to color them!<br><br>PS: If you are
-            colorblind, there is a <strong>colorblind mode</strong> in the settings!
+  reward_painter:
+    title: Painting
+    desc: >-
+      The <strong>painter</strong> has been unlocked - Extract some color veins (just as you do with shapes) and combine it with a shape in the painter to color them!<br><br>PS: If you are
+      colorblind, there is a <strong>colorblind mode</strong> in the settings!
 
-    reward_mixer:
-        title: Color Mixing
-        desc: The <strong>mixer</strong> has been unlocked - It mixes two colors using <strong>additive blending</strong>!
+  reward_mixer:
+    title: Color Mixing
+    desc: The <strong>mixer</strong> has been unlocked - It mixes two colors using <strong>additive blending</strong>!
 
-    reward_stacker:
-        title: Stacker
-        desc: >-
-            You can now combine shapes with the <strong>stacker</strong>! Both inputs are combined, and if they can be put next to each other, they will be <strong>fused</strong>. If not, the right
-            input is <strong>stacked on top</strong> of the left input!
+  reward_stacker:
+    title: Stacker
+    desc: >-
+      You can now combine shapes with the <strong>stacker</strong>! Both inputs are combined, and if they can be put next to each other, they will be <strong>fused</strong>. If not, the right
+      input is <strong>stacked on top</strong> of the left input!
 
-    reward_balancer:
-        title: Balancer
-        desc: The multifunctional <strong>balancer</strong> has been unlocked - It can be used to build bigger factories by <strong>splitting and merging items</strong> onto multiple belts!
+  reward_balancer:
+    title: Balancer
+    desc: The multifunctional <strong>balancer</strong> has been unlocked - It can be used to build bigger factories by <strong>splitting and merging items</strong> onto multiple belts!
 
-    reward_tunnel:
-        title: Tunnel
-        desc: The <strong>tunnel</strong> has been unlocked - You can now tunnel items below belts and buildings with it!
+  reward_tunnel:
+    title: Tunnel
+    desc: The <strong>tunnel</strong> has been unlocked - You can now tunnel items below belts and buildings with it!
 
-    reward_rotater_ccw:
-        title: CCW Rotating
-        desc: >-
-            You have unlocked a variant of the <strong>rotator</strong> - It allows you to rotate shapes counter-clockwise! To build it, select the rotator and
-            <strong>press 'T' to cycle through its variants</strong>!
+  reward_rotater_ccw:
+    title: CCW Rotating
+    desc: >-
+      You have unlocked a variant of the <strong>rotator</strong> - It allows you to rotate shapes counter-clockwise! To build it, select the rotator and
+      <strong>press 'T' to cycle through its variants</strong>!
 
-    reward_miner_chainable:
-        title: Chaining Extractor
-        desc: >-
-            You have unlocked the <strong>chained extractor</strong>! It can <strong>forward its resources</strong> to other extractors so you can more efficiently extract resources!<br><br>
-            PS: The old extractor has been replaced in your toolbar now!
+  reward_miner_chainable:
+    title: Chaining Extractor
+    desc: >-
+      You have unlocked the <strong>chained extractor</strong>! It can <strong>forward its resources</strong> to other extractors so you can more efficiently extract resources!<br><br>
+      PS: The old extractor has been replaced in your toolbar now!
 
-    reward_underground_belt_tier_2:
-        title: Tunnel Tier II
-        desc: You have unlocked a new variant of the <strong>tunnel</strong> - It has a <strong>bigger range</strong>, and you can also mix-n-match those tunnels now!
+  reward_underground_belt_tier_2:
+    title: Tunnel Tier II
+    desc: You have unlocked a new variant of the <strong>tunnel</strong> - It has a <strong>bigger range</strong>, and you can also mix-n-match those tunnels now!
 
-    reward_merger:
-        title: Compact Merger
-        desc: >-
-            You have unlocked a <strong>merger</strong> variant of the <strong>balancer</strong> - It accepts two inputs and merges them into one belt!
+  reward_merger:
+    title: Compact Merger
+    desc: >-
+      You have unlocked a <strong>merger</strong> variant of the <strong>balancer</strong> - It accepts two inputs and merges them into one belt!
 
-    reward_splitter:
-        title: Compact Splitter
-        desc: >-
-            You have unlocked a <strong>splitter</strong> variant of the <strong>balancer</strong> - It accepts one input and splits them into two!
+  reward_splitter:
+    title: Compact Splitter
+    desc: >-
+      You have unlocked a <strong>splitter</strong> variant of the <strong>balancer</strong> - It accepts one input and splits them into two!
 
-    reward_belt_reader:
-        title: Belt reader
-        desc: >-
-            You have now unlocked the <strong>belt reader</strong>! It allows you to measure the throughput of a belt.<br><br>And wait until you unlock wires - then it gets really useful!
+  reward_belt_reader:
+    title: Belt reader
+    desc: >-
+      You have now unlocked the <strong>belt reader</strong>! It allows you to measure the throughput of a belt.<br><br>And wait until you unlock wires - then it gets really useful!
 
-    reward_cutter_quad:
-        title: Quad Cutter
-        desc: You have unlocked a variant of the <strong>cutter</strong> - It allows you to cut shapes in <strong>four parts</strong> instead of just two!
+  reward_cutter_quad:
+    title: Quad Cutter
+    desc: You have unlocked a variant of the <strong>cutter</strong> - It allows you to cut shapes in <strong>four parts</strong> instead of just two!
 
-    reward_painter_double:
-        title: Double Painting
-        desc: >-
-            You have unlocked a variant of the <strong>painter</strong> - It works similar to the regular painter but processes <strong>two shapes at once</strong>, consuming just one color
-            instead of two!
+  reward_painter_double:
+    title: Double Painting
+    desc: >-
+      You have unlocked a variant of the <strong>painter</strong> - It works similar to the regular painter but processes <strong>two shapes at once</strong>, consuming just one color
+      instead of two!
 
-    reward_storage:
-        title: Storage
-        desc: >-
-            You have unlocked the <strong>storage</strong> building - It allows you to store items up to a given capacity!<br><br>
-            It priorities the left output, so you can also use it as an <strong>overflow gate</strong>!
+  reward_storage:
+    title: Storage
+    desc: >-
+      You have unlocked the <strong>storage</strong> building - It allows you to store items up to a given capacity!<br><br>
+      It priorities the left output, so you can also use it as an <strong>overflow gate</strong>!
 
-    reward_blueprints:
-        title: Blueprints
-        desc: >-
-            You can now <strong>copy and paste</strong> parts of your factory! Select an area (Hold CTRL, then drag with your mouse), and press 'C' to copy it.<br><br>Pasting it is
-            <strong>not free</strong>, you need to produce <strong>blueprint shapes</strong> to afford it! (Those you just delivered).
+  reward_blueprints:
+    title: Blueprints
+    desc: >-
+      You can now <strong>copy and paste</strong> parts of your factory! Select an area (Hold CTRL, then drag with your mouse), and press 'C' to copy it.<br><br>Pasting it is
+      <strong>not free</strong>, you need to produce <strong>blueprint shapes</strong> to afford it! (Those you just delivered).
 
-    reward_rotater_180:
-        title: Rotator (180°)
-        desc: You just unlocked the 180 degrees <strong>rotator</strong>! - It allows you to rotate a shape by 180 degrees (Surprise! :D)
+  reward_rotater_180:
+    title: Rotator (180°)
+    desc: You just unlocked the 180 degrees <strong>rotator</strong>! - It allows you to rotate a shape by 180 degrees (Surprise! :D)
 
-    reward_wires_painter_and_levers:
-        title: >-
-            Wires & Quad Painter
-        desc: >-
-            You just unlocked the <strong>Wires Layer</strong>: It is a separate layer on top of the regular layer and introduces a lot of new mechanics!<br><br>
-            For the beginning I unlocked you the <strong>Quad Painter</strong> - Connect the slots you would like to paint with on the wires layer!<br><br>
-            To switch to the wires layer, press <strong>E</strong>. <br><br>
-            PS: <strong>Enable hints</strong> in the settings to activate the wires tutorial!
+  reward_wires_painter_and_levers:
+    title: >-
+      Wires & Quad Painter
+    desc: >-
+      You just unlocked the <strong>Wires Layer</strong>: It is a separate layer on top of the regular layer and introduces a lot of new mechanics!<br><br>
+      For the beginning I unlocked you the <strong>Quad Painter</strong> - Connect the slots you would like to paint with on the wires layer!<br><br>
+      To switch to the wires layer, press <strong>E</strong>. <br><br>
+      PS: <strong>Enable hints</strong> in the settings to activate the wires tutorial!
 
-    reward_filter:
-        title: >-
-            Item Filter
-        desc: >-
-            You unlocked the <strong>Item Filter</strong>! It will route items either to the top or the right output depending on whether they match the signal from the wires layer or not.<br><br>
-            You can also pass in a boolean signal (1 or 0) to entirely activate or disable it.
+  reward_filter:
+    title: >-
+      Item Filter
+    desc: >-
+      You unlocked the <strong>Item Filter</strong>! It will route items either to the top or the right output depending on whether they match the signal from the wires layer or not.<br><br>
+      You can also pass in a boolean signal (1 or 0) to entirely activate or disable it.
 
-    reward_display:
-        title: Display
-        desc: >-
-            You have unlocked the <strong>Display</strong> - Connect a signal on the wires layer to visualize it!<br><br>
-            PS: Did you notice the belt reader and storage output their last read item? Try showing it on a display!
+  reward_display:
+    title: Display
+    desc: >-
+      You have unlocked the <strong>Display</strong> - Connect a signal on the wires layer to visualize it!<br><br>
+      PS: Did you notice the belt reader and storage output their last read item? Try showing it on a display!
 
-    reward_constant_signal:
-        title: Constant Signal
-        desc: >-
-            You unlocked the <strong>constant signal</strong> building on the wires layer! This is useful to connect it to <strong>item filters</strong> for example.<br><br>
-            The constant signal can emit a <strong>shape</strong>, <strong>color</strong> or <strong>boolean</strong> (1 or 0).
+  reward_constant_signal:
+    title: Constant Signal
+    desc: >-
+      You unlocked the <strong>constant signal</strong> building on the wires layer! This is useful to connect it to <strong>item filters</strong> for example.<br><br>
+      The constant signal can emit a <strong>shape</strong>, <strong>color</strong> or <strong>boolean</strong> (1 or 0).
 
-    reward_logic_gates:
-        title: Logic Gates
-        desc: >-
-            You unlocked <strong>logic gates</strong>! You don't have to be excited about this, but it's actually super cool!<br><br>
-            With logic gates you can now compute AND, OR, XOR and NOT operations.<br><br>
-            As a bonus on top I also just gave you a <strong>transistor</strong>!
+  reward_logic_gates:
+    title: Logic Gates
+    desc: >-
+      You unlocked <strong>logic gates</strong>! You don't have to be excited about this, but it's actually super cool!<br><br>
+      With logic gates you can now compute AND, OR, XOR and NOT operations.<br><br>
+      As a bonus on top I also just gave you a <strong>transistor</strong>!
 
-    reward_virtual_processing:
-        title: Virtual Processing
-        desc: >-
-            I just gave a whole bunch of new buildings which allow you to <strong>simulate the processing of shapes</strong>!<br><br>
-            You can now simulate a cutter, rotator, stacker and more on the wires layer!
-            With this you now have three options to continue the game:<br><br>
-            - Build an <strong>automated machine</strong> to create any possible shape requested by the HUB (I recommend to try it!).<br><br>
-            - Build something cool with wires.<br><br>
-            - Continue to play normally.<br><br>
-            Whatever you choose, remember to have fun!
+  reward_virtual_processing:
+    title: Virtual Processing
+    desc: >-
+      I just gave a whole bunch of new buildings which allow you to <strong>simulate the processing of shapes</strong>!<br><br>
+      You can now simulate a cutter, rotator, stacker and more on the wires layer!
+      With this you now have three options to continue the game:<br><br>
+      - Build an <strong>automated machine</strong> to create any possible shape requested by the HUB (I recommend to try it!).<br><br>
+      - Build something cool with wires.<br><br>
+      - Continue to play normally.<br><br>
+      Whatever you choose, remember to have fun!
 
-    # Special reward, which is shown when there is no reward actually
-    no_reward:
-        title: Next level
-        desc: >-
-            This level gave you no reward, but the next one will! <br><br> PS: Better not destroy your existing factory - You'll need <strong>all</strong> those shapes later to
-            <strong>unlock upgrades</strong>!
+  # Special reward, which is shown when there is no reward actually
+  no_reward:
+    title: Next level
+    desc: >-
+      This level gave you no reward, but the next one will! <br><br> PS: Better not destroy your existing factory - You'll need <strong>all</strong> those shapes later to
+      <strong>unlock upgrades</strong>!
 
-    no_reward_freeplay:
-        title: Next level
-        desc: >-
-            Congratulations!
+  no_reward_freeplay:
+    title: Next level
+    desc: >-
+      Congratulations!
 
-    reward_freeplay:
-        title: Freeplay
-        desc: >-
-            You did it! You unlocked the <strong>free-play mode</strong>! This means that shapes are now <strong>randomly</strong> generated!<br><br>
-            Since the hub will require a <strong>throughput</strong> from now on, I highly recommend to build a machine which automatically delivers the requested shape!<br><br>
-            The HUB outputs the requested shape on the wires layer, so all you have to do is to analyze it and automatically configure your factory based on that.
+  reward_freeplay:
+    title: Freeplay
+    desc: >-
+      You did it! You unlocked the <strong>free-play mode</strong>! This means that shapes are now <strong>randomly</strong> generated!<br><br>
+      Since the hub will require a <strong>throughput</strong> from now on, I highly recommend to build a machine which automatically delivers the requested shape!<br><br>
+      The HUB outputs the requested shape on the wires layer, so all you have to do is to analyze it and automatically configure your factory based on that.
 
-    reward_demo_end:
-        title: End of Demo
-        desc: >-
-            You have reached the end of the demo version!
+  reward_demo_end:
+    title: End of Demo
+    desc: >-
+      You have reached the end of the demo version!
 
 settings:
-    title: Settings
-    categories:
-        general: General
-        userInterface: User Interface
-        advanced: Advanced
-        performance: Performance
+  title: Settings
+  categories:
+    general: General
+    userInterface: User Interface
+    advanced: Advanced
+    performance: Performance
 
-    versionBadges:
-        dev: Development
-        staging: Staging
-        prod: Production
-    buildDate: Built <at-date>
+  versionBadges:
+    dev: Development
+    staging: Staging
+    prod: Production
+  buildDate: Built <at-date>
 
-    rangeSliderPercentage: <amount> %
+  rangeSliderPercentage: <amount> %
 
-    labels:
-        uiScale:
-            title: Interface scale
-            description: >-
-                Changes the size of the user interface. The interface will still scale based on your device's resolution, but this setting controls the amount of scaling.
-            scales:
-                super_small: Super small
-                small: Small
-                regular: Regular
-                large: Large
-                huge: Huge
+  labels:
+    uiScale:
+      title: Interface scale
+      description: >-
+        Changes the size of the user interface. The interface will still scale based on your device's resolution, but this setting controls the amount of scaling.
+      scales:
+        super_small: Super small
+        small: Small
+        regular: Regular
+        large: Large
+        huge: Huge
 
-        autosaveInterval:
-            title: Autosave Interval
-            description: >-
-                Controls how often the game saves automatically. You can also disable it entirely here.
+    autosaveInterval:
+      title: Autosave Interval
+      description: >-
+        Controls how often the game saves automatically. You can also disable it entirely here.
 
-            intervals:
-                one_minute: 1 Minute
-                two_minutes: 2 Minutes
-                five_minutes: 5 Minutes
-                ten_minutes: 10 Minutes
-                twenty_minutes: 20 Minutes
-                disabled: Disabled
+      intervals:
+        one_minute: 1 Minute
+        two_minutes: 2 Minutes
+        five_minutes: 5 Minutes
+        ten_minutes: 10 Minutes
+        twenty_minutes: 20 Minutes
+        disabled: Disabled
 
-        scrollWheelSensitivity:
-            title: Zoom sensitivity
-            description: >-
-                Changes how sensitive the zoom is (Either mouse wheel or trackpad).
-            sensitivity:
-                super_slow: Super slow
-                slow: Slow
-                regular: Regular
-                fast: Fast
-                super_fast: Super fast
+    scrollWheelSensitivity:
+      title: Zoom sensitivity
+      description: >-
+        Changes how sensitive the zoom is (Either mouse wheel or trackpad).
+      sensitivity:
+        super_slow: Super slow
+        slow: Slow
+        regular: Regular
+        fast: Fast
+        super_fast: Super fast
 
-        movementSpeed:
-            title: Movement speed
-            description: >-
-                Changes how fast the view moves when using the keyboard or moving the mouse to the screen borders.
-            speeds:
-                super_slow: Super slow
-                slow: Slow
-                regular: Regular
-                fast: Fast
-                super_fast: Super Fast
-                extremely_fast: Extremely Fast
+    movementSpeed:
+      title: Movement speed
+      description: >-
+        Changes how fast the view moves when using the keyboard or moving the mouse to the screen borders.
+      speeds:
+        super_slow: Super slow
+        slow: Slow
+        regular: Regular
+        fast: Fast
+        super_fast: Super Fast
+        extremely_fast: Extremely Fast
 
-        language:
-            title: Language
-            description: >-
-                Change the language. All translations are user-contributed and might be incomplete!
+    language:
+      title: Language
+      description: >-
+        Change the language. All translations are user-contributed and might be incomplete!
 
-        enableColorBlindHelper:
-            title: Color Blind Mode
-            description: >-
-                Enables various tools which allow you to play the game if you are color blind.
+    enableColorBlindHelper:
+      title: Color Blind Mode
+      description: >-
+        Enables various tools which allow you to play the game if you are color blind.
 
-        fullscreen:
-            title: Fullscreen
-            description: >-
-                It is recommended to play the game in fullscreen to get the best experience. Only available in the standalone.
+    fullscreen:
+      title: Fullscreen
+      description: >-
+        It is recommended to play the game in fullscreen to get the best experience. Only available in the standalone.
 
-        soundsMuted:
-            title: Mute Sounds
-            description: >-
-                If enabled, mutes all sound effects.
+    soundsMuted:
+      title: Mute Sounds
+      description: >-
+        If enabled, mutes all sound effects.
 
-        musicMuted:
-            title: Mute Music
-            description: >-
-                If enabled, mutes all music.
+    musicMuted:
+      title: Mute Music
+      description: >-
+        If enabled, mutes all music.
 
-        soundVolume:
-            title: Sound Volume
-            description: >-
-                Set the volume for sound effects
+    soundVolume:
+      title: Sound Volume
+      description: >-
+        Set the volume for sound effects
 
-        musicVolume:
-            title: Music Volume
-            description: >-
-                Set the volume for music
+    musicVolume:
+      title: Music Volume
+      description: >-
+        Set the volume for music
 
-        theme:
-            title: Game theme
-            description: >-
-                Choose the game theme (light / dark).
-            themes:
-                dark: Dark
-                light: Light
+    theme:
+      title: Game theme
+      description: >-
+        Choose the game theme (light / dark).
+      themes:
+        dark: Dark
+        light: Light
 
-        refreshRate:
-            title: Tick Rate
-            description: >-
-                This determines how many game ticks happen per second. In general, a higher tick rate means better precision but also worse performance. On lower tickrates, the throughput may not be
-                exact.
+    refreshRate:
+      title: Tick Rate
+      description: >-
+        This determines how many game ticks happen per second. In general, a higher tick rate means better precision but also worse performance. On lower tickrates, the throughput may not be
+        exact.
 
-        alwaysMultiplace:
-            title: Multiplace
-            description: >-
-                If enabled, all buildings will stay selected after placement until you cancel it. This is equivalent to constantly holding SHIFT.
+    alwaysMultiplace:
+      title: Multiplace
+      description: >-
+        If enabled, all buildings will stay selected after placement until you cancel it. This is equivalent to constantly holding SHIFT.
 
-        offerHints:
-            title: Hints & Tutorials
-            description: >-
-                Whether to offer hints and tutorials while playing. Also hides certain UI elements up to a given level to make it easier to get into the game.
+    offerHints:
+      title: Hints & Tutorials
+      description: >-
+        Whether to offer hints and tutorials while playing. Also hides certain UI elements up to a given level to make it easier to get into the game.
 
-        enableTunnelSmartplace:
-            title: Smart Tunnels
-            description: >-
-                When enabled, placing tunnels will automatically remove unnecessary belts. This also enables you to drag tunnels and excess tunnels will get removed.
+    enableTunnelSmartplace:
+      title: Smart Tunnels
+      description: >-
+        When enabled, placing tunnels will automatically remove unnecessary belts. This also enables you to drag tunnels and excess tunnels will get removed.
 
-        vignette:
-            title: Vignette
-            description: >-
-                Enables the vignette, which darkens the screen corners and makes text easier to read.
+    vignette:
+      title: Vignette
+      description: >-
+        Enables the vignette, which darkens the screen corners and makes text easier to read.
 
-        rotationByBuilding:
-            title: Rotation by building type
-            description: >-
-                Each building type remembers the rotation you last set it to individually. This may be more comfortable if you frequently switch between placing different building types.
+    rotationByBuilding:
+      title: Rotation by building type
+      description: >-
+        Each building type remembers the rotation you last set it to individually. This may be more comfortable if you frequently switch between placing different building types.
 
-        compactBuildingInfo:
-            title: Compact Building Infos
-            description: >-
-                Shortens info boxes for buildings by only showing their ratios. Otherwise a description and image is shown.
+    compactBuildingInfo:
+      title: Compact Building Infos
+      description: >-
+        Shortens info boxes for buildings by only showing their ratios. Otherwise a description and image is shown.
 
-        disableCutDeleteWarnings:
-            title: Disable Cut/Delete Warnings
-            description: >-
-                Disables the warning dialogues brought up when cutting/deleting more than 100 entities.
+    disableCutDeleteWarnings:
+      title: Disable Cut/Delete Warnings
+      description: >-
+        Disables the warning dialogues brought up when cutting/deleting more than 100 entities.
 
-        lowQualityMapResources:
-            title: Low Quality Map Resources
-            description: >-
-                Simplifies the rendering of resources on the map when zoomed in to improve performance.
-                It even looks cleaner, so be sure to try it out!
+    lowQualityMapResources:
+      title: Low Quality Map Resources
+      description: >-
+        Simplifies the rendering of resources on the map when zoomed in to improve performance.
+        It even looks cleaner, so be sure to try it out!
 
-        disableTileGrid:
-            title: Disable Grid
-            description: >-
-                Disabling the tile grid can help with the performance. This also makes the game look cleaner!
+    disableTileGrid:
+      title: Disable Grid
+      description: >-
+        Disabling the tile grid can help with the performance. This also makes the game look cleaner!
 
-        clearCursorOnDeleteWhilePlacing:
-            title: Clear Cursor on Right Click
-            description: >-
-                Enabled by default, clears the cursor whenever you right click while you have a building selected for placement. If disabled, you can delete buildings by right-clicking while placing
-                a building.
+    clearCursorOnDeleteWhilePlacing:
+      title: Clear Cursor on Right Click
+      description: >-
+        Enabled by default, clears the cursor whenever you right click while you have a building selected for placement. If disabled, you can delete buildings by right-clicking while placing
+        a building.
 
-        lowQualityTextures:
-            title: Low quality textures (Ugly)
-            description: >-
-                Uses low quality textures to save performance. This will make the game look very ugly!
+    lowQualityTextures:
+      title: Low quality textures (Ugly)
+      description: >-
+        Uses low quality textures to save performance. This will make the game look very ugly!
 
-        displayChunkBorders:
-            title: Display Chunk Borders
-            description: >-
-                The game is divided into chunks of 16x16 tiles, if this setting is enabled the borders of each chunk are displayed.
+    displayChunkBorders:
+      title: Display Chunk Borders
+      description: >-
+        The game is divided into chunks of 16x16 tiles, if this setting is enabled the borders of each chunk are displayed.
 
-        pickMinerOnPatch:
-            title: Select extractor on resource patch
-            description: >-
-                Enabled by default, selects the extractor if you use the pipette when hovering a resource patch.
+    pickMinerOnPatch:
+      title: Select extractor on resource patch
+      description: >-
+        Enabled by default, selects the extractor if you use the pipette when hovering a resource patch.
 
-        simplifiedBelts:
-            title: Simplified Belts (Ugly)
-            description: >-
-                Does not render belt items except when hovering the belt to save performance. I do not recommend to play with this setting if you do not absolutely need the performance.
+    simplifiedBelts:
+      title: Simplified Belts (Ugly)
+      description: >-
+        Does not render belt items except when hovering the belt to save performance. I do not recommend to play with this setting if you do not absolutely need the performance.
 
-        enableMousePan:
-            title: Screen Edge Panning
-            description: >-
-                Allows panning the map by moving the cursor to the edges of the screen. The scroll speed depends on the Movement Speed setting.
+    enableMousePan:
+      title: Screen Edge Panning
+      description: >-
+        Allows panning the map by moving the cursor to the edges of the screen. The scroll speed depends on the Movement Speed setting.
 
-        zoomToCursor:
-            title: Zoom towards Cursor
-            description: >-
-                If activated the zoom will happen in the direction of your mouse position, otherwise in the middle of the screen.
+    zoomToCursor:
+      title: Zoom towards Cursor
+      description: >-
+        If activated the zoom will happen in the direction of your mouse position, otherwise in the middle of the screen.
 
-        mapResourcesScale:
-            title: Map Resources Size
-            description: >-
-                Controls the size of the shapes on the map overview (when zooming out).
+    mapResourcesScale:
+      title: Map Resources Size
+      description: >-
+        Controls the size of the shapes on the map overview (when zooming out).
 
 keybindings:
-    title: Keybindings
-    hint: >-
-        Tip: Be sure to make use of CTRL, SHIFT and ALT! They enable different placement options.
+  title: Keybindings
+  hint: >-
+    Tip: Be sure to make use of CTRL, SHIFT and ALT! They enable different placement options.
 
-    resetKeybindings: Reset
+  resetKeybindings: Reset
 
-    categoryLabels:
-        general: Application
-        ingame: Game
-        navigation: Navigating
-        placement: Placement
-        massSelect: Mass Select
-        buildings: Building Shortcuts
-        placementModifiers: Placement Modifiers
+  categoryLabels:
+    general: Application
+    ingame: Game
+    navigation: Navigating
+    placement: Placement
+    massSelect: Mass Select
+    buildings: Building Shortcuts
+    placementModifiers: Placement Modifiers
 
-    mappings:
-        confirm: Confirm
-        back: Back
-        mapMoveUp: Move Up
-        mapMoveRight: Move Right
-        mapMoveDown: Move Down
-        mapMoveLeft: Move Left
-        mapMoveFaster: Move Faster
-        centerMap: Center Map
+  mappings:
+    confirm: Confirm
+    back: Back
+    mapMoveUp: Move Up
+    mapMoveRight: Move Right
+    mapMoveDown: Move Down
+    mapMoveLeft: Move Left
+    mapMoveFaster: Move Faster
+    centerMap: Center Map
 
-        mapZoomIn: Zoom in
-        mapZoomOut: Zoom out
-        createMarker: Create Marker
+    mapZoomIn: Zoom in
+    mapZoomOut: Zoom out
+    createMarker: Create Marker
 
-        menuOpenShop: Upgrades
-        menuOpenStats: Statistics
-        menuClose: Close Menu
+    menuOpenShop: Upgrades
+    menuOpenStats: Statistics
+    menuClose: Close Menu
 
-        toggleHud: Toggle HUD
-        toggleFPSInfo: Toggle FPS and Debug Info
-        switchLayers: Switch layers
-        exportScreenshot: Export whole Base as Image
+    toggleHud: Toggle HUD
+    toggleFPSInfo: Toggle FPS and Debug Info
+    switchLayers: Switch layers
+    exportScreenshot: Export whole Base as Image
 
-        # --- Do not translate the values in this section
-        belt: *belt
-        balancer: *balancer
-        underground_belt: *underground_belt
-        miner: *miner
-        cutter: *cutter
-        rotater: *rotater
-        stacker: *stacker
-        mixer: *mixer
-        painter: *painter
-        trash: *trash
-        storage: *storage
-        wire: *wire
-        constant_signal: *constant_signal
-        logic_gate: Logic Gate
-        lever: *lever
-        filter: *filter
-        wire_tunnel: *wire_tunnel
-        display: *display
-        reader: *reader
-        virtual_processor: *virtual_processor
-        transistor: *transistor
-        analyzer: *analyzer
-        comparator: *comparator
-        item_producer: Item Producer (Sandbox)
-        # ---
+    # --- Do not translate the values in this section
+    belt: *belt
+    balancer: *balancer
+    underground_belt: *underground_belt
+    miner: *miner
+    cutter: *cutter
+    rotater: *rotater
+    stacker: *stacker
+    mixer: *mixer
+    painter: *painter
+    trash: *trash
+    storage: *storage
+    wire: *wire
+    constant_signal: *constant_signal
+    logic_gate: Logic Gate
+    lever: *lever
+    filter: *filter
+    wire_tunnel: *wire_tunnel
+    display: *display
+    reader: *reader
+    virtual_processor: *virtual_processor
+    transistor: *transistor
+    analyzer: *analyzer
+    comparator: *comparator
+    item_producer: Item Producer (Sandbox)
+    # ---
 
-        pipette: Pipette
-        rotateWhilePlacing: Rotate
-        rotateInverseModifier: >-
-            Modifier: Rotate CCW instead
-        cycleBuildingVariants: Cycle Variants
-        confirmMassDelete: Delete area
-        pasteLastBlueprint: Paste last blueprint
-        cycleBuildings: Cycle Buildings
-        lockBeltDirection: Enable belt planner
-        switchDirectionLockSide: >-
-            Planner: Switch side
-        copyWireValue: >-
-            Wires: Copy value below cursor
-        massSelectStart: Hold and drag to start
-        massSelectSelectMultiple: Select multiple areas
-        massSelectCopy: Copy area
-        massSelectCut: Cut area
+    pipette: Pipette
+    rotateWhilePlacing: Rotate
+    rotateInverseModifier: >-
+      Modifier: Rotate CCW instead
+    cycleBuildingVariants: Cycle Variants
+    confirmMassDelete: Delete area
+    pasteLastBlueprint: Paste last blueprint
+    cycleBuildings: Cycle Buildings
+    lockBeltDirection: Enable belt planner
+    switchDirectionLockSide: >-
+      Planner: Switch side
+    copyWireValue: >-
+      Wires: Copy value below cursor
+    massSelectStart: Hold and drag to start
+    massSelectSelectMultiple: Select multiple areas
+    massSelectCopy: Copy area
+    massSelectCut: Cut area
 
-        placementDisableAutoOrientation: Disable automatic orientation
-        placeMultiple: Stay in placement mode
-        placeInverse: Invert automatic belt orientation
+    placeBuilding: Place Building
+    placementDisableAutoOrientation: Disable automatic orientation
+    placeMultiple: Stay in placement mode
+    placeInverse: Invert automatic belt orientation
 
 about:
-    title: About this Game
-    body: >-
-        This game is open source and developed by <a href="https://github.com/tobspr" target="_blank">Tobias Springer</a> (this is me).<br><br>
+  title: About this Game
+  body: >-
+    This game is open source and developed by <a href="https://github.com/tobspr" target="_blank">Tobias Springer</a> (this is me).<br><br>
 
-        If you want to contribute, check out <a href="<githublink>" target="_blank">shapez.io on GitHub</a>.<br><br>
+    If you want to contribute, check out <a href="<githublink>" target="_blank">shapez.io on GitHub</a>.<br><br>
 
-        This game wouldn't have been possible without the great Discord community around my games - You should really join the <a href="<discordlink>" target="_blank">Discord server</a>!<br><br>
+    This game wouldn't have been possible without the great Discord community around my games - You should really join the <a href="<discordlink>" target="_blank">Discord server</a>!<br><br>
 
-        The soundtrack was made by <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsen</a> - He's awesome.<br><br>
+    The soundtrack was made by <a href="https://soundcloud.com/pettersumelius" target="_blank">Peppsen</a> - He's awesome.<br><br>
 
-        Finally, huge thanks to my best friend <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Without our Factorio sessions, this game would never have existed.
+    Finally, huge thanks to my best friend <a href="https://github.com/niklas-dahl" target="_blank">Niklas</a> - Without our Factorio sessions, this game would never have existed.
 
 changelog:
-    title: Changelog
+  title: Changelog
 
 demo:
-    features:
-        restoringGames: Restoring savegames
-        importingGames: Importing savegames
-        oneGameLimit: Limited to one savegame
-        customizeKeybindings: Customizing Keybindings
-        exportingBase: Exporting whole Base as Image
+  features:
+    restoringGames: Restoring savegames
+    importingGames: Importing savegames
+    oneGameLimit: Limited to one savegame
+    customizeKeybindings: Customizing Keybindings
+    exportingBase: Exporting whole Base as Image
 
-    settingNotAvailable: Not available in the demo.
+  settingNotAvailable: Not available in the demo.
 
 tips:
-    - The hub will accept any input, not just the current shape!
-    - Make sure your factories are modular - it will pay out!
-    - Don't build too close to the hub, or it will be a mess!
-    - If stacking does not work, try switching the inputs.
-    - You can toggle the belt planner direction by pressing <b>R</b>.
-    - Holding <b>CTRL</b> allows dragging of belts without auto-orientation.
-    - Ratios stay the same, as long as all upgrades are on the same Tier.
-    - Serial execution is more efficient than parallel.
-    - You will unlock more variants of buildings later in the game!
-    - You can use <b>T</b> to switch between different variants.
-    - Symmetry is key!
-    - You can weave different tiers of tunnels.
-    - Try to build compact factories - it will pay out!
-    - The painter has a mirrored variant which you can select with <b>T</b>
-    - Having the right building ratios will maximize efficiency.
-    - At maximum level, 5 extractors will fill a single belt.
-    - Don't forget about tunnels!
-    - You don't need to divide up items evenly for full efficiency.
-    - Holding <b>SHIFT</b> will activate the belt planner, letting you place long lines of belts easily.
-    - Cutters always cut vertically, regardless of their orientation.
-    - The storage buffer prioritises the left output.
-    - Invest time to build repeatable designs - it's worth it!
-    - Holding <b>SHIFT</b> lets you place multiple buildings at a time.
-    - You can hold <b>ALT</b> to invert the direction of placed belts.
-    - Efficiency is key!
-    - Shape patches that are further away from the hub are more complex.
-    - Machines have a limited speed, divide them up for maximum efficiency.
-    - Use balancers to maximize your efficiency.
-    - Organization is important. Try not to cross conveyors too much.
-    - Plan in advance, or it will be a mess!
-    - Don't remove your old factories! You'll need them to unlock upgrades.
-    - Try beating level 20 or 26 on your own before seeking for help!
-    - Don't complicate things, try to stay simple and you'll go far.
-    - You may need to reuse factories later in the game. Build your factories to be reusable.
-    - Sometimes, you can find a needed shape in the map without creating it with stackers.
-    - Full windmills/pinwheels can never spawn naturally.
-    - Color your shapes before cutting for maximum efficiency.
-    - With modules, space is merely a perception; a concern for mortal men.
-    - Make a separate blueprint factory. They're important for modules.
-    - Have a closer look at the color mixer, and your questions will be answered.
-    - Use <b>CTRL</b> + Click to select an area.
-    - Building too close to the hub can get in the way of later projects.
-    - The pin icon next to each shape in the upgrade list pins it to the screen.
-    - Mix all three primary colors to make white!
-    - You have an infinite map. Don't cramp your factory, expand!
-    - Also try Factorio! It's my favorite game.
-    - The quad cutter cuts clockwise, starting from the top right.
-    - You can download your savegames in the main menu!
-    - This game has a lot of useful keybindings! Be sure to check out the settings page.
-    - This game has a lot of settings, be sure to check them out!
-    - Your hub marker has a small compass that shows which direction it is in!
-    - To clear belts, cut the area and then paste it at the same location.
-    - Press F4 to show your FPS and Tick Rate.
-    - Press F4 twice to show the tile of your mouse and camera.
-    - You can click a pinned shape on the left side to unpin it.
+  - The hub will accept any input, not just the current shape!
+  - Make sure your factories are modular - it will pay out!
+  - Don't build too close to the hub, or it will be a mess!
+  - If stacking does not work, try switching the inputs.
+  - You can toggle the belt planner direction by pressing <b>R</b>.
+  - Holding <b>CTRL</b> allows dragging of belts without auto-orientation.
+  - Ratios stay the same, as long as all upgrades are on the same Tier.
+  - Serial execution is more efficient than parallel.
+  - You will unlock more variants of buildings later in the game!
+  - You can use <b>T</b> to switch between different variants.
+  - Symmetry is key!
+  - You can weave different tiers of tunnels.
+  - Try to build compact factories - it will pay out!
+  - The painter has a mirrored variant which you can select with <b>T</b>
+  - Having the right building ratios will maximize efficiency.
+  - At maximum level, 5 extractors will fill a single belt.
+  - Don't forget about tunnels!
+  - You don't need to divide up items evenly for full efficiency.
+  - Holding <b>SHIFT</b> will activate the belt planner, letting you place long lines of belts easily.
+  - Cutters always cut vertically, regardless of their orientation.
+  - The storage buffer prioritises the left output.
+  - Invest time to build repeatable designs - it's worth it!
+  - Holding <b>SHIFT</b> lets you place multiple buildings at a time.
+  - You can hold <b>ALT</b> to invert the direction of placed belts.
+  - Efficiency is key!
+  - Shape patches that are further away from the hub are more complex.
+  - Machines have a limited speed, divide them up for maximum efficiency.
+  - Use balancers to maximize your efficiency.
+  - Organization is important. Try not to cross conveyors too much.
+  - Plan in advance, or it will be a mess!
+  - Don't remove your old factories! You'll need them to unlock upgrades.
+  - Try beating level 20 or 26 on your own before seeking for help!
+  - Don't complicate things, try to stay simple and you'll go far.
+  - You may need to reuse factories later in the game. Build your factories to be reusable.
+  - Sometimes, you can find a needed shape in the map without creating it with stackers.
+  - Full windmills/pinwheels can never spawn naturally.
+  - Color your shapes before cutting for maximum efficiency.
+  - With modules, space is merely a perception; a concern for mortal men.
+  - Make a separate blueprint factory. They're important for modules.
+  - Have a closer look at the color mixer, and your questions will be answered.
+  - Use <b>CTRL</b> + Click to select an area.
+  - Building too close to the hub can get in the way of later projects.
+  - The pin icon next to each shape in the upgrade list pins it to the screen.
+  - Mix all three primary colors to make white!
+  - You have an infinite map. Don't cramp your factory, expand!
+  - Also try Factorio! It's my favorite game.
+  - The quad cutter cuts clockwise, starting from the top right.
+  - You can download your savegames in the main menu!
+  - This game has a lot of useful keybindings! Be sure to check out the settings page.
+  - This game has a lot of settings, be sure to check them out!
+  - Your hub marker has a small compass that shows which direction it is in!
+  - To clear belts, cut the area and then paste it at the same location.
+  - Press F4 to show your FPS and Tick Rate.
+  - Press F4 twice to show the tile of your mouse and camera.
+  - You can click a pinned shape on the left side to unpin it.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5103,14 +5103,6 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-line-column@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/line-column/-/line-column-1.0.2.tgz#d25af2936b6f4849172b312e4792d1d987bc34a2"
-  integrity sha1-0lryk2tvSEkXKzEuR5LR2Ye8NKI=
-  dependencies:
-    isarray "^1.0.0"
-    isobject "^2.0.0"
-
 load-bmfont@^1.3.1, load-bmfont@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/load-bmfont/-/load-bmfont-1.4.0.tgz#75f17070b14a8c785fe7f5bee2e6fd4f98093b6b"
@@ -5619,10 +5611,10 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
   integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
 
-nanoid@^3.1.12:
-  version "3.1.12"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.12.tgz#6f7736c62e8d39421601e4a0c77623a97ea69654"
-  integrity sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==
+nanoid@^3.1.20:
+  version "3.1.20"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
+  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -6927,6 +6919,15 @@ postcss-zindex@^4.0.1:
     postcss "^7.0.0"
     uniqs "^2.0.0"
 
+postcss@>=5.0.0:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.1.tgz#eabc5557c4558059b9d9e5b15bce7ffa9089c2a8"
+  integrity sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==
+  dependencies:
+    colorette "^1.2.1"
+    nanoid "^3.1.20"
+    source-map "^0.6.1"
+
 postcss@^5.0.2:
   version "5.2.18"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-5.2.18.tgz#badfa1497d46244f6390f58b319830d9107853c5"
@@ -6954,16 +6955,6 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
-
-postcss@^8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.1.1.tgz#c3a287dd10e4f6c84cb3791052b96a5d859c9389"
-  integrity sha512-9DGLSsjooH3kSNjTZUOt2eIj2ZTW0VI2PZ/3My+8TC7KIbH2OKwUlISfDsf63EP4aiRUt3XkEWMWvyJHvJelEg==
-  dependencies:
-    colorette "^1.2.1"
-    line-column "^1.0.2"
-    nanoid "^3.1.12"
-    source-map "^0.6.1"
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Solving #1039 

Adds basic support for gamepad buttons available as keybindings

This is pretty rudimental implementation.

I think ideally the gamepad controls would be fixed (i.e. not configurable). Also it would be ideal to add sort of "tile cursor", and make use of dual joystick gamepad controls - one to move view, one to move cursor.

Needed to add keybindings for previously hardcoded mouse buttons for building placement and delete.

Some keybindings are useful to be overloaded - like delete and rotate with single gamepad button, as those actions are mutually exclusive based on the context. Given that gamepad has limited number of buttons, this is must do.

This PR is just proof-of-concept. Not all game aspects are supported yet (wires, don't know what else is there)

Mouse drag gestures may be tricky (i.e. belt placing). Not supported right now.

Does not recognize joysticks (yet)

## My mappings

* Move view - Gamepad arrows cross
* Zoom in / Zoom out - LT / RT
* Cycle buildings - RB
* Cycle alternatives - LB
* Place building - A
* Rotate building / Delete building - B