### PR TITLE
Mass selector optimization

### DIFF
--- a/src/js/game/hud/parts/mass_selector.js
+++ b/src/js/game/hud/parts/mass_selector.js
@@ -202,11 +202,7 @@ export class HUDMassSelector extends BaseHUDPart {
      * @param {enumMouseButton} mouseButton
      */
     onMouseDown(pos, mouseButton) {
-        if (!this.root.keyMapper.getBinding(KEYMAPPINGS.massSelect.massSelectStart).pressed) {
-            return;
-        }
-
-        if (mouseButton !== enumMouseButton.left) {
+        if (!(this.root.keyMapper.getBinding(KEYMAPPINGS.massSelect.massSelectStart).pressed) || mouseButton !== enumMouseButton.left) {
             return;
         }
 

--- a/src/js/game/hud/parts/mass_selector.js
+++ b/src/js/game/hud/parts/mass_selector.js
@@ -16,10 +16,13 @@ import { enumHubGoalRewards } from "../../tutorial_goals";
 import { Blueprint } from "../../blueprint";
 
 const logger = createLogger("hud/mass_selector");
+var globalTileSizeAdjusted = 0;
 
 export class HUDMassSelector extends BaseHUDPart {
+    
     createElements(parent) {}
 
+    
     initialize() {
         this.currentSelectionStartWorld = null;
         this.currentSelectionEnd = null;
@@ -41,6 +44,7 @@ export class HUDMassSelector extends BaseHUDPart {
 
         this.root.hud.signals.selectedPlacementBuildingChanged.add(this.clearSelection, this);
         this.root.signals.editModeChanged.add(this.clearSelection, this);
+        globalTileSizeAdjusted = globalConfig.tileSize - 2 * 2;
     }
 
     /**
@@ -315,18 +319,20 @@ export class HUDMassSelector extends BaseHUDPart {
         }
 
         parameters.context.fillStyle = THEME.map.selectionOverlay;
+        parameters.context.beginPath();
         this.selectedUids.forEach(uid => {
             const entity = this.root.entityMgr.findByUid(uid);
             const staticComp = entity.components.StaticMapEntity;
             const bounds = staticComp.getTileSpaceBounds();
-            parameters.context.beginRoundedRect(
+            // tried writing this in one line: it worked but it was very slow... WHY?
+            parameters.context.fillRect(
                 bounds.x * globalConfig.tileSize + boundsBorder,
                 bounds.y * globalConfig.tileSize + boundsBorder,
-                bounds.w * globalConfig.tileSize - 2 * boundsBorder,
-                bounds.h * globalConfig.tileSize - 2 * boundsBorder,
-                2
+                bounds.w * globalTileSizeAdjusted,
+                bounds.h * globalTileSizeAdjusted, // This seems like microoptimization but on a huuuge scale it makes a difference
             );
-            parameters.context.fill();
         });
+        parameters.context.closePath(); // +1 fps for some reason
+        
     }
 }


### PR DESCRIPTION
Optimized mass selection drawing.
I have another much much faster cache-based approach for this which kind of works but its unstable, so i'll keep it private until it's more polished.
I don't know JS so I hope this is good.

Selecting large, compact areas:
17 FPS -> 21 FPS