### PR TITLE
Fix docker image, Electron missing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY translations ./translations
 COPY src/js ./src/js
 COPY res_raw ./res_raw
 COPY .git ./.git
+COPY electron ./electron
 
 WORKDIR /shapez.io/gulp
 ENTRYPOINT ["yarn", "gulp"]


### PR DESCRIPTION
Electron was missing so the image failed when trying to run it.