### PR TITLE
Puzzle Mode fixes: Correct zone restrictions and more

### DIFF
--- a/src/js/core/rectangle.js
+++ b/src/js/core/rectangle.js
@@ -72,7 +72,7 @@ export class Rectangle {
     /**
      * Returns if this rectangle is equal to the other while taking an epsilon into account
      * @param {Rectangle} other
-     * @param {number} epsilon
+     * @param {number} [epsilon]
      */
     equalsEpsilon(other, epsilon) {
         return (

--- a/src/js/game/game_mode.js
+++ b/src/js/game/game_mode.js
@@ -142,7 +142,7 @@ export class GameMode extends BasicSerializableObject {
      * @param {number} w
      * @param {number} h
      */
-    expandZone(w = 0, h = 0) {
+    adjustZone(w = 0, h = 0) {
         abstract;
         return;
     }

--- a/src/js/game/game_mode.js
+++ b/src/js/game/game_mode.js
@@ -47,7 +47,7 @@ export class GameMode extends BasicSerializableObject {
     constructor(root) {
         super();
         this.root = root;
-        this.hiddenHurtParts = {};
+        this.hiddenHudParts = {};
 
         /** @type {typeof MetaBuilding[]} */
         this.hiddenBuildings = [MetaItemProducerBuilding];
@@ -83,7 +83,7 @@ export class GameMode extends BasicSerializableObject {
      * @returns {boolean}
      */
     isHudPartExcluded(name) {
-        return this.hiddenHurtParts[name] === false;
+        return this.hiddenHudParts[name] === false;
     }
 
     /**

--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -234,7 +234,7 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
      * @param {DrawParameters} parameters
      */
     draw(parameters) {
-        if (this.root.camera.zoomLevel < globalConfig.mapChunkOverviewMinZoom) {
+        if (this.root.camera.getIsMapOverlayActive()) {
             // Dont allow placing in overview mode
             this.domAttach.update(false);
             this.variantsAttach.update(false);

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -430,7 +430,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
      * @param {Vector} tile
      */
     tryPlaceCurrentBuildingAt(tile) {
-        if (this.root.camera.zoomLevel < globalConfig.mapChunkOverviewMinZoom) {
+        if (this.root.camera.getIsMapOverlayActive()) {
             // Dont allow placing in overview mode
             return;
         }

--- a/src/js/game/hud/parts/mode_settings.js
+++ b/src/js/game/hud/parts/mode_settings.js
@@ -48,7 +48,7 @@ export class HUDModeSettings extends BaseHUDPart {
     }
 
     modifyZone(width, height) {
-        this.root.gameMode.expandZone(width, height);
+        this.root.gameMode.adjustZone(width, height);
         this.updateZoneValues();
     }
 

--- a/src/js/game/modes/puzzle.js
+++ b/src/js/game/modes/puzzle.js
@@ -32,7 +32,7 @@ export class PuzzleGameMode extends GameMode {
 
         const data = this.getSaveData();
 
-        this.hiddenHurtParts = {
+        this.hiddenHudParts = {
             [HUDGameMenu.name]: false,
             [HUDMassSelector.name]: false,
             [HUDInteractiveTutorial.name]: false,

--- a/src/js/game/modes/puzzle_edit.js
+++ b/src/js/game/modes/puzzle_edit.js
@@ -55,16 +55,28 @@ export class PuzzleEditGameMode extends PuzzleGameMode {
         ];
     }
 
-    expandZone(w = 0, h = 0) {
-        if (this.zoneWidth + w > 0) {
-            this.zoneWidth += w;
+    adjustZone(w = 0, h = 0) {
+        // @todo notify user when zone cannot be shrunk
+        if (this.zoneWidth + w <= 0) {
+            return;
         }
 
-        if (this.zoneHeight + h > 0) {
-            this.zoneHeight += h;
+        if (this.zoneHeight + h <= 0) {
+            return;
         }
 
-        this.zone = this.createCenteredRectangle(this.zoneWidth, this.zoneHeight);
+        const newZone = this.createCenteredRectangle(this.zoneWidth + w, this.zoneHeight + h);
+        const entities = this.root.entityMgr.entities;
+
+        for (const entity of entities) {
+            const point = entity.components.StaticMapEntity.origin;
+            if (!newZone.containsPoint(point.x, point.y)) {
+                return;
+            }
+        }
+
+        this.zoneWidth = newZone.w;
+        this.zoneHeight = newZone.h;
     }
 
     getIsEditor() {

--- a/src/js/game/modes/puzzle_edit.js
+++ b/src/js/game/modes/puzzle_edit.js
@@ -68,9 +68,11 @@ export class PuzzleEditGameMode extends PuzzleGameMode {
         const newZone = this.createCenteredRectangle(this.zoneWidth + w, this.zoneHeight + h);
         const entities = this.root.entityMgr.entities;
 
+        // @fixme find a better way to check this
         for (const entity of entities) {
-            const point = entity.components.StaticMapEntity.origin;
-            if (!newZone.containsPoint(point.x, point.y)) {
+            const staticComp = entity.components.StaticMapEntity;
+            const union = newZone.getUnion(staticComp.getTileSpaceBounds());
+            if (!union.equalsEpsilon(newZone)) {
                 return;
             }
         }

--- a/src/js/game/modes/regular.js
+++ b/src/js/game/modes/regular.js
@@ -13,6 +13,7 @@ import { enumGameModeIds, enumGameModeTypes, GameMode } from "../game_mode";
 import { ShapeDefinition } from "../shape_definition";
 import { enumHubGoalRewards } from "../tutorial_goals";
 import { HUDPuzzleDLCLogo } from "../hud/parts/puzzle_dlc_logo";
+import { HUDPuzzleEditorControls } from "../hud/parts/puzzle_editor_controls";
 
 /** @typedef {{
  *   shape: string,
@@ -516,12 +517,13 @@ export class RegularGameMode extends GameMode {
     constructor(root) {
         super(root);
 
-        this.hiddenHurtParts = {
+        this.hiddenHudParts = {
             [HUDModeMenuBack.name]: false,
             [HUDPuzzleReview.name]: false,
             [HUDModeMenu.name]: false,
             [HUDModeSettings.name]: false,
             [HUDPuzzleDLCLogo.name]: false,
+            [HUDPuzzleEditorControls.name]: false,
         };
 
         this.hiddenBuildings = [MetaConstantProducerBuilding, MetaGoalAcceptorBuilding];

--- a/src/js/game/systems/zone.js
+++ b/src/js/game/systems/zone.js
@@ -49,17 +49,14 @@ export class ZoneSystem extends GameSystem {
             transformed.y += tile.y;
         }
 
-        let withinAnyZone = false;
         for (const zone of zones) {
             const intersection = zone.getIntersection(transformed);
             if (intersection && intersection.w * intersection.h === transformed.w * transformed.h) {
-                withinAnyZone = true;
+                return;
             }
         }
 
-        if (!withinAnyZone) {
-            return STOP_PROPAGATION;
-        }
+        return STOP_PROPAGATION;
     }
 
     /**


### PR DESCRIPTION
This PR makes these changes:

- ~~New method for `GameMode`, `getSupportsMapOverlay`.~~
- Building placer now relies on `Camera#getIsMapOverlayActive` for consistency.
- Rename `GameMode#hiddenHurtParts` to `hiddenHudParts`.
- Regular game mode now doesn't show `HUDPuzzleEditorControls`.
- **NEW** Prevent user from shrinking zone with buildings on edges.
- **NEW** Rename `expandZone` to `adjustZone` because it makes more sense.
- **NEW** Fix building placer allowing multi-tile buildings outside of the zone.