### PR TITLE
Aggregate map chunks in overlay.

### DIFF
--- a/src/js/core/buffer_maintainer.js
+++ b/src/js/core/buffer_maintainer.js
@@ -167,4 +167,25 @@ export class BufferMaintainer {
         });
         return canvas;
     }
+
+    /**
+     * @param {object} param0
+     * @param {string} param0.key
+     * @param {string} param0.subKey
+     * @returns {HTMLCanvasElement?}
+     *
+     */
+    getForKeyOrNullNoUpdate({ key, subKey }) {
+        let parent = this.cache.get(key);
+        if (!parent) {
+            return null;
+        }
+
+        // Now search for sub key
+        const cacheHit = parent.get(subKey);
+        if (cacheHit) {
+            return cacheHit.canvas;
+        }
+        return null;
+    }
 }

--- a/src/js/core/config.js
+++ b/src/js/core/config.js
@@ -55,6 +55,7 @@ export const globalConfig = {
 
     // Map
     mapChunkSize: 16,
+    chunkAggregateSize: 4,
     mapChunkOverviewMinZoom: 0.9,
     mapChunkWorldSize: null, // COMPUTED
 

--- a/src/js/game/map.js
+++ b/src/js/game/map.js
@@ -3,6 +3,7 @@ import { Vector } from "../core/vector";
 import { BasicSerializableObject, types } from "../savegame/serialization";
 import { BaseItem } from "./base_item";
 import { Entity } from "./entity";
+import { MapChunkAggregate } from "./map_chunk_aggregate";
 import { MapChunkView } from "./map_chunk_view";
 import { GameRoot } from "./root";
 
@@ -31,6 +32,11 @@ export class BaseMap extends BasicSerializableObject {
          * Mapping of 'X|Y' to chunk
          * @type {Map<string, MapChunkView>} */
         this.chunksById = new Map();
+
+        /**
+         * Mapping of 'X|Y' to chunk aggregate
+         * @type {Map<string, MapChunkAggregate>} */
+        this.aggregatesById = new Map();
     }
 
     /**
@@ -49,6 +55,39 @@ export class BaseMap extends BasicSerializableObject {
         if (createIfNotExistent) {
             const instance = new MapChunkView(this.root, chunkX, chunkY);
             this.chunksById.set(chunkIdentifier, instance);
+            return instance;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns the chunk aggregate containing a given chunk
+     * @param {number} chunkX
+     * @param {number} chunkY
+     */
+    getAggregateForChunk(chunkX, chunkY, createIfNotExistent = false) {
+        const aggX = Math.floor(chunkX / globalConfig.chunkAggregateSize);
+        const aggY = Math.floor(chunkY / globalConfig.chunkAggregateSize);
+        return this.getAggregate(aggX, aggY, createIfNotExistent);
+    }
+
+    /**
+     * Returns the given chunk aggregate by index
+     * @param {number} aggX
+     * @param {number} aggY
+     */
+    getAggregate(aggX, aggY, createIfNotExistent = false) {
+        const aggIdentifier = aggX + "|" + aggY;
+        let storedAggregate;
+
+        if ((storedAggregate = this.aggregatesById.get(aggIdentifier))) {
+            return storedAggregate;
+        }
+
+        if (createIfNotExistent) {
+            const instance = new MapChunkAggregate(this.root, aggX, aggY);
+            this.aggregatesById.set(aggIdentifier, instance);
             return instance;
         }
 

--- a/src/js/game/map_chunk_aggregate.js
+++ b/src/js/game/map_chunk_aggregate.js
@@ -1,0 +1,146 @@
+import { globalConfig } from "../core/config";
+import { DrawParameters } from "../core/draw_parameters";
+import { MapChunk } from "./map_chunk";
+import { GameRoot } from "./root";
+import { drawSpriteClipped } from "../core/draw_utils";
+
+export const CHUNK_OVERLAY_RES = 3;
+
+export class MapChunkAggregate {
+    /**
+     *
+     * @param {GameRoot} root
+     * @param {number} x
+     * @param {number} y
+     */
+    constructor(root, x, y) {
+        this.root = root;
+        this.x = x;
+        this.y = y;
+
+        /**
+         * Whenever something changes, we increase this number - so we know we need to redraw
+         */
+        this.renderIteration = 0;
+        this.dirty = false;
+        /** @type {Array<boolean>} */
+        this.dirtyList = new Array(globalConfig.chunkAggregateSize ** 2).fill(true);
+        this.markDirty(0, 0);
+    }
+
+    /**
+     * Marks this chunk as dirty, rerendering all caches
+     * @param {number} chunkX
+     * @param {number} chunkY
+     */
+    markDirty(chunkX, chunkY) {
+        const relX = chunkX % globalConfig.chunkAggregateSize;
+        const relY = chunkY % globalConfig.chunkAggregateSize;
+        this.dirtyList[relY * globalConfig.chunkAggregateSize + relX] = true;
+        if (this.dirty) {
+            return;
+        }
+        this.dirty = true;
+        ++this.renderIteration;
+        this.renderKey = this.x + "/" + this.y + "@" + this.renderIteration;
+    }
+
+    /**
+     *
+     * @param {HTMLCanvasElement} canvas
+     * @param {CanvasRenderingContext2D} context
+     * @param {number} w
+     * @param {number} h
+     * @param {number} dpi
+     */
+    generateOverlayBuffer(canvas, context, w, h, dpi) {
+        const prevKey = this.x + "/" + this.y + "@" + (this.renderIteration - 1);
+        const prevBuffer = this.root.buffers.getForKeyOrNullNoUpdate({
+            key: "agg@" + this.root.currentLayer,
+            subKey: prevKey,
+        });
+
+        const overlaySize = globalConfig.mapChunkSize * CHUNK_OVERLAY_RES;
+        let onlyDirty = false;
+        if (prevBuffer) {
+            context.drawImage(prevBuffer, 0, 0);
+            onlyDirty = true;
+        }
+
+        for (let x = 0; x < globalConfig.chunkAggregateSize; x++) {
+            for (let y = 0; y < globalConfig.chunkAggregateSize; y++) {
+                if (onlyDirty && !this.dirtyList[globalConfig.chunkAggregateSize * y + x]) continue;
+                this.root.map
+                    .getChunk(
+                        this.x * globalConfig.chunkAggregateSize + x,
+                        this.y * globalConfig.chunkAggregateSize + y,
+                        true
+                    )
+                    .generateOverlayBuffer(
+                        context,
+                        overlaySize,
+                        overlaySize,
+                        x * overlaySize,
+                        y * overlaySize
+                    );
+            }
+        }
+
+        this.dirty = false;
+        this.dirtyList.fill(false);
+    }
+
+    /**
+     * Overlay
+     * @param {DrawParameters} parameters
+     */
+    drawOverlay(parameters) {
+        const aggregateOverlaySize =
+            globalConfig.mapChunkSize * globalConfig.chunkAggregateSize * CHUNK_OVERLAY_RES;
+        const sprite = this.root.buffers.getForKey({
+            key: "agg@" + this.root.currentLayer,
+            subKey: this.renderKey,
+            w: aggregateOverlaySize,
+            h: aggregateOverlaySize,
+            dpi: 1,
+            redrawMethod: this.generateOverlayBuffer.bind(this),
+        });
+
+        const dims = globalConfig.mapChunkWorldSize * globalConfig.chunkAggregateSize;
+        const extrude = 0.05;
+
+        // Draw chunk "pixel" art
+        parameters.context.imageSmoothingEnabled = false;
+        drawSpriteClipped({
+            parameters,
+            sprite,
+            x: this.x * dims - extrude,
+            y: this.y * dims - extrude,
+            w: dims + 2 * extrude,
+            h: dims + 2 * extrude,
+            originalW: aggregateOverlaySize,
+            originalH: aggregateOverlaySize,
+        });
+
+        parameters.context.imageSmoothingEnabled = true;
+        const resourcesScale = this.root.app.settings.getAllSettings().mapResourcesScale;
+
+        // Draw patch items
+        if (this.root.currentLayer === "regular" && resourcesScale > 0.05) {
+            const diameter = (70 / Math.pow(parameters.zoomLevel, 0.35)) * (0.2 + 2 * resourcesScale);
+
+            for (let x = 0; x < globalConfig.chunkAggregateSize; x++) {
+                for (let y = 0; y < globalConfig.chunkAggregateSize; y++) {
+                    this.root.map
+                        .getChunk(this.x + x, this.y + y, true)
+                        .drawOverlayPatches(
+                            parameters,
+                            this.x * dims + x * globalConfig.mapChunkSize * CHUNK_OVERLAY_RES,
+                            this.y * dims + y * globalConfig.mapChunkSize * CHUNK_OVERLAY_RES,
+                            diameter
+                        );
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Overlay rendering performance seemed bottlenecked by drawImage calls. To
reduce both the number of calls and the number of different source
buffers, cache overlay buffers for squares of chunks. This adds a very
small extra cost for updates (one additional drawImage) and some cost
for drawing chunks outside of view, but this is more than made up for by
the savings.

By default, the aggregate are 4x4 squares of chunks.