### PR TITLE
Hotfix to prevent pasting locked buildings

### DIFF
--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -80,14 +80,16 @@ export class GameLogic {
         }
 
         // Perform additional placement checks
-        if (this.root.signals.prePlacementCheck.dispatch(entity, offset) === STOP_PROPAGATION) {
-            return false;
+        if (this.root.gameMode.getIsEditor()) {
+            const toolbar = this.root.hud.parts.buildingsToolbar;
+            const id = entity.components.StaticMapEntity.getMetaBuilding().getId();
+
+            if (toolbar.buildingHandles[id].puzzleLocked) {
+                return false;
+            }
         }
 
-        const toolbar = this.root.hud.parts.buildingsToolbar;
-        const id = entity.components.StaticMapEntity.getMetaBuilding().getId();
-
-        if (toolbar.buildingHandles[id].puzzleLocked) {
+        if (this.root.signals.prePlacementCheck.dispatch(entity, offset) === STOP_PROPAGATION) {
             return false;
         }
 

--- a/src/js/game/logic.js
+++ b/src/js/game/logic.js
@@ -84,6 +84,13 @@ export class GameLogic {
             return false;
         }
 
+        const toolbar = this.root.hud.parts.buildingsToolbar;
+        const id = entity.components.StaticMapEntity.getMetaBuilding().getId();
+
+        if (toolbar.buildingHandles[id].puzzleLocked) {
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
Simple change which makes sure that a building which is locked can never be placed.

I changed this to only check in the editor as it is never going to apply anywhere else anyway.

I think this may partially break my PR which adds a test mode but it needs some minor changes anyway.