### PR TITLE
Fixed the bug that caused the double painter to run slower than shown

### DIFF
--- a/src/js/game/components/item_processor.js
+++ b/src/js/game/components/item_processor.js
@@ -96,7 +96,7 @@ export class ItemProcessorComponent extends Component {
          * @type {number}
          */
         this.bonusTime = 0;
-        
+
         /**
          * The extra time it took to empty the last charge to the outputs
          * @type {number}

--- a/src/js/game/components/item_processor.js
+++ b/src/js/game/components/item_processor.js
@@ -96,6 +96,12 @@ export class ItemProcessorComponent extends Component {
          * @type {number}
          */
         this.bonusTime = 0;
+        
+        /**
+         * The extra time it took to empty the last charge to the outputs
+         * @type {number}
+         */
+        this.extraOutputTime = 0;
     }
 
     /**

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -79,7 +79,8 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
             if (currentCharge) {
                 // Process next charge
                 if (currentCharge.remainingTime > 0.0) {
-                    currentCharge.remainingTime -= this.root.dynamicTickrate.deltaSeconds;
+                    const deltaTime = this.root.dynamicTickrate.deltaSeconds + processorComp.bonusTime;
+                    currentCharge.remainingTime -= deltaTime;
                     if (currentCharge.remainingTime < 0.0) {
                         // Add bonus time, this is the time we spent too much
                         processorComp.bonusTime += -currentCharge.remainingTime;

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -300,7 +300,7 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
         const bonusTimeToApply = Math.min(originalTime, processorComp.bonusTime);
         let timeToProcess = originalTime - bonusTimeToApply;
         const itemOnBeltSpeed = 1 / this.root.hubGoals.getBeltBaseSpeed();
-        if (processorComp.extraOutputTime <= itemOnBeltSpeed){
+        if (processorComp.extraOutputTime <= itemOnBeltSpeed) {
             timeToProcess -= processorComp.extraOutputTime;
         }
         processorComp.extraOutputTime = 0;

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -293,7 +293,7 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
         }
 
         // Queue Charge
-        let baseSpeed = this.root.hubGoals.getProcessorBaseSpeed(processorComp.type);
+        const baseSpeed = this.root.hubGoals.getProcessorBaseSpeed(processorComp.type);
         const originalTime = 1 / baseSpeed;
 
         const bonusTimeToApply = Math.min(originalTime, processorComp.bonusTime);

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -128,6 +128,8 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
                     // If the charge was entirely emptied to the outputs, start the next charge
                     if (itemsToEject.length === 0) {
                         processorComp.ongoingCharges.shift();
+                    } else {
+                        processorComp.extraOutputTime += this.root.dynamicTickrate.deltaSeconds;
                     }
                 }
             }
@@ -291,12 +293,15 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
         }
 
         // Queue Charge
-        const baseSpeed = this.root.hubGoals.getProcessorBaseSpeed(processorComp.type);
+        let baseSpeed = this.root.hubGoals.getProcessorBaseSpeed(processorComp.type);
         const originalTime = 1 / baseSpeed;
 
         const bonusTimeToApply = Math.min(originalTime, processorComp.bonusTime);
-        const timeToProcess = originalTime - bonusTimeToApply;
-
+        let timeToProcess = originalTime - bonusTimeToApply;
+        if(processorComp.extraOutputTime <= 1 / this.root.hubGoals.getBeltBaseSpeed()){
+            timeToProcess -= processorComp.extraOutputTime;
+        }
+        processorComp.extraOutputTime = 0;
         processorComp.bonusTime -= bonusTimeToApply;
         processorComp.ongoingCharges.push({
             items: outItems,

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -299,8 +299,8 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
 
         const bonusTimeToApply = Math.min(originalTime, processorComp.bonusTime);
         let timeToProcess = originalTime - bonusTimeToApply;
-        const itemOnBeltSpeed = 1/ this.root.hubGoals.getBeltBaseSpeed();
-        if(processorComp.extraOutputTime <= itemOnBeltSpeed){
+        const itemOnBeltSpeed = 1 / this.root.hubGoals.getBeltBaseSpeed();
+        if (processorComp.extraOutputTime <= itemOnBeltSpeed){
             timeToProcess -= processorComp.extraOutputTime;
         }
         processorComp.extraOutputTime = 0;

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -299,7 +299,8 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
 
         const bonusTimeToApply = Math.min(originalTime, processorComp.bonusTime);
         let timeToProcess = originalTime - bonusTimeToApply;
-        if(processorComp.extraOutputTime <= 1 / this.root.hubGoals.getBeltBaseSpeed()){
+        const itemOnBeltSpeed = 1/ this.root.hubGoals.getBeltBaseSpeed();
+        if(processorComp.extraOutputTime <= itemOnBeltSpeed){
             timeToProcess -= processorComp.extraOutputTime;
         }
         processorComp.extraOutputTime = 0;


### PR DESCRIPTION
The double painter outputs two shapes to the same output, and this means that the next charge doesn't start processing until the second item has started ejecting. 
To stop this, I have added a new variable in the item processor which keeps track of the extra time it takes for a building to push all the shapes to the outputs.

When starting a new charge, if the extraOutputTime is less than the time it takes for one item to travel along a belt (this is to prevent backed up buildings to start new charges with no wait time) the time it would take to process that charge is reduced by the extra time it took to output the last charge.

Hopefully the code isn't too messy :).