### PR TITLE
[puzzle] Prevent pipette cheats

### DIFF
--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -366,7 +366,8 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
             if (
                 tileBelow &&
                 this.root.app.settings.getAllSettings().pickMinerOnPatch &&
-                this.root.currentLayer === "regular"
+                this.root.currentLayer === "regular" &&
+                this.root.gameMode.hasResources()
             ) {
                 this.currentMetaBuilding.set(gMetaBuildingRegistry.findByClass(MetaMinerBuilding));
 
@@ -386,6 +387,12 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
         // Disable pipetting the hub
         if (extracted.metaInstance.getId() === gMetaBuildingRegistry.findByClass(MetaHubBuilding).getId()) {
+            this.currentMetaBuilding.set(null);
+            return;
+        }
+
+        // Disallow picking excluded buildings
+        if (this.root.gameMode.isBuildingExcluded(extracted.metaClass)) {
             this.currentMetaBuilding.set(null);
             return;
         }


### PR DESCRIPTION
This PR makes it impossible to select forbidden buildings in puzzle mode (like extractor or constant producer) by making it obey `hasResources()` and `isBuildingExcluded()`.