### PR TITLE
SCSS: Fix variable name ($num -> $animName)

### DIFF
--- a/src/css/animations.scss
+++ b/src/css/animations.scss
@@ -1,4 +1,4 @@
-@each $num in ("changeAnimEven", "changeAnimOdd") {
+@each $animName in ("changeAnimEven", "changeAnimOdd") {
     @keyframes #{$animName} {
         0% {
             transform: scale(1, 1);


### PR DESCRIPTION
As always, I forget "that one last change" before I make a Pull Request, and this time I did not finish refactoring animation code (it really sucked before)... Sorry.

Attaching build log to be sure that is right:
<details>
<summary><code>yarn gulp css.dev</code></summary>
<pre>
[03:21:09] Starting 'css.dev'...
[03:21:09] Starting 'css.main.dev'...
[03:21:09] Starting 'css.resources.dev'...
[03:21:14] Finished 'css.main.dev' after 4.19 s
[03:21:14] Finished 'css.resources.dev' after 4.33 s
[03:21:14] Finished 'css.dev' after 4.34 s
Done in 6.20s.
</pre>
</details>