### PR TITLE
Portuguese translation fix on "splitters unlocked" text

### DIFF
--- a/translations/base-pt-PT.yaml
+++ b/translations/base-pt-PT.yaml
@@ -630,8 +630,8 @@ storyRewards:
             esquerda!
     reward_splitter:
         title: Divisor
-        desc: Desbloqueaste o <strong>dvisor</strong> uma variante do
-            <strong>distribuidor</strong> - Aceita uma entradae divide-a em
+        desc: Desbloqueaste o <strong>divisor</strong> uma variante do
+            <strong>distribuidor</strong> - Aceita uma entrada e divide-a em
             duas!
     reward_tunnel:
         title: Túnel


### PR DESCRIPTION
Small error i found while unlocking level 19.