### PR TITLE
Fix formatItemsPerSecond with double = true

### DIFF
--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -573,12 +573,14 @@ export function round1DigitLocalized(speed, separator = T.global.decimalSeparato
  * @param {string=} separator The decimal separator for numbers like 50.1 (separator='.')
  */
 export function formatItemsPerSecond(speed, double = false, separator = T.global.decimalSeparator) {
-    return (speed === 1.0
-        ? T.ingame.buildingPlacement.infoTexts.oneItemPerSecond
-        : T.ingame.buildingPlacement.infoTexts.itemsPerSecond.replace(
-              "<x>",
-              round2Digits(speed).toString().replace(".", separator)
-        )) + (double ? "  " + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "");
+    return (
+        (speed === 1.0
+            ? T.ingame.buildingPlacement.infoTexts.oneItemPerSecond
+            : T.ingame.buildingPlacement.infoTexts.itemsPerSecond.replace(
+                  "<x>",
+                  round2Digits(speed).toString().replace(".", separator)
+              )) + (double ? "··" + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "")
+    );
 }
 
 /**

--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -573,12 +573,12 @@ export function round1DigitLocalized(speed, separator = T.global.decimalSeparato
  * @param {string=} separator The decimal separator for numbers like 50.1 (separator='.')
  */
 export function formatItemsPerSecond(speed, double = false, separator = T.global.decimalSeparator) {
-    return speed === 1.0
+    return (speed === 1.0
         ? T.ingame.buildingPlacement.infoTexts.oneItemPerSecond
         : T.ingame.buildingPlacement.infoTexts.itemsPerSecond.replace(
               "<x>",
               round2Digits(speed).toString().replace(".", separator)
-          ) + (double ? "  " + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "");
+        )) + (double ? "  " + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "");
 }
 
 /**


### PR DESCRIPTION
I noticed that when you use the double painter, the speed info says a certain speed suffixed with `(x2)`, since it processes two items at once. However, with a speed of 1.0, that suffix is lost:
![Screenshot_20210419_230103](https://user-images.githubusercontent.com/27965164/115303102-79aac100-a163-11eb-9b97-45511c36f669.png)

I figured I'd just create a PR, because it's only a tiny little change.
