### PR TITLE
Copy from ejectors

### DIFF
--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -98,13 +98,6 @@ export class HUDWiresOverlay extends BaseHUDPart {
             if (network && network.hasValue()) {
                 value = network.currentValue;
             }
-        } else if (contents.components.Display) {
-            const pinsComp = contents.components.WiredPins;
-            const network = pinsComp.slots[0].linkedNetwork;
-
-            if (network && network.hasValue()) {
-                value = network.currentValue;
-            }
         }
         // else if (contents.components.ConstantSignal) {
         // value = contents.components.ConstantSignal.signal;
@@ -131,6 +124,7 @@ export class HUDWiresOverlay extends BaseHUDPart {
                 const effectiveRotation = Math.radians(
                     staticComp.rotation + enumDirectionToAngle[slot.direction]
                 );
+                // -9.1 comes from systems > wired_pins.js > line 207
                 const valueSpritePos = slotPos.add(new Vector(0, -9.1).rotated(effectiveRotation));
                 const length = mouseTilePos.sub(valueSpritePos).length();
 

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -108,6 +108,7 @@ export class HUDWiresOverlay extends BaseHUDPart {
 
             // Go over all slots and see if they are close to mouse or not
             const pinSlots = pinComp.slots;
+            let minLength = Infinity;
             for (let i = 0; i < pinSlots.length; ++i) {
                 const slot = pinSlots[i];
 
@@ -127,7 +128,8 @@ export class HUDWiresOverlay extends BaseHUDPart {
                 const length = mouseTilePos.sub(valueSpritePos).length();
 
                 // If it is closer than 8 we can copy that value
-                if (length <= 8) {
+                if (length < minLength) {
+                    minLength = length;
                     value = slot.value;
                 }
             }

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -104,6 +104,8 @@ export class HUDWiresOverlay extends BaseHUDPart {
             const pinComp = contents.components.WiredPins;
             const staticComp = contents.components.StaticMapEntity;
 
+            const mouseTilePos = this.root.camera.screenToWorld(mousePos);
+
             // Go over all slots and see if they are close to mouse or not
             const pinSlots = pinComp.slots;
             for (let i = 0; i < pinSlots.length; ++i) {
@@ -115,8 +117,6 @@ export class HUDWiresOverlay extends BaseHUDPart {
                 }
 
                 // Check if slot is close to mouse
-                const mouseTilePos = this.root.camera.screenToWorld(mousePos);
-
                 // Dirty math that I don't like the look of
                 const slotPos = staticComp.localTileToWorld(slot.pos).toWorldSpaceCenterOfTile();
                 const effectiveRotation = Math.radians(

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -127,7 +127,7 @@ export class HUDWiresOverlay extends BaseHUDPart {
                 );
                 const length = mouseTilePos.sub(valueSpritePos).length();
 
-                // If it is closer than 8 we can copy that value
+                // If it is closer than current minimum length we can copy that value
                 if (length < minLength) {
                     minLength = length;
                     value = slot.value;

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -98,11 +98,9 @@ export class HUDWiresOverlay extends BaseHUDPart {
             if (network && network.hasValue()) {
                 value = network.currentValue;
             }
-        }
-        // else if (contents.components.ConstantSignal) {
-        // value = contents.components.ConstantSignal.signal;
-        // }
-        else if (contents.components.WiredPins) {
+        } else if (contents.components.ConstantSignal) {
+            value = contents.components.ConstantSignal.signal;
+        } else if (contents.components.WiredPins) {
             const pinComp = contents.components.WiredPins;
             const staticComp = contents.components.StaticMapEntity;
 

--- a/src/js/game/hud/parts/wires_overlay.js
+++ b/src/js/game/hud/parts/wires_overlay.js
@@ -119,11 +119,11 @@ export class HUDWiresOverlay extends BaseHUDPart {
                 // Check if slot is close to mouse
                 // Dirty math that I don't like the look of
                 const slotPos = staticComp.localTileToWorld(slot.pos).toWorldSpaceCenterOfTile();
-                const effectiveRotation = Math.radians(
-                    staticComp.rotation + enumDirectionToAngle[slot.direction]
-                );
+                const effectiveRotation = (staticComp.rotation + enumDirectionToAngle[slot.direction]) % 360;
                 // -9.1 comes from systems > wired_pins.js > line 207
-                const valueSpritePos = slotPos.add(new Vector(0, -9.1).rotated(effectiveRotation));
+                const valueSpritePos = slotPos.add(
+                    new Vector(0, -9.1).rotateInplaceFastMultipleOf90(effectiveRotation)
+                );
                 const length = mouseTilePos.sub(valueSpritePos).length();
 
                 // If it is closer than 8 we can copy that value


### PR DESCRIPTION
With this pr, "copy wire value" key will copy from ejectors instead of entities. What I am trying to say is, this pr will make copying from transistor, virtual processors etc. possible. It does this with calculating the position of sprite of value, finding the distance of it to mouse, then it just copies it if it is close enough. 