### PR TITLE
Highlight focused text inputs, Show old signal

### DIFF
--- a/src/js/core/modal_dialog_forms.js
+++ b/src/js/core/modal_dialog_forms.js
@@ -124,6 +124,7 @@ export class FormElementInput extends FormElement {
 
     focus() {
         this.element.focus();
+        this.element.select();
     }
 }
 

--- a/src/js/game/systems/constant_signal.js
+++ b/src/js/game/systems/constant_signal.js
@@ -49,11 +49,12 @@ export class ConstantSignalSystem extends GameSystemWithFilter {
         // Ok, query, but also save the uid because it could get stale
         const uid = entity.uid;
 
+        const signal = entity.components.ConstantSignal.signal;
         const signalValueInput = new FormElementInput({
             id: "signalValue",
             label: fillInLinkIntoTranslation(T.dialogs.editSignal.descShortKey, THIRDPARTY_URLS.shapeViewer),
             placeholder: "",
-            defaultValue: "",
+            defaultValue: signal ? signal.getAsCopyableKey() : "",
             validator: val => this.parseSignalCode(entity, val),
         });
 


### PR DESCRIPTION
This PR highlights the text of the auto-focused text input in a form, to allow for easily typing over the default text. It additionally fills in the previous key when editing a signal, since it can now be easily typed over.

This also affects editing marker and world names, which work similarly to signal values. Additionally, this affects resubmitting a puzzle after an error, but it highlights the shape key by default, which matches the (presumably) most common error of an already-used shape key.

Fixes #658
