### PR TITLE
Set building rotation with arrow keys ⬆⬇⬅➡

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -311,8 +311,6 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
                 this.currentBaseRotation = 90;
             } else if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateToLeft).pressed) {
                 this.currentBaseRotation = 270;
-            } else {
-                // No op
             }
 
             const staticComp = this.fakeEntity.components.StaticMapEntity;

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -110,6 +110,12 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         // KEYBINDINGS
         const keyActionMapper = this.root.keyMapper;
         keyActionMapper.getBinding(KEYMAPPINGS.placement.rotateWhilePlacing).add(this.tryRotate, this);
+
+        keyActionMapper.getBinding(KEYMAPPINGS.placement.rotateToUp).add(this.trySetRotate, this);
+        keyActionMapper.getBinding(KEYMAPPINGS.placement.rotateToDown).add(this.trySetRotate, this);
+        keyActionMapper.getBinding(KEYMAPPINGS.placement.rotateToRight).add(this.trySetRotate, this);
+        keyActionMapper.getBinding(KEYMAPPINGS.placement.rotateToLeft).add(this.trySetRotate, this);
+
         keyActionMapper.getBinding(KEYMAPPINGS.placement.cycleBuildingVariants).add(this.cycleVariants, this);
         keyActionMapper
             .getBinding(KEYMAPPINGS.placement.switchDirectionLockSide)
@@ -290,6 +296,30 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             staticComp.rotation = this.currentBaseRotation;
         }
     }
+
+    /**
+     * Rotates the current building to the specified direction.
+     */
+    trySetRotate() {
+        const selectedBuilding = this.currentMetaBuilding.get();
+        if (selectedBuilding) {
+            if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateToUp).pressed) {
+                this.currentBaseRotation = 0;
+            } else if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateToDown).pressed) {
+                this.currentBaseRotation = 180;
+            } else if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateToRight).pressed) {
+                this.currentBaseRotation = 90;
+            } else if (this.root.keyMapper.getBinding(KEYMAPPINGS.placement.rotateToLeft).pressed) {
+                this.currentBaseRotation = 270;
+            } else {
+                // No op
+            }
+
+            const staticComp = this.fakeEntity.components.StaticMapEntity;
+            staticComp.rotation = this.currentBaseRotation;
+        }
+    }
+
     /**
      * Tries to delete the building under the mouse
      */

--- a/src/js/game/key_action_mapper.js
+++ b/src/js/game/key_action_mapper.js
@@ -11,6 +11,11 @@ function key(str) {
     return str.toUpperCase().charCodeAt(0);
 }
 
+const KEYCODE_UP_ARROW = 38;
+const KEYCODE_DOWN_ARROW = 40;
+const KEYCODE_LEFT_ARROW = 37;
+const KEYCODE_RIGHT_ARROW = 39;
+
 export const KEYMAPPINGS = {
     general: {
         confirm: { keyCode: 13 }, // enter
@@ -81,6 +86,10 @@ export const KEYMAPPINGS = {
         pipette: { keyCode: key("Q") },
         rotateWhilePlacing: { keyCode: key("R") },
         rotateInverseModifier: { keyCode: 16 }, // SHIFT
+        rotateToUp: { keyCode: KEYCODE_UP_ARROW },
+        rotateToDown: { keyCode: KEYCODE_DOWN_ARROW },
+        rotateToRight: { keyCode: KEYCODE_RIGHT_ARROW },
+        rotateToLeft: { keyCode: KEYCODE_LEFT_ARROW },
         cycleBuildingVariants: { keyCode: key("T") },
         cycleBuildings: { keyCode: 9 }, // TAB
         switchDirectionLockSide: { keyCode: key("R") },
@@ -162,13 +171,13 @@ export function getStringForKeyCode(code) {
             return "END";
         case 36:
             return "HOME";
-        case 37:
+        case KEYCODE_LEFT_ARROW:
             return "⬅";
-        case 38:
+        case KEYCODE_UP_ARROW:
             return "⬆";
-        case 39:
+        case KEYCODE_RIGHT_ARROW:
             return "➡";
-        case 40:
+        case KEYCODE_DOWN_ARROW:
             return "⬇";
         case 44:
             return "PRNT";

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -1163,6 +1163,10 @@ keybindings:
         rotateWhilePlacing: Rotate
         rotateInverseModifier: >-
             Modifier: Rotate CCW instead
+        rotateToUp: "Rotate: Point Up"
+        rotateToDown: "Rotate: Point Down"
+        rotateToRight: "Rotate: Point Right"
+        rotateToLeft: "Rotate: Point Left"
         cycleBuildingVariants: Cycle Variants
         confirmMassDelete: Delete area
         pasteLastBlueprint: Paste last blueprint


### PR DESCRIPTION
## What 

Adds 4 default keybinds to quickly set building rotation in each of the four cardinal directions - up, down, left, and right - using the arrow keys.

When placing a building, press Up to set the building facing up, Down, Left and Right respectively. 
#### In Action

![facing-buildings](https://user-images.githubusercontent.com/28196/109435026-36936380-79e6-11eb-8f6a-82728f2d8dfb.gif)

#### Settings

![image](https://user-images.githubusercontent.com/28196/109435129-e799fe00-79e6-11eb-9506-13720e06559c.png)

#### Quickly set directions

![image](https://user-images.githubusercontent.com/28196/109434891-7dcd2480-79e5-11eb-8e8b-99fc218a5d59.png)


### Why 

This PR adds a solution for a pain point I was feeling when building, especially in the phases before unlocking blueprints! Where placing lots of buildings in quick succession, I found building rotation (R) and counter-rotation (Shift+R) difficult and error prone.