### PR TITLE
Improved Screenshots

### DIFF
--- a/src/css/ingame_hud/dialogs.scss
+++ b/src/css/ingame_hud/dialogs.scss
@@ -233,7 +233,7 @@
                 @include S(min-width, 160px);
 
                 > div {
-                    background: #fff;
+                    background: $mainBgColor;
                     display: flex;
                     justify-content: center;
                     align-items: center;
@@ -245,7 +245,7 @@
 
                     transition: background-color 0.12s ease-in-out;
                     &:hover {
-                        background-color: #fafafa;
+                        background-color: darken($mainBgColor, 5);
                     }
 
                     @include DarkThemeOverride {

--- a/src/css/ingame_hud/dialogs.scss
+++ b/src/css/ingame_hud/dialogs.scss
@@ -164,7 +164,7 @@
             .keybinding {
                 position: relative;
                 background: #eee;
-                @include PlainText;
+                @include SuperSmallText;
                 height: unset;
                 margin: 1px 0;
             }

--- a/src/css/ingame_hud/dialogs.scss
+++ b/src/css/ingame_hud/dialogs.scss
@@ -226,6 +226,18 @@
                 }
             }
 
+            .checkBoxGridFormElem {
+                display: inline-grid;
+                grid-template-columns: 1fr;
+                @include S(margin, 10px, 0);
+                @include S(grid-row-gap, 10px);
+
+                > .checkBoxFormElem {
+                    margin: 0;
+                    justify-content: space-between;
+                }
+            }
+
             .enum {
                 display: grid;
                 grid-template-columns: auto 1fr auto;

--- a/src/css/ingame_hud/dialogs.scss
+++ b/src/css/ingame_hud/dialogs.scss
@@ -215,24 +215,28 @@
                 }
             }
 
-            .checkBoxFormElem {
+            .checkBoxFormElem,
+            .enumFormElem {
+                display: flex;
+                align-items: center;
                 @include S(margin, 10px, 0);
+
                 > label {
                     @include S(margin-right, 10px);
                 }
-                display: flex;
-                align-items: center;
             }
 
             .enum {
-                @include S(margin, 10px, 0);
                 display: grid;
                 grid-template-columns: auto 1fr auto;
                 @include S(grid-gap, 4px);
-                @include S(width, 200px);
+                @include S(min-width, 160px);
 
-                > * {
+                > div {
                     background: #fff;
+                    display: flex;
+                    justify-content: center;
+                    align-items: center;
                     text-align: center;
                     pointer-events: all;
                     cursor: pointer;
@@ -253,7 +257,7 @@
                     }
 
                     &.toggle {
-                        @include S(width, 20px);
+                        @include S(width, 16px);
                     }
 
                     &.value {

--- a/src/css/ingame_hud/dialogs.scss
+++ b/src/css/ingame_hud/dialogs.scss
@@ -214,6 +214,53 @@
                     }
                 }
             }
+
+            .checkBoxFormElem {
+                @include S(margin, 10px, 0);
+                > label {
+                    @include S(margin-right, 10px);
+                }
+                display: flex;
+                align-items: center;
+            }
+
+            .enum {
+                @include S(margin, 10px, 0);
+                display: grid;
+                grid-template-columns: auto 1fr auto;
+                @include S(grid-gap, 4px);
+                @include S(width, 200px);
+
+                > * {
+                    background: #fff;
+                    text-align: center;
+                    pointer-events: all;
+                    cursor: pointer;
+                    @include S(border-radius, $globalBorderRadius);
+                    @include S(padding, 4px);
+
+                    transition: background-color 0.12s ease-in-out;
+                    &:hover {
+                        background-color: #fafafa;
+                    }
+
+                    @include DarkThemeOverride {
+                        background-color: $darkModeControlsBackground;
+                        color: #ddd;
+                        &:hover {
+                            background-color: darken($darkModeControlsBackground, 2);
+                        }
+                    }
+
+                    &.toggle {
+                        @include S(width, 20px);
+                    }
+
+                    &.value {
+                        transform: none !important;
+                    }
+                }
+            }
         }
 
         > .buttons {

--- a/src/js/core/modal_dialog_forms.js
+++ b/src/js/core/modal_dialog_forms.js
@@ -238,12 +238,12 @@ export class FormElementItemChooser extends FormElement {
 }
 
 export class FormElementEnum extends FormElement {
-    constructor({ id, label = null, options, valueGetter, textGetter }) {
+    constructor({ id, label = null, options, defaultValue = 0, valueGetter, textGetter }) {
         super(id, label);
         this.options = options;
         this.valueGetter = valueGetter;
         this.textGetter = textGetter;
-        this.index = 0;
+        this.index = defaultValue;
 
         this.element = null;
     }
@@ -254,7 +254,7 @@ export class FormElementEnum extends FormElement {
                 ${this.label ? `<label>${this.label}</label>` : ""}
                 <div class="enum" data-formId="${this.id}">
                     <div class="toggle prev">⯇</div>
-                    <div class="value">${this.textGetter(this.options[0])}</div>
+                    <div class="value">${this.textGetter(this.options[this.index])}</div>
                     <div class="toggle next">⯈</div>
                 </div>
             </div>

--- a/src/js/core/modal_dialog_forms.js
+++ b/src/js/core/modal_dialog_forms.js
@@ -1,5 +1,6 @@
 import { BaseItem } from "../game/base_item";
 import { ClickDetector } from "./click_detector";
+import { createLogger } from "./logging";
 import { Signal } from "./signal";
 import { safeModulo } from "./utils";
 
@@ -13,6 +14,8 @@ import { safeModulo } from "./utils";
  *
  * ***************************************************
  */
+
+const logger = createLogger("dialog_forms");
 
 export class FormElement {
     constructor(id, label) {
@@ -263,12 +266,20 @@ export class FormElementItemChooser extends FormElement {
 }
 
 export class FormElementEnum extends FormElement {
-    constructor({ id, label = null, options, defaultValue = 0, valueGetter, textGetter }) {
+    constructor({ id, label = null, options, defaultValue = null, valueGetter, textGetter }) {
         super(id, label);
         this.options = options;
         this.valueGetter = valueGetter;
         this.textGetter = textGetter;
-        this.index = defaultValue;
+        this.index = 0;
+        if (defaultValue !== null) {
+            const index = this.options.findIndex(option => option.id === defaultValue);
+            if (index >= 0) {
+                this.index = index;
+            } else {
+                logger.warn("Option ID", defaultValue, "not found in", options, "!");
+            }
+        }
 
         this.element = null;
     }

--- a/src/js/core/modal_dialog_forms.js
+++ b/src/js/core/modal_dialog_forms.js
@@ -140,7 +140,7 @@ export class FormElementCheckbox extends FormElement {
     getHtml() {
         return `
             <div class="formElement checkBoxFormElem">
-            ${this.label ? `<label>${this.label}</label>` : ""}
+                ${this.label ? `<label>${this.label}</label>` : ""}
                 <div class="checkbox ${this.defaultValue ? "checked" : ""}" data-formId='${this.id}'>
                     <span class="knob"></span >
                 </div >
@@ -165,6 +165,31 @@ export class FormElementCheckbox extends FormElement {
     toggle() {
         this.value = !this.value;
         this.element.classList.toggle("checked", this.value);
+    }
+
+    focus(parent) {}
+}
+
+export class FormElementCheckboxList extends FormElement {
+    constructor({ id, label = null, checkboxes = [] }) {
+        super(id, label);
+        this.checkboxes = checkboxes;
+    }
+
+    getHtml() {
+        return `
+            <div class="formElement checkBoxGridFormElem">
+                ${this.checkboxes.map(checkbox => checkbox.getHtml()).join("\n")}
+            </div>
+        `;
+    }
+
+    bindEvents(parent, clickTrackers) {
+        this.checkboxes.forEach(checkbox => checkbox.bindEvents(parent, clickTrackers));
+    }
+
+    getValue() {
+        return this.checkboxes.map(checkbox => checkbox.getValue());
     }
 
     focus(parent) {}

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -321,10 +321,7 @@ export class HUDScreenshotExporter extends BaseHUDPart {
             if (hideBackground) {
                 this.root.map.drawVisibleChunks(
                     parameters,
-                    /** @this {MapChunkView} */ function (parameters) {
-                        this.root.systemMgr.systems.beltUnderlays.drawChunk(parameters, this);
-                        this.root.systemMgr.systems.belt.drawChunk(parameters, this);
-                    }
+                    MapChunkView.prototype.drawBackgroundLayerBeltsOnly
                 );
             } else {
                 this.root.map.drawBackground(parameters);

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -67,7 +67,9 @@ export class HUDScreenshotExporter extends BaseHUDPart {
                 const tileStart = worldStart.toTileSpace();
                 const tileEnd = worldEnd.toTileSpace();
 
-                bounds = Rectangle.fromTwoPoints(tileStart, tileEnd.addScalars(1, 1));
+                bounds = Rectangle.fromTwoPoints(tileStart, tileEnd);
+                bounds.w += 1;
+                bounds.h += 1;
             } else if (massSelector.selectedUids.size > 0) {
                 const minTile = new Vector(Infinity, Infinity);
                 const maxTile = new Vector(-Infinity, -Infinity);

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -171,7 +171,9 @@ export class HUDScreenshotExporter extends BaseHUDPart {
             maxTile.x = Math.ceil(maxTile.x / globalConfig.mapChunkSize) * globalConfig.mapChunkSize;
             maxTile.y = Math.ceil(maxTile.y / globalConfig.mapChunkSize) * globalConfig.mapChunkSize;
 
-            tileBounds = Rectangle.fromTwoPoints(minTile, maxTile);
+            tileBounds = Rectangle.fromTwoPoints(minTile, maxTile).expandedInAllDirections(
+                globalConfig.mapChunkSize
+            );
         }
 
         // if the desired pixels per tile is too small, we do not create a border

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -100,7 +100,7 @@ export class HUDScreenshotExporter extends BaseHUDPart {
             id: "screenshotQuality",
             label: "Quality",
             options: screenshotQualities,
-            defaultValue: 1,
+            defaultValue: "medium",
             valueGetter: quality => quality.resolution,
             // @TODO: translation (T.dialogs.exportScreenshotWarning.qualityLabel)
             textGetter: quality => qualityNames[quality.id],

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -96,6 +96,7 @@ export class HUDScreenshotExporter extends BaseHUDPart {
             id: "screenshotQuality",
             label: "Quality",
             options: screenshotQualities,
+            defaultValue: 1,
             valueGetter: quality => quality.resolution,
             // @TODO: translation (T.dialogs.exportScreenshotWarning.qualityLabel)
             textGetter: quality => qualityNames[quality.id],

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -54,14 +54,34 @@ export class HUDScreenshotExporter extends BaseHUDPart {
 
         let bounds = undefined;
         const massSelector = this.root.hud.parts.massSelector;
-        if (massSelector instanceof HUDMassSelector && massSelector.currentSelectionStartWorld) {
-            const worldStart = massSelector.currentSelectionStartWorld;
-            const worldEnd = this.root.camera.screenToWorld(massSelector.currentSelectionEnd);
+        if (massSelector instanceof HUDMassSelector) {
+            if (massSelector.currentSelectionStartWorld) {
+                const worldStart = massSelector.currentSelectionStartWorld;
+                const worldEnd = this.root.camera.screenToWorld(massSelector.currentSelectionEnd);
 
-            const tileStart = worldStart.toTileSpace();
-            const tileEnd = worldEnd.toTileSpace();
+                const tileStart = worldStart.toTileSpace();
+                const tileEnd = worldEnd.toTileSpace();
 
-            bounds = Rectangle.fromTwoPoints(tileStart, tileEnd.addScalars(1, 1));
+                bounds = Rectangle.fromTwoPoints(tileStart, tileEnd.addScalars(1, 1));
+            } else if (massSelector.selectedUids.size > 0) {
+                const minTile = new Vector(Infinity, Infinity);
+                const maxTile = new Vector(-Infinity, -Infinity);
+
+                const entityUids = Array.from(massSelector.selectedUids);
+                for (let i = 0; i < entityUids.length; ++i) {
+                    const entityBounds = this.root.entityMgr
+                        .findByUid(entityUids[i])
+                        .components.StaticMapEntity.getTileSpaceBounds();
+
+                    minTile.x = Math.min(minTile.x, entityBounds.x);
+                    minTile.y = Math.min(minTile.y, entityBounds.y);
+
+                    maxTile.x = Math.max(maxTile.x, entityBounds.x + entityBounds.w);
+                    maxTile.y = Math.max(maxTile.y, entityBounds.y + entityBounds.h);
+                }
+
+                bounds = Rectangle.fromTwoPoints(minTile, maxTile);
+            }
         }
 
         const qualityInput = new FormElementEnum({

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -337,7 +337,9 @@ export class HUDScreenshotExporter extends BaseHUDPart {
             this.root.systemMgr.systems.belt.drawBeltItems(parameters);
             this.root.map.drawForeground(parameters);
             this.root.systemMgr.systems.hub.draw(parameters);
-            this.root.hud.parts.wiresOverlay.draw(parameters);
+            if (this.root.hud.parts.wiresOverlay) {
+                this.root.hud.parts.wiresOverlay.draw(parameters);
+            }
             if (this.root.currentLayer === "wires") {
                 this.root.map.drawWiresForegroundLayer(parameters);
             }

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -79,6 +79,12 @@ export class HUDScreenshotExporter extends BaseHUDPart {
             buttons: ["cancel:good", "ok:bad"],
         });
 
+        dialog.inputReciever.keydown.add(({ keyCode }) => {
+            if (keyCode === KEYMAPPINGS.ingame.exportScreenshot.keyCode) {
+                this.root.hud.parts.dialogs.closeDialog(dialog);
+            }
+        });
+
         this.root.hud.parts.dialogs.internalShowDialog(dialog);
         dialog.buttonSignals.ok.add(
             () => this.doExport(qualityInput.getValue(), overlayInput.getValue(), layerInput.getValue()),

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -307,6 +307,7 @@ export class HUDScreenshotExporter extends BaseHUDPart {
             this.root.currentLayer = "regular";
             this.root.hud.parts.wiresOverlay.currentAlpha = 0;
         }
+        this.root.systemMgr.systems.itemAcceptor.updateForScreenshot();
 
         // Render all relevant chunks
         this.root.signals.gameFrameStarted.dispatch();

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -142,13 +142,12 @@ export class HUDScreenshotExporter extends BaseHUDPart {
     doExport(resolution, overlay, wiresLayer, bounds) {
         logger.log("Starting export ...");
 
-        // Find extends
-        const staticEntities = this.root.entityMgr.getAllWithComponent(StaticMapEntityComponent);
-
         if (!bounds) {
+            // Find extends
+            const staticEntities = this.root.entityMgr.getAllWithComponent(StaticMapEntityComponent);
+
             const minTile = new Vector(0, 0);
             const maxTile = new Vector(0, 0);
-
             for (let i = 0; i < staticEntities.length; ++i) {
                 const entityBounds = staticEntities[i].components.StaticMapEntity.getTileSpaceBounds();
                 minTile.x = Math.min(minTile.x, entityBounds.x);

--- a/src/js/game/hud/parts/screenshot_exporter.js
+++ b/src/js/game/hud/parts/screenshot_exporter.js
@@ -19,6 +19,7 @@ import { getDeviceDPI } from "../../../core/dpi_manager";
 import { HUDMassSelector } from "./mass_selector";
 import { clamp } from "../../../core/utils";
 import { CHUNK_OVERLAY_RES, MapChunkView } from "../../map_chunk_view";
+import { enumHubGoalRewards } from "../../tutorial_goals";
 
 const logger = createLogger("screenshot_exporter");
 
@@ -125,7 +126,13 @@ export class HUDScreenshotExporter extends BaseHUDPart {
         });
         const checkboxInputs = new FormElementCheckboxList({
             id: "screenshotCheckboxes",
-            checkboxes: [overlayInput, layerInput, backgroundInput],
+            checkboxes: [
+                overlayInput,
+                ...(this.root.hubGoals.isRewardUnlocked(enumHubGoalRewards.reward_wires_painter_and_levers)
+                    ? [layerInput]
+                    : []),
+                backgroundInput,
+            ],
         });
         const dialog = new DialogWithForm({
             app: this.root.app,

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -114,10 +114,9 @@ export class HUDWiresOverlay extends BaseHUDPart {
     /**
      *
      * @param {DrawParameters} parameters
-     * @param {boolean=} forced
      */
-    draw(parameters, forced = false) {
-        if (!forced && this.currentAlpha < 0.02) {
+    draw(parameters) {
+        if (this.currentAlpha < 0.02) {
             return;
         }
 
@@ -128,7 +127,7 @@ export class HUDWiresOverlay extends BaseHUDPart {
 
         const bounds = parameters.visibleRect;
 
-        parameters.context.globalAlpha = forced ? 1 : this.currentAlpha;
+        parameters.context.globalAlpha = this.currentAlpha;
 
         const scaleFactor = 1 / wiresBackgroundDpi;
         parameters.context.globalCompositeOperation = "overlay";

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -114,9 +114,10 @@ export class HUDWiresOverlay extends BaseHUDPart {
     /**
      *
      * @param {DrawParameters} parameters
+     * @param {boolean=} forced
      */
-    draw(parameters) {
-        if (this.currentAlpha < 0.02) {
+    draw(parameters, forced = false) {
+        if (!forced && this.currentAlpha < 0.02) {
             return;
         }
 
@@ -127,7 +128,7 @@ export class HUDWiresOverlay extends BaseHUDPart {
 
         const bounds = parameters.visibleRect;
 
-        parameters.context.globalAlpha = this.currentAlpha;
+        parameters.context.globalAlpha = forced ? 1 : this.currentAlpha;
 
         const scaleFactor = 1 / wiresBackgroundDpi;
         parameters.context.globalCompositeOperation = "overlay";

--- a/src/js/game/map_chunk_view.js
+++ b/src/js/game/map_chunk_view.js
@@ -54,6 +54,17 @@ export class MapChunkView extends MapChunk {
     }
 
     /**
+     * Draws only the belts of the background layer
+     * @param {DrawParameters} parameters
+     */
+    drawBackgroundLayerBeltsOnly(parameters) {
+        const systems = this.root.systemMgr.systems;
+
+        systems.beltUnderlays.drawChunk(parameters, this);
+        systems.belt.drawChunk(parameters, this);
+    }
+
+    /**
      * Draws the dynamic foreground layer
      * @param {DrawParameters} parameters
      */

--- a/src/js/game/map_chunk_view.js
+++ b/src/js/game/map_chunk_view.js
@@ -131,6 +131,40 @@ export class MapChunkView extends MapChunk {
     }
 
     /**
+     * Overlay with transparent background
+     * @param {DrawParameters} parameters
+     */
+    drawOverlayNoBackground(parameters) {
+        const overlaySize = globalConfig.mapChunkSize * CHUNK_OVERLAY_RES;
+        const sprite = this.root.buffers.getForKey({
+            key: "chunknobg@" + this.root.currentLayer,
+            subKey: this.renderKey,
+            w: overlaySize,
+            h: overlaySize,
+            dpi: 1,
+            redrawMethod: this.generateOverlayBufferNoBackground.bind(this),
+        });
+
+        const dims = globalConfig.mapChunkWorldSize;
+        const extrude = 0.05;
+
+        // Draw chunk "pixel" art
+        parameters.context.imageSmoothingEnabled = false;
+        drawSpriteClipped({
+            parameters,
+            sprite,
+            x: this.x * dims - extrude,
+            y: this.y * dims - extrude,
+            w: dims + 2 * extrude,
+            h: dims + 2 * extrude,
+            originalW: overlaySize,
+            originalH: overlaySize,
+        });
+
+        parameters.context.imageSmoothingEnabled = true;
+    }
+
+    /**
      *
      * @param {HTMLCanvasElement} canvas
      * @param {CanvasRenderingContext2D} context
@@ -225,6 +259,94 @@ export class MapChunkView extends MapChunk {
                         CHUNK_OVERLAY_RES,
                         CHUNK_OVERLAY_RES
                     );
+                }
+            }
+        }
+
+        if (this.root.currentLayer === "wires") {
+            // Draw wires overlay
+
+            context.fillStyle = THEME.map.wires.overlayColor;
+            context.fillRect(0, 0, w, h);
+
+            for (let x = 0; x < globalConfig.mapChunkSize; ++x) {
+                const wiresArray = this.wireContents[x];
+                for (let y = 0; y < globalConfig.mapChunkSize; ++y) {
+                    const content = wiresArray[y];
+                    if (!content) {
+                        continue;
+                    }
+                    MapChunkView.drawSingleWiresOverviewTile({
+                        context,
+                        x: x * CHUNK_OVERLAY_RES,
+                        y: y * CHUNK_OVERLAY_RES,
+                        entity: content,
+                        tileSizePixels: CHUNK_OVERLAY_RES,
+                    });
+                }
+            }
+        }
+    }
+
+    /**
+     *
+     * @param {HTMLCanvasElement} canvas
+     * @param {CanvasRenderingContext2D} context
+     * @param {number} w
+     * @param {number} h
+     * @param {number} dpi
+     */
+    generateOverlayBufferNoBackground(canvas, context, w, h, dpi) {
+        for (let x = 0; x < globalConfig.mapChunkSize; ++x) {
+            const upperArray = this.contents[x];
+            for (let y = 0; y < globalConfig.mapChunkSize; ++y) {
+                const upperContent = upperArray[y];
+                if (upperContent) {
+                    const staticComp = upperContent.components.StaticMapEntity;
+                    const data = getBuildingDataFromCode(staticComp.code);
+                    const metaBuilding = data.metaInstance;
+
+                    const overlayMatrix = metaBuilding.getSpecialOverlayRenderMatrix(
+                        staticComp.rotation,
+                        data.rotationVariant,
+                        data.variant,
+                        upperContent
+                    );
+
+                    if (overlayMatrix) {
+                        context.fillStyle = metaBuilding.getSilhouetteColor(
+                            data.variant,
+                            data.rotationVariant
+                        );
+                        for (let dx = 0; dx < 3; ++dx) {
+                            for (let dy = 0; dy < 3; ++dy) {
+                                const isFilled = overlayMatrix[dx + dy * 3];
+                                if (isFilled) {
+                                    context.fillRect(
+                                        x * CHUNK_OVERLAY_RES + dx,
+                                        y * CHUNK_OVERLAY_RES + dy,
+                                        1,
+                                        1
+                                    );
+                                }
+                            }
+                        }
+
+                        continue;
+                    } else {
+                        context.fillStyle = metaBuilding.getSilhouetteColor(
+                            data.variant,
+                            data.rotationVariant
+                        );
+                        context.fillRect(
+                            x * CHUNK_OVERLAY_RES,
+                            y * CHUNK_OVERLAY_RES,
+                            CHUNK_OVERLAY_RES,
+                            CHUNK_OVERLAY_RES
+                        );
+
+                        continue;
+                    }
                 }
             }
         }

--- a/src/js/game/systems/item_acceptor.js
+++ b/src/js/game/systems/item_acceptor.js
@@ -56,6 +56,36 @@ export class ItemAcceptorSystem extends GameSystemWithFilter {
         }
     }
 
+    updateForScreenshot() {
+        // Compute how much ticks we missed
+        const numTicks = this.accumulatedTicksWhileInMapOverview;
+        const progress =
+            this.root.dynamicTickrate.deltaSeconds *
+            2 *
+            this.root.hubGoals.getBeltBaseSpeed() *
+            globalConfig.itemSpacingOnBelts * // * 2 because its only a half tile
+            numTicks;
+
+        // Reset accumulated ticks
+        this.accumulatedTicksWhileInMapOverview = 0;
+
+        for (let i = 0; i < this.allEntities.length; ++i) {
+            const entity = this.allEntities[i];
+            const aceptorComp = entity.components.ItemAcceptor;
+            const animations = aceptorComp.itemConsumptionAnimations;
+
+            // Process item consumption animations to avoid items popping from the belts
+            for (let animIndex = 0; animIndex < animations.length; ++animIndex) {
+                const anim = animations[animIndex];
+                anim.animProgress += progress;
+                if (anim.animProgress > 1) {
+                    fastArrayDelete(animations, animIndex);
+                    animIndex -= 1;
+                }
+            }
+        }
+    }
+
     /**
      * @param {DrawParameters} parameters
      * @param {MapChunkView} chunk


### PR DESCRIPTION
This PR adds many improvements to the screenshot functionality currently in the game.

### Fixes
* Fixes buildings not rendering where the camera is.
* Fixes item acceptors not processing their animations when taking a screenshot from map view.
* Fixes the hub not rendering.
* Fixes belt items not rendering.
### Changes
* Shrinks the size of keybindings in dialogs (this also affects already-existing dialogs).
* Changes the formatting of the toggle switch dialog form option.
* Adds a 1-chunk border around base screenshots.
* Changes the rendering code to mimic the game rendering code.
### Additions
* Adds multiple target resolutions for screenshots.
* Adds the ability to select a region (either the current mouse selection or the selected buildings) to take a screenshot of it.
* Adds the ability to take a screenshot in map view.
* Adds the ability to take a screenshot of the wires layer.
* Adds the ability to take a screenshot with a transparent background.
* Adds a toggle switch list dialog form option.
* Adds a cycle button dialog form option.
* Adds the ability to close the screenshot dialog with the key used to open it.

## Examples
### Dialogs
<details><summary><strong>Screenshot dialog (full base)</strong></summary><br>

![image](https://user-images.githubusercontent.com/69981203/120900733-133b0e80-c5fc-11eb-8586-acc3684e30b6.png)
</details><details><summary><strong>Screenshot dialog (full base, light theme, pre-wires layer)</strong></summary><br>

![image](https://user-images.githubusercontent.com/69981203/120902357-8f861f80-c605-11eb-8b50-0cca14808335.png)
</details><details><summary><strong>Screenshot dialog (selection)</strong></summary><br>

![image](https://user-images.githubusercontent.com/69981203/120900839-d15e9800-c5fc-11eb-94d3-e23037803a30.png)
</details><details><summary><strong>"Too large" dialog (full base)</strong></summary><br>

![image](https://user-images.githubusercontent.com/69981203/120901548-5946a100-c601-11eb-98f0-c86dc4fc8ae0.png)
</details><details><summary><strong>"Too large" dialog (selection)</strong></summary><br>

![image](https://user-images.githubusercontent.com/69981203/120901594-9d39a600-c601-11eb-996c-6e46d83ae303.png)
</details>

### Screenshots
<details><summary><strong>Selection screenshot</strong></summary><br>

![screenshot](https://user-images.githubusercontent.com/69981203/120900903-29959a00-c5fd-11eb-99e0-b7e830e33e4d.png)
</details><details><summary><strong>Selection screenshot (light theme)</strong></summary><br>

![baselight](https://user-images.githubusercontent.com/69981203/120902439-12a77580-c606-11eb-96eb-41a2c3ac7517.png)
</details><details><summary><strong>Selection screenshot (light theme, all performance settings enabled)</strong></summary><br>

![baseugly](https://user-images.githubusercontent.com/69981203/120902440-15a26600-c606-11eb-995c-821b31c72c17.png)
</details><details><summary><strong>Selection screenshot (wires)</strong></summary><br>

![screenshotwires](https://user-images.githubusercontent.com/69981203/120900944-63ff3700-c5fd-11eb-9ab9-81b8ed6089d4.png)
</details><details><summary><strong>Selection screenshot (pixels)</strong></summary><br>

![screenshotpixels](https://user-images.githubusercontent.com/69981203/120900982-96109900-c5fd-11eb-9e92-f91d4688335d.png)
</details><details><summary><strong>Selection screenshot (map)</strong></summary><br>

![screenshotmap](https://user-images.githubusercontent.com/69981203/120900967-7d07e800-c5fd-11eb-86c4-0d3262d5e868.png)
</details><details><summary><strong>Selection screenshot (transparent background)</strong></summary><br>

![screenshotnobg](https://user-images.githubusercontent.com/69981203/120900992-b0e30d80-c5fd-11eb-893d-74cf368643aa.png)
</details><details><summary><strong>Full-base screenshot (small base, map, low res)</strong></summary><br>

![screenshotsmall](https://user-images.githubusercontent.com/69981203/120901258-5185fd00-c5ff-11eb-913b-4e03a4b9ade6.png)
</details><details><summary><strong>Full-base screenshot (small base, light theme, map, low res)</strong></summary><br>

![screenshotsmalllight](https://user-images.githubusercontent.com/69981203/120902514-7467df80-c606-11eb-8692-fe194cd6a7ed.png)
</details><details><summary><strong>Full-base screenshot (small base, low res)</strong></summary><br>

![screenshotsmallshapes](https://user-images.githubusercontent.com/69981203/120901293-8abe6d00-c5ff-11eb-912e-00658a48e757.png)
</details><details><summary><strong>Full-base screenshot (medium base, wires, pixels, map, transparent background)</strong></summary><br>

![screenshoteverything](https://user-images.githubusercontent.com/69981203/120901115-74fc7800-c5fe-11eb-956f-9e09801bf0a4.png)
</details><details><summary><strong>Full-base screenshot (large base)</strong></summary><br>

![basehuge](https://user-images.githubusercontent.com/69981203/120901428-6fa02d00-c600-11eb-860a-09e55fd454df.png)
</details><details><summary><strong>Full-base screenshot (large base, pixels, map, transparent background)</strong></summary><br>

![basehugepixels](https://user-images.githubusercontent.com/69981203/120901475-bee65d80-c600-11eb-992c-b33ecddac554.png)
</details>