### PR TITLE
Respect "offerHints" in puzzle editor

### DIFF
--- a/src/js/game/modes/puzzle_edit.js
+++ b/src/js/game/modes/puzzle_edit.js
@@ -55,7 +55,10 @@ export class PuzzleEditGameMode extends PuzzleGameMode {
             MetaTransistorBuilding,
         ];
 
-        this.additionalHudParts.puzzleEditorControls = HUDPuzzleEditorControls;
+        if (this.root.app.settings.getAllSettings().offerHints) {
+            this.additionalHudParts.puzzleEditorControls = HUDPuzzleEditorControls;
+        }
+
         this.additionalHudParts.puzzleEditorReview = HUDPuzzleEditorReview;
         this.additionalHudParts.puzzleEditorSettings = HUDPuzzleEditorSettings;
     }


### PR DESCRIPTION
Stops Puzzle Editor game mode from adding Puzzle Editor Controls HUD if `offerHints` setting is disabled. Done with same code as already used in Regular game mode for interactive tutorial, got 5 positive votes on Discord suggestion.