### PR TITLE
WIP: undo / redo commands (entity placement)

### DIFF
--- a/src/js/core/input_distributor.js
+++ b/src/js/core/input_distributor.js
@@ -210,6 +210,7 @@ export class InputDistributor {
             this.forwardToReceiver("keydown", {
                 keyCode: keyCode,
                 shift: event.shiftKey,
+                ctrl: event.ctrlKey,
                 alt: event.altKey,
                 initial: isInitial,
                 event,

--- a/src/js/game/core.js
+++ b/src/js/game/core.js
@@ -38,6 +38,7 @@ import { ShapeDefinitionManager } from "./shape_definition_manager";
 import { AchievementProxy } from "./achievement_proxy";
 import { SoundProxy } from "./sound_proxy";
 import { GameTime } from "./time/game_time";
+import { HistoryManager } from "./history_manager";
 
 const logger = createLogger("ingame/core");
 
@@ -123,6 +124,7 @@ export class GameCore {
         root.hubGoals = new HubGoals(root);
         root.productionAnalytics = new ProductionAnalytics(root);
         root.buffers = new BufferMaintainer(root);
+        root.historyMgr = new HistoryManager(root);
 
         // Initialize the hud once everything is loaded
         this.root.hud.initialize();

--- a/src/js/game/history_manager.js
+++ b/src/js/game/history_manager.js
@@ -29,15 +29,15 @@ class LiFoQueue {
 }
 
 const ActionType = {
-    add: "ADD",
-    remove: "REMOVE",
+    add: 0,
+    remove: 1,
 };
 
 export class HistoryManager {
     constructor(root) {
         this.root = root;
-        this._forUndo = new LiFoQueue();
-        this._forRedo = new LiFoQueue();
+        this._forUndo = new LiFoQueue(100);
+        this._forRedo = new LiFoQueue(20);
 
         this.initializeBindings();
     }

--- a/src/js/game/history_manager.js
+++ b/src/js/game/history_manager.js
@@ -1,0 +1,101 @@
+import { Entity } from "./entity";
+import { SOUNDS } from "../platform/sound";
+import { KEYMAPPINGS } from "./key_action_mapper";
+
+class LiFoQueue {
+    constructor(size = 20) {
+        this.size = size;
+        this.items = [];
+    }
+
+    enqueue(element) {
+        if (this.size < this.items.length + 1) {
+            this.items.shift();
+        }
+        this.items.push(element);
+    }
+
+    dequeue() {
+        return this.items.pop();
+    }
+
+    clear() {
+        this.items = [];
+    }
+}
+
+const ActionType = {
+    add: "ADD",
+    remove: "REMOVE",
+};
+
+export class HistoryManager {
+    constructor(root) {
+        this.root = root;
+        this._entities = new LiFoQueue();
+        this._forRedo = new LiFoQueue();
+
+        this.initializeBindings();
+    }
+
+    initializeBindings() {
+        this.root.keyMapper.getBinding(KEYMAPPINGS.placement.undo).add(this._undo, this);
+        this.root.keyMapper.getBinding(KEYMAPPINGS.placement.redo).add(this._redo, this);
+    }
+
+    /**
+     * @param {Entity} entity
+     */
+    addAction(entity) {
+        this._forRedo.clear();
+        this._entities.enqueue({ type: ActionType.add, entity });
+    }
+
+    removeAction(entity) {
+        this._forRedo.clear();
+        this._entities.enqueue({ type: ActionType.remove, entity });
+    }
+
+    _undo() {
+        const { type, entity } = this._entities.dequeue() || {};
+        if (!entity) {
+            return;
+        }
+        if (type === ActionType.add && this.root.logic.canDeleteBuilding(entity)) {
+            this._forRedo.enqueue({ type: ActionType.remove, entity: entity.clone() });
+            this._removeEntity(entity);
+        }
+        if (type === ActionType.remove && this.root.logic.checkCanPlaceEntity(entity)) {
+            this._forRedo.enqueue({ type: ActionType.add, entity: entity });
+            this._placeEntity(entity);
+        }
+    }
+
+    _redo() {
+        const { type, entity } = this._forRedo.dequeue() || {};
+        if (!entity) {
+            return;
+        }
+        if (type === ActionType.remove && this.root.logic.checkCanPlaceEntity(entity)) {
+            this._placeEntity(entity);
+            this._entities.enqueue({ type: ActionType.add, entity });
+        }
+        if (type === ActionType.add && this.root.logic.canDeleteBuilding(entity)) {
+            this._entities.enqueue({ type: ActionType.remove, entity: entity.clone() });
+            this._removeEntity(entity);
+        }
+    }
+
+    _removeEntity(entity) {
+        this.root.map.removeStaticEntity(entity);
+        this.root.entityMgr.destroyEntity(entity);
+        this.root.entityMgr.processDestroyList();
+        this.root.soundProxy.playUi(SOUNDS.destroyBuilding);
+    }
+
+    _placeEntity(entity) {
+        this.root.logic.freeEntityAreaBeforeBuild(entity);
+        this.root.map.placeStaticEntity(entity);
+        this.root.entityMgr.registerEntity(entity);
+    }
+}

--- a/src/js/game/hud/parts/keybinding_overlay.js
+++ b/src/js/game/hud/parts/keybinding_overlay.js
@@ -120,6 +120,14 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
         return this.root.camera.getIsMapOverlayActive();
     }
 
+    get undoActive() {
+        return !this.mapOverviewActive && !this.blueprintPlacementActive && this.root.historyMgr.canUndo;
+    }
+
+    get redoActive() {
+        return !this.mapOverviewActive && !this.blueprintPlacementActive && this.root.historyMgr.canRedo;
+    }
+
     /**
      * Initializes the element
      * @param {HTMLElement} parent
@@ -183,6 +191,20 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
                 label: T.ingame.keybindingsOverlay.pipette,
                 keys: [k.placement.pipette],
                 condition: () => !this.mapOverviewActive && !this.blueprintPlacementActive,
+            },
+
+            {
+                // Undo
+                label: T.ingame.keybindingsOverlay.undo,
+                keys: [k.placement.undo],
+                condition: () => this.undoActive,
+            },
+
+            {
+                // Redo
+                label: T.ingame.keybindingsOverlay.redo,
+                keys: [k.placement.redo],
+                condition: () => this.redoActive,
             },
 
             {
@@ -297,10 +319,18 @@ export class HUDKeybindingOverlay extends BaseHUDPart {
                     case ADDER_TOKEN:
                         html += `+`;
                         break;
-                    default:
-                        html += `<code class="keybinding">${getStringForKeyCode(
-                            mapper.getBinding(/** @type {KeyCode} */ (key)).keyCode
-                        )}</code>`;
+                    default: {
+                        const binding = mapper.getBinding(/** @type {KeyCode} */ (key));
+                        if (binding.shift) {
+                            html += `<code class="keybinding">${getStringForKeyCode(16)}</code>`;
+                            html += `+`;
+                        }
+                        if (binding.ctrl) {
+                            html += `<code class="keybinding">${getStringForKeyCode(17)}</code>`;
+                            html += `+`;
+                        }
+                        html += `<code class="keybinding">${getStringForKeyCode(binding.keyCode)}</code>`;
+                    }
                 }
             }
             html += `<label>${handle.label}</label>`;

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -66,7 +66,7 @@ export const KEYMAPPINGS = {
         item_producer: { keyCode: key("L") },
 
         // Secondary toolbar
-        storage: { keyCode: key("Y") },
+        storage: { keyCode: key("Y"), ctrl: false },
         reader: { keyCode: key("U") },
         lever: { keyCode: key("I") },
         filter: { keyCode: key("O") },
@@ -98,7 +98,7 @@ export const KEYMAPPINGS = {
         copyWireValue: { keyCode: key("Z") },
 
         undo: { keyCode: key("Z"), ctrl: true, shift: false },
-        redo: { keyCode: key("Z"), ctrl: true, shift: true },
+        redo: { keyCode: key("Y"), ctrl: true, shift: false },
     },
 
     massSelect: {

--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -110,6 +110,7 @@ export class GameLogic {
             this.freeEntityAreaBeforeBuild(entity);
             this.root.map.placeStaticEntity(entity);
             this.root.entityMgr.registerEntity(entity);
+            this.root.historyMgr.addAction(entity);
             return entity;
         }
         return null;
@@ -178,6 +179,7 @@ export class GameLogic {
         if (!this.canDeleteBuilding(building)) {
             return false;
         }
+        this.root.historyMgr.removeAction(building.clone());
         this.root.map.removeStaticEntity(building);
         this.root.entityMgr.destroyEntity(building);
         this.root.entityMgr.processDestroyList();

--- a/src/js/game/root.js
+++ b/src/js/game/root.js
@@ -29,6 +29,7 @@ import { DynamicTickrate } from "./dynamic_tickrate";
 import { KeyActionMapper } from "./key_action_mapper";
 import { Vector } from "../core/vector";
 import { GameMode } from "./game_mode";
+import { HistoryManager } from "./history_manager";
 /* typehints:end */
 
 const logger = createLogger("game/root");
@@ -137,6 +138,9 @@ export class GameRoot {
 
         /** @type {GameMode} */
         this.gameMode = null;
+
+        /** @type {HistoryManager} */
+        this.historyMgr = null;
 
         this.signals = {
             // Entities

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -275,6 +275,8 @@ ingame:
         copySelection: Copy
         clearSelection: Clear selection
         pipette: Pipette
+        undo: Undo
+        redo: Redo
         switchLayers: Switch layers
 
     # Names of the colors, used for the color blind mode
@@ -1131,6 +1133,8 @@ keybindings:
         # ---
 
         pipette: Pipette
+        undo: Undo
+        redo: Redo
         rotateWhilePlacing: Rotate
         rotateInverseModifier: >-
             Modifier: Rotate CCW instead


### PR DESCRIPTION
Currently working:
 - redo/undo can store up to 20 events
 - Ctrl+Z to undo last block placement / last block removal
 - ~Ctrl+Shift+Z~ Ctrl+Y to redo last undo
 
 TODO:
 - lock history until ?? level
 - localize and fix save corruptions - related to bulk operations
 - ~~add HUD info~~
 - ~~add possibility to bulk undo operation (paste/remove)~~
 - ~~reduce memory footprint & performance test~~