### PR TITLE
docs: fix gitpod link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can use [Gitpod](https://www.gitpod.io/) (an Online Open Source VS Code-like
 -   install all of the dependencies.
 -   start `gulp` in `gulp/` directory.
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/tobspr/shapez.io)
 
 ## Helping translate
 


### PR DESCRIPTION
The from-referrer goes to gitpod.io/#https://github.com so I changed it to be the actual repo