### PR TITLE
massCutConfirm desc, line 187

### DIFF
--- a/translations/base-pl.yaml
+++ b/translations/base-pl.yaml
@@ -186,7 +186,7 @@ dialogs:
             wersję gry dla nielimitowanych znaczników!
     massCutConfirm:
         title: Potwierdź wycinanie
-        desc: Wycinasz sporą ilość maszyn (<count> gwoli ścisłości)! Czy na pewno chcesz
+        desc: Wycinasz sporą ilość maszyn (<count> w roli ścisłości)! Czy na pewno chcesz
             kontynuować?
     exportScreenshotWarning:
         title: Tworzenie zrzutu fabryki


### PR DESCRIPTION
This should translated to (<count> **w roli** ścisłości), not (<count> **gwoli** ścisłości).