### PR TITLE
Improve building experience involving overlay.

### DIFF
--- a/src/js/game/hud/parts/building_placer.js
+++ b/src/js/game/hud/parts/building_placer.js
@@ -235,14 +235,17 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
      */
     draw(parameters) {
         if (this.root.camera.getIsMapOverlayActive()) {
-            // Dont allow placing in overview mode
             this.domAttach.update(false);
             this.variantsAttach.update(false);
-            return;
-        }
 
-        this.domAttach.update(!!this.currentMetaBuilding.get());
-        this.variantsAttach.update(!!this.currentMetaBuilding.get());
+            if (!this.isDirectionLockActive) {
+                // only draw preview in overlay if this is a belt or wire
+                return;
+            }
+        } else {
+            this.domAttach.update(!!this.currentMetaBuilding.get());
+            this.variantsAttach.update(!!this.currentMetaBuilding.get());
+        }
         const metaBuilding = this.currentMetaBuilding.get();
 
         if (!metaBuilding) {
@@ -430,28 +433,32 @@ export class HUDBuildingPlacer extends HUDBuildingPlacerLogic {
             parameters.context.beginCircle(endLine.x, endLine.y, 5);
             parameters.context.fill();
 
-            // Draw arrow
-            const arrowSprite = this.lockIndicatorSprites[this.root.currentLayer];
-            const path = this.computeDirectionLockPath();
-            for (let i = 0; i < path.length - 1; i += 1) {
-                const { rotation, tile } = path[i];
-                const worldPos = tile.toWorldSpaceCenterOfTile();
-                const angle = Math.radians(rotation);
+            if (!this.root.camera.getIsMapOverlayActive()) {
+                // Draw arrow
+                const arrowSprite = this.lockIndicatorSprites[this.root.currentLayer];
+                const path = this.computeDirectionLockPath();
+                for (let i = 0; i < path.length - 1; i += 1) {
+                    const { rotation, tile } = path[i];
+                    const worldPos = tile.toWorldSpaceCenterOfTile();
+                    const angle = Math.radians(rotation);
 
-                parameters.context.translate(worldPos.x, worldPos.y);
-                parameters.context.rotate(angle);
-                parameters.context.drawImage(
-                    arrowSprite,
-                    -6,
-                    -globalConfig.halfTileSize -
-                        clamp((this.root.time.realtimeNow() * 1.5) % 1.0, 0, 1) * 1 * globalConfig.tileSize +
-                        globalConfig.halfTileSize -
-                        6,
-                    12,
-                    12
-                );
-                parameters.context.rotate(-angle);
-                parameters.context.translate(-worldPos.x, -worldPos.y);
+                    parameters.context.translate(worldPos.x, worldPos.y);
+                    parameters.context.rotate(angle);
+                    parameters.context.drawImage(
+                        arrowSprite,
+                        -6,
+                        -globalConfig.halfTileSize -
+                            clamp((this.root.time.realtimeNow() * 1.5) % 1.0, 0, 1) *
+                                1 *
+                                globalConfig.tileSize +
+                            globalConfig.halfTileSize -
+                            6,
+                        12,
+                        12
+                    );
+                    parameters.context.rotate(-angle);
+                    parameters.context.translate(-worldPos.x, -worldPos.y);
+                }
             }
         }
     }

--- a/src/js/game/hud/parts/building_placer_logic.js
+++ b/src/js/game/hud/parts/building_placer_logic.js
@@ -46,6 +46,12 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
         this.currentMetaBuilding = new TrackedState(this.onSelectedMetaBuildingChanged, this);
 
         /**
+         * The building selected before being interrupted by an overlay
+         * @type {MetaBuilding}
+         */
+        this.prevMetaBuilding = null;
+
+        /**
          * The current rotation
          * @type {number}
          */
@@ -251,7 +257,7 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
      * Aborts any dragging
      */
     abortDragging() {
-        this.currentlyDragging = true;
+        this.currentlyDragging = false;
         this.currentlyDeleting = false;
         this.initialPlacementVector = null;
         this.lastDragTile = null;
@@ -263,6 +269,9 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
     update() {
         // Abort placement if a dialog was shown in the meantime
         if (this.root.hud.hasBlockingOverlayOpen()) {
+            if (this.currentMetaBuilding.get()) {
+                this.prevMetaBuilding = this.currentMetaBuilding.get();
+            }
             this.abortPlacement();
             return;
         }
@@ -275,9 +284,14 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
 
         // Make sure we have nothing selected while in overview mode
         if (this.root.camera.getIsMapOverlayActive()) {
-            if (this.currentMetaBuilding.get()) {
+            const drawingPath = this.currentlyDragging && this.isDirectionLockActive;
+            if (this.currentMetaBuilding.get() && !drawingPath) {
+                this.prevMetaBuilding = this.currentMetaBuilding.get();
                 this.currentMetaBuilding.set(null);
             }
+        } else if (this.prevMetaBuilding && !this.currentMetaBuilding.get()) {
+            this.currentMetaBuilding.set(this.prevMetaBuilding);
+            this.prevMetaBuilding = null;
         }
     }
 
@@ -437,8 +451,8 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
      * @param {Vector} tile
      */
     tryPlaceCurrentBuildingAt(tile) {
-        if (this.root.camera.getIsMapOverlayActive()) {
-            // Dont allow placing in overview mode
+        if (this.root.camera.getIsMapOverlayActive() && !this.isDirectionLockActive) {
+            // Only allow placing belt and wire plans in overlay mode
             return;
         }
 
@@ -826,10 +840,6 @@ export class HUDBuildingPlacerLogic extends BaseHUDPart {
      * Mouse up handler
      */
     onMouseUp() {
-        if (this.root.camera.getIsMapOverlayActive()) {
-            return;
-        }
-
         // Check for direction lock
         if (this.lastDragTile && this.currentlyDragging && this.isDirectionLockActive) {
             this.executeDirectionLockedPlacement();


### PR DESCRIPTION
Allow continuing and placing belt/wire path plans in the map overlay
view. All logic is the same except for not drawing the arrows when
zoomed out.

Also remember previously selected building when an overlay prevents
building and switch back when appropriate.

Clearly wasn't that important, but abortDragging didn't actually change
the dragging variable. The value of this variable now matters for
properly cancelling the belt/wire planning state after placing in
overlay view.