### PR TITLE
Update base-zh-TW.yaml

### DIFF
--- a/translations/base-zh-TW.yaml
+++ b/translations/base-zh-TW.yaml
@@ -266,14 +266,14 @@ ingame:
             itemsPerSecondDouble: （2倍）
             tiles: <x>格
     levelCompleteNotification:
-        levelTitle: 第<level>級
+        levelTitle: 第<level>關
         completed: 完成
         unlockText: 解鎖<reward>！
         buttonNextLevel: 下一關
     notifications:
         newUpgrade: 有新的更新啦！
         gameSaved: 遊戲已保存。
-        freeplayLevelComplete: 已完成第<level>級！
+        freeplayLevelComplete: 已完成第<level>關！
     shop:
         title: 建築升級
         buttonUnlock: 升級
@@ -305,7 +305,7 @@ ingame:
         showHint: 顯示
         hideHint: 關閉
     blueprintPlacer:
-        cost: 需要
+        cost: 消耗
     waypoints:
         waypoints: 地圖標記
         hub: 基地
@@ -341,7 +341,7 @@ ingame:
         green: 綠
         blue: 藍
         yellow: 黃
-        purple: 紫
+        purple: 洋紅（紫）
         cyan: 青
         white: 白
         uncolored: 無顏色
@@ -349,7 +349,7 @@ ingame:
     shapeViewer:
         title: 層
         empty: 空
-        copyKey: 複製鍵
+        copyKey: 複製圖形代碼
     connectedMiners:
         one_miner: 1 個開採機
         n_miners: <amount> 個開採機
@@ -450,25 +450,25 @@ buildings:
             name: &miner 開採機
             description: &miner_desc 在圖形礦脈或者顏色礦脈上放置開採機來開採。
         chainable:
-            name: &chainable_miner 鏈式開採機
-            description: *miner_desc （鏈式開採機可以鏈結）
+            name: 鏈式開採機
+            description: *miner_desc （鏈式開採機可以以頭接尾或側鏈結）
     underground_belt:
         default:
-            name: 隧道
+            name: &underground_belt 隧道
             description: 可以從其他輸送帶或建築底下方運送物品。
         tier2:
             name: 二級隧道
-            description: 可以從其他輸送帶或建築底下方運送物品。
+            description: 可以從其他輸送帶或建築底下方運送物品，運送距離更長。
     cutter:
         default:
-            name: 切割機
+            name: &cutter 切割機
             description: 將圖形從上到下切開並輸出。 <strong>如果你只需要其中一半，記得把另一半銷毀掉，否則切割機會停止運作！ </strong>
         quad:
             name: 四分切割機
             description: 將輸入的圖形切成四塊。 <strong>如果你只需要其中一塊，記得把其他的銷毀掉，否則切割機會停止運作！ </strong>
     rotater:
         default:
-            name: 旋轉機
+            name: &rotator 旋轉機
             description: 將圖形順時針旋轉90度。
         ccw:
             name: 旋轉機（逆時針）
@@ -478,29 +478,29 @@ buildings:
             description: 將圖形旋轉180度。
     stacker:
         default:
-            name: 混合機
-            description: 將輸入的圖形拼貼在一起。如果不能被直接拼貼，右邊的圖形會被疊在左邊的圖形上面.
+            name: &stacker 圖形拼貼機
+            description: 將輸入的圖形拼貼在一起。如果不能在同一圖層直接拼貼，右邊的圖形會被堆疊在左邊的圖形上面.
     mixer:
         default:
-            name: 混色機
-            description: 將兩個顏色加在一起。
+            name: &mixer 混色機
+            description: 將兩個顏料<strong>加在一起</strong>。
     painter:
         default:
-            name: 上色機
-            description: 將整個圖形塗上輸入的顏色。
+            name: &painter 上色機
+            description: &painter_desc 將整個圖形塗上輸入的顏料。
         double:
-            name: 上色機（雙倍）
+            name: 雙倍上色機
             description: 同時為兩個輸入的圖形上色，每次上色只消耗一份顏色塗料。
         quad:
-            name: 上色機（四向）
-            description: 分別為圖形的四個部分上色。 只有 <strong>有「真」訊號輸入</strong> 的格子會被上色。
+            name: 四分上色機
+            description: 分別為圖形的四個部分上色。 只有從 <strong>有「真」訊號輸入</strong> 的顏料輸入端輸入的顏料會用來為相對的四分位上色。
         mirrored:
-            name: 上色機
-            description: 將整個圖形塗上輸入的顏色。
+            name: *painter
+            description: *painter_desc
     trash:
         default:
-            name: 垃圾桶
-            description: 從所有四個方向上輸入物品並永遠銷毀它們。
+            name: &trash 垃圾桶
+            description: 從所有從四個方向輸入的物品銷毀。
     hub:
         deliver: 交付
         toUnlock: 來解鎖
@@ -509,38 +509,38 @@ buildings:
     wire:
         default:
             name: &wire 電線
-            description: &wire_desc 傳輸訊號，訊號可以是物件，顏色或布林值（0或1）。 不同顏色的電線無法互相連接。
+            description: &wire_desc 傳輸訊號，訊號可以是圖形，顏料或布林值（0或1）。 不同顏色的電線無法互相連接。
         second:
             name: *wire
             description: *wire_desc
     balancer:
         default:
             name: &balancer 平衡機
-            description: 多功能——將所有輸入平均分配到所有輸出。
+            description: 多功能 —— 將單一輸入平均分配到所有輸出；及將多個輸入集合到一個輸出。
         merger:
             name: 合流機（右）
-            description: 將兩個輸送帶整合成一個。
+            description: 將兩條輸送帶（底部和右側）整合成一條（頂部）。
         merger-inverse:
             name: 合流機（左）
-            description: 將兩個輸送帶整合成一個。
+            description: 將兩條輸送帶（底部和左側）整合成一條（頂部）。
         splitter:
             name: 分流機（右）
-            description: 將單個輸送帶分流成兩個。
+            description: 將底部的輸送帶輸入分流成兩個（頂部和右側）。
         splitter-inverse:
             name: 分流機（左）
-            description: 將單個輸送帶分流成兩個
+            description: 將底部的輸送帶輸入分流成兩個（頂部和左側）。
     storage:
         default:
-            name: 倉庫
+            name: &storage 倉庫
             description: 儲存多餘的物品，有一定儲存上限。優先從左側輸出，可以被用來作為溢流門。
     wire_tunnel:
         default:
-            name: 電線交叉
+            name: &wire_tunnel 電線交叉
             description: 電線彼此交叉但不互相連接。
     constant_signal:
         default:
-            name: &constant_signal 固定信號
-            description: 輸出固定信號，可以是形狀、顏料或布林值（1或0）。
+            name: &constant_signal 固定訊號
+            description: 輸出固定訊號，可以是形狀、顏料或布林值（1或0）。
     lever:
         default:
             name: &lever 信號切換器
@@ -580,7 +580,7 @@ buildings:
             description: 它會讀取輸送帶的平均流量，（解鎖後）在電路層輸出最後讀取的物件。
     analyzer:
         default:
-            name: &analyzer 形狀分析機
+            name: &analyzer 圖形分析機
             description: 分析輸入的圖形訊號中最底層右上角的圖形並輸出其形狀和顏色。
     comparator:
         default:
@@ -589,7 +589,7 @@ buildings:
     virtual_processor:
         default:
             name: 虛擬切割機
-            description: 虛擬地將圖形訊號從上到下切開並輸出。
+            description: 虛擬地將圖形訊號從上到下切開。
         rotater:
             name: 虛擬旋轉機
             description: 虛擬地將圖形訊號順時針旋轉。
@@ -608,21 +608,21 @@ buildings:
             description: 沙盒模式專有，將電路層的輸入轉化成一般層的輸出。
     constant_producer:
         default:
-            name: Constant Producer
-            description: Constantly outputs a specified shape or color.
+            name: &constant_producer 恆定生產機
+            description: 持續輸出圖形或顏料。
     goal_acceptor:
         default:
-            name: Goal Acceptor
-            description: Deliver shapes to the goal acceptor to set them as a goal.
+            name: &goal_acceptor 目標接收機
+            description: 交付接收機所示圖形以完成目標。
     block:
         default:
-            name: Block
-            description: Allows you to block a tile.
+            name: &block 障礙物
+            description: 用來禁止在障礙物處放置物件。
 storyRewards:
     reward_cutter_and_trash:
         title: 切割圖形
         desc: <strong>切割機</strong>已解鎖。不論切割機的方向，它都會把圖形<strong>垂直地</strong>切成兩半。
-            <br><br>記得把不需要的部分處理掉，否則這個這個建築會<strong>因為堵塞而停止運作</strong>。
+            <br><br>記得把不需要的部分處理掉，否則切割機會<strong>因為堵塞而停止運作</strong>。
             為此我給你準備了<strong>垃圾桶</strong>，它會把所有放進去的物品銷毀掉。
     reward_rotater:
         title: 順時針旋轉
@@ -634,8 +634,8 @@ storyRewards:
         title: 混色
         desc: <strong>混色器</strong>已解鎖-在此建築物中使用<strong>附加混合</strong>結合兩種顏色！
     reward_stacker:
-        title: 混合
-        desc: <strong>混合機</strong>已解鎖。如果沒有重疊的部分，混合機會嘗試把兩個輸入的圖形<strong>拼貼</strong>在一起。如果有重疊的部分，右邊的輸入會被<strong>疊</strong>到左邊的輸入上方！
+        title: 拼貼
+        desc: <strong>圖形拼貼機</strong>已解鎖。如果沒有重疊的部分，圖形拼貼機會嘗試把兩個輸入的圖形<strong>拼貼</strong>在一起。如果有重疊的部分，右邊的輸入會被<strong>疊</strong>到左邊的輸入上方！
     reward_splitter:
         title: 分流
         desc: <strong>分流機</strong>（<strong>平衡機</strong>的變體）已解鎖。 - 它將單個輸送帶分流成兩個。
@@ -717,7 +717,7 @@ storyRewards:
             利用電路層蓋一些很酷建築<br><br> - 繼續用原本的方式破關。<br><br> 不論你的選擇是什麼，祝你玩得開心！
     reward_wires_painter_and_levers:
         title: 電路層 & 四角上色機
-        desc: "You just unlocked the <strong>電路層</strong>已解鎖。
+        desc: "<strong>電路層</strong>已解鎖。
             它是一個獨立於一般層之外的存在，將帶給你更多玩法！<br><br> 首先，我為你解鎖<strong>四角上色機</strong>。
             想要上色的角落記得在電路層通電！<br><br> 按<strong>E</strong>切換至電路層。<br><br> PS:
             設定裡<strong>開啟提示</strong>來啟動教學！"
@@ -804,8 +804,8 @@ settings:
             title: 暈映
             description: 啟用暈映，將螢幕角落裡的顏色變深，更容易閱讀文字。
         autosaveInterval:
-            title: 自動刷新時間
-            description: 控制遊戲自動刷新的頻率。您也可以停用它。
+            title: 自動存檔時間
+            description: 控制遊戲自動存檔的頻率。您也可以停用它。
             intervals:
                 one_minute: 1 分鐘
                 two_minutes: 2 分鐘
@@ -897,14 +897,14 @@ keybindings:
         toggleHud: 開關基地
         toggleFPSInfo: 開關幀數與除錯信息
         belt: *belt
-        underground_belt: 隧道
-        miner: 開採機
-        cutter: 切割機
-        rotater: 旋轉機
-        stacker: 混合機
-        mixer: 混色機
-        painter: 上色機
-        trash: 垃圾桶
+        underground_belt: *underground_belt
+        miner: *miner
+        cutter: *cutter
+        rotater: *rotater
+        stacker: *stacker
+        mixer: *mixer
+        painter: *painter
+        trash: *trash
         rotateWhilePlacing: 順時針旋轉
         rotateInverseModifier: "修飾鍵: 改為逆時針旋轉"
         cycleBuildingVariants: 選擇建築變體
@@ -924,31 +924,31 @@ keybindings:
         switchDirectionLockSide: 規劃器：換邊
         pipette: 滴管
         menuClose: 關閉選單
-        switchLayers: 更換層
-        wire: 電線
-        balancer: 平衡機
-        storage: 倉庫
-        constant_signal: 固定信號
+        switchLayers: 切換實體層／電路層
+        wire: *wire
+        balancer: *balancer
+        storage: *storage
+        constant_signal: *constant_signal
         logic_gate: 邏輯閘
-        lever: 開關（一般）
-        filter: 過濾器
-        wire_tunnel: 電線交叉
-        display: Display
-        reader: 輸送帶讀取機
-        virtual_processor: 虛擬切割機
-        transistor: 電晶體
-        analyzer: 形狀分析機
-        comparator: 比對機
+        lever: *lever
+        filter: *filter
+        wire_tunnel: *wire_tunnel
+        display: *display
+        reader: *reader
+        virtual_processor: 虛擬處理
+        transistor: *transistor
+        analyzer: *analyzer
+        comparator: *comparator
         item_producer: 物品生產機（沙盒模式）
         copyWireValue: 電路：複製數值於游標底下
         rotateToUp: "轉動: 向上"
         rotateToDown: "轉動: 向下"
         rotateToRight: "轉動: 向右"
         rotateToLeft: "轉動: 向左"
-        constant_producer: Constant Producer
-        goal_acceptor: Goal Acceptor
-        block: Block
-        massSelectClear: Clear belts
+        constant_producer: *constant_producer
+        goal_acceptor: *goal_acceptor
+        block: *block
+        massSelectClear: 清空輸送帶
         showShapeTooltip: Show shape output tooltip
 about:
     title: 關於遊戲

--- a/translations/base-zh-TW.yaml
+++ b/translations/base-zh-TW.yaml
@@ -451,7 +451,7 @@ buildings:
             description: &miner_desc 在圖形礦脈或者顏色礦脈上放置開採機來開採。
         chainable:
             name: 鏈式開採機
-            description: *miner_desc （鏈式開採機可以以頭接尾或側鏈結）
+            description: *miner_desc
     underground_belt:
         default:
             name: &underground_belt 隧道
@@ -525,14 +525,14 @@ buildings:
             description: 將兩條輸送帶（底部和左側）整合成一條（頂部）。
         splitter:
             name: 分流機（右）
-            description: 將底部的輸送帶輸入分流成兩個（頂部和右側）。
+            description: 將底部的輸送帶輸入分流成兩個輸出（頂部和右側）。
         splitter-inverse:
             name: 分流機（左）
-            description: 將底部的輸送帶輸入分流成兩個（頂部和左側）。
+            description: 將底部的輸送帶輸入分流成兩個輸出（頂部和左側）。
     storage:
         default:
             name: &storage 倉庫
-            description: 儲存多餘的物品，有一定儲存上限。優先從左側輸出，可以被用來作為溢流門。
+            description: 儲存多餘的物品，有一定儲存上限。優先從左側輸出，右側輸出可以被用來作為溢流門。
     wire_tunnel:
         default:
             name: &wire_tunnel 電線交叉
@@ -569,7 +569,7 @@ buildings:
     filter:
         default:
             name: &filter 物件分類器
-            description: 它會依據電路層收到的訊號，從分類器底部輸入的物件如符合輸入信號的會輸出到頂部，不符合的會從右方（交叉標記）排出。 它也可以被布林值訊號控制，「1（真值）」時全部輸出到。
+            description: 它會依據電路層收到的訊號，從分類器底部輸入的物件如符合輸入信號的會輸出到頂部，不符合的會從右方（交叉標記）排出。 它也可以被布林值訊號控制。
     display:
         default:
             name: &display 顯示器
@@ -577,7 +577,7 @@ buildings:
     reader:
         default:
             name: &reader 輸送帶讀取機
-            description: 它會讀取輸送帶的平均流量，（解鎖後）在電路層輸出最後讀取的物件。
+            description: 它會讀取輸送帶的平均流量，（電路層解鎖後）在電路層輸出最後讀取的物件。
     analyzer:
         default:
             name: &analyzer 圖形分析機
@@ -585,7 +585,7 @@ buildings:
     comparator:
         default:
             name: &comparator 比較機
-            description: 當兩個輸入訊號完全相等時，輸出布林值「1」。它可以比較形狀、物件或布林值。
+            description: 當兩個輸入訊號完全相等時，輸出布林值「1（真值）」。它可以比較形狀、物件或布林值。
     virtual_processor:
         default:
             name: 虛擬切割機
@@ -622,53 +622,62 @@ storyRewards:
     reward_cutter_and_trash:
         title: 切割圖形
         desc: >-
-            <strong>切割機</strong>已解鎖。不論切割機的方向，它都會把圖形<strong>垂直地</strong>切成兩半。
-            <br><br>記得把不需要的部分處理掉，否則切割機會<strong>因為堵塞而停止運作</strong>。
+            <strong>切割機</strong>已解鎖！不論切割機的方向，它都會把圖形<strong>垂直地</strong>切成兩半。<br><br>
+            記得把不需要的部分處理掉，否則切割機會<strong>因為堵塞而停止運作</strong>。
             為此我給你準備了<strong>垃圾桶</strong>，它會把所有放進去的物品銷毀掉。
     reward_rotater:
         title: 順時針旋轉
         desc: >-
-            <strong>順時針旋轉機</strong>已解鎖。它會順時針旋轉輸入的圖形90度。
+            <strong>順時針旋轉機</strong>已解鎖！
+            它會順時針旋轉輸入的圖形90度。
     reward_painter:
         title: 上色
         desc: >-
-            <strong>上色機</strong>已解鎖。開採一些顏色，用上色機把顏色和圖形混合，就可以為圖形著色。<br><br>備註：如果你是色盲，設定中有<strong>色盲模式</strong>可以選。
+            <strong>上色機</strong>已解鎖！
+            開採一些顏色，用上色機把顏色和圖形混合，就可以為圖形著色。<br><br>備註：如果你是色盲，設定中有<strong>色盲模式</strong>可以選。
     reward_mixer:
         title: 混色
         desc: >-
-            <strong>混色器</strong>已解鎖-在此建築物中使用<strong>附加混合</strong>結合兩種顏色！
+            <strong>混色器</strong>已解鎖！
+            在此建築物中使用<strong>附加混合</strong>結合兩種顏色！
     reward_stacker:
         title: 拼貼
         desc: >-
-            <strong>圖形拼貼機</strong>已解鎖。如果沒有重疊的部分，圖形拼貼機會嘗試把兩個輸入的圖形<strong>拼貼</strong>在一起。如果有重疊的部分，右邊的輸入會被<strong>疊</strong>到左邊的輸入上方！
+            <strong>圖形拼貼機</strong>已解鎖！
+            如果沒有重疊的部分，圖形拼貼機會嘗試把兩個輸入的圖形<strong>拼貼</strong>在一起。如果有重疊的部分，右邊的輸入會被<strong>疊</strong>到左邊的輸入上方！
     reward_splitter:
         title: 分流
         desc: >-
-            <strong>分流機</strong>（<strong>平衡機</strong>的變體）已解鎖。 - 它將單個輸送帶分流成兩個。
+            <strong>分流機</strong>（<strong>平衡機</strong>的變體）已解鎖！
+             - 它將單個輸送帶分流成兩個。
     reward_tunnel:
         title: 隧道
         desc: >-
-            <strong>隧道</strong>已解鎖。你現在可以從其他輸送帶或建築底下運送物品了！
+            <strong>隧道</strong>已解鎖！
+            你現在可以在其他輸送帶或建築底下運送物品了！
     reward_rotater_ccw:
         title: 逆時針旋轉
         desc: >-
-            <strong>逆時針旋轉機</strong>已解鎖。它會逆時針旋轉輸入的圖形90度。
-            逆時針旋轉機是順時針旋轉機的變體。選擇「順時針旋轉機」並<strong>按「T」來切換變體</strong>就能建立。
+            <strong>逆時針旋轉機</strong>已解鎖！
+            它會逆時針旋轉輸入的圖形90度。
+            逆時針旋轉機是順時針旋轉機的變體。選擇「順時針旋轉機」並<strong>按「T」來切換變體</strong>就能使用。
     reward_miner_chainable:
         title: 鏈式開採
         desc: >-
-            <strong>鏈式開採機</strong>已解鎖。它是開採機的一個變體。
+            <strong>鏈式開採機</strong>已解鎖！
+            它是開採機的一個變體。
             它可以將開採出來的資源<strong>傳遞</strong>給其他的開採機，使得資源提取更加高效！<br><br>
-            PS: 工具列中舊的開採機已被取代。
+            備註：工具列中舊的開採機已被取代。
     reward_underground_belt_tier_2:
         title: 二級隧道
         desc: >-
-            <strong>二級隧道</strong>已解鎖。這個隧道變體有<strong>更長的傳輸距離</strong>。你還可以混用不同的隧道變體！
+            <strong>二級隧道</strong>已解鎖！
+            這個隧道變體有<strong>更長的傳輸距離</strong>。你還可以混用不同的隧道變體！
     reward_cutter_quad:
         title: 四分切割
         desc: >-
             您已解鎖了<strong>切割機</strong>的變體：四分切割機。
-            它允許您將形狀直接切割為<strong>四個部分</strong>，而不是兩個！
+            它允許您將直接切割出形狀的<strong>四個邊角</strong>，而不是分成兩半！
     reward_painter_double:
         title: 雙倍上色
         desc: >-
@@ -676,13 +685,16 @@ storyRewards:
             它的運作方式跟上色機類似，但一次能處理<strong>兩個形狀</strong>，而且只消耗一種顏色而不是兩種顏色！
     reward_storage:
         title: 倉庫
-        desc: <strong>倉庫</strong> 已解鎖：
-            可以儲存多餘的物品，有一定儲存上限。<br><br>優先從左側輸出，可以被用來作為<strong>溢流門</strong>。
+        desc: >-
+            <strong>倉庫</strong> 已解鎖：
+            它可以儲存多餘的物品，但有一定儲存上限。<br><br>
+            物品優先從左側輸出，它也可以被用來作為<strong>溢流門</strong>。
     reward_freeplay:
         title: 自由模式
-        desc: 你做到了！你解鎖了<strong>自由模式</strong>！現在圖形將會是<strong>隨機</strong>生成的！<br><br>
+        desc: >-
+            你做到了！你解鎖了<strong>自由模式</strong>！現在圖形將會是<strong>隨機</strong>生成的！<br><br>
             從現在開始，基地會有<strong>交付速率下限</strong>的要求，因此我強烈建議你建造全自動化的生產線。<br><br>
-            基地會在電路層輸出他需要的形狀，你只需要分析這些訊號，然後依照需求自動調整你的工廠。
+            基地會在電路層輸出它需要的形狀，你只需要分析這些訊號，然後依照需求自動調整你的工廠。
     reward_blueprints:
         title: 藍圖
         desc: >-
@@ -691,42 +703,46 @@ storyRewards:
     no_reward:
         title: 下一關
         desc: >-
-            這一關沒有獎勵，但是下一關有！ <br><br>
+            這一關沒有獎勵，但是下一關會有！ <br><br>
             備註：你生產過的<strong>所有</strong>圖形都會被用來<strong>升級建築</strong>。
     no_reward_freeplay:
         title: 下一關
-        desc: 恭喜你！另外，我們已經計劃在單機版中加入更多內容！
+        desc: >-
+            恭喜你！另外，我們已經計劃在單機版中加入更多內容！
     reward_balancer:
         title: 平衡物流
-        desc: <strong>平衡機</strong>已解鎖。在大型工廠中，平衡機負責<strong>合流或分流</strong>多個輸送帶上的物品。
+        desc: >-
+            <strong>平衡機</strong>已解鎖！
+            在大型工廠中，平衡機負責<strong>合流或分流</strong>多個輸送帶上的物品。
     reward_merger:
         title: 合流
         desc: >-
-            <strong>合流機</strong>（<strong>平衡機</strong>的變體）已解鎖。 - 它會將兩個輸送帶整合成一個。
+            <strong>合流機</strong>（<strong>平衡機</strong>的變體）已解鎖！
+             - 它會將兩個輸送帶整合成一個。
     reward_belt_reader:
         title: 讀取輸送帶
         desc: >-
-            <strong>輸送帶讀取機</strong>已解鎖。 它會讀取輸送帶的流量。<br><br>
+            <strong>輸送帶讀取機</strong>已解鎖！ 它會讀取輸送帶的流量。<br><br>
             當你解鎖電路層時，它會變得超有用！
     reward_rotater_180:
         title: 180度旋轉
         desc: >-
-            180度<strong>旋轉機</strong>已解鎖。 - 它可以180度旋轉物件（驚喜！:D）
+            <strong>180度旋轉機</strong>已解鎖！ - 它可以180度旋轉物件（驚喜！:D）
     reward_display:
         title: 顯示器
         desc: >-
-            <strong>顯示器</strong> 已解鎖。 - 在電路層上連接一個訊號到顯示器上顯示！<br><br>
+            <strong>顯示器</strong> 已解鎖！ - 在電路層上連接一個訊號到顯示器上顯示！<br><br>
             備註：你有注意到輸送帶讀取機跟倉庫都會輸出它們最後讀取的物件嗎？ 試試看在顯示器上顯示它吧！"
     reward_constant_signal:
         title: 固定信號
-        desc: 電路層上的<strong>固定信號</strong>已解鎖。
+        desc: 電路層上的<strong>固定信號</strong>已解鎖！
             舉例，將<strong>物件分類器</strong>連上固定信號會很有用。<br><br>
             固定信號可以輸出<strong>形狀</strong>、<strong>顏色</strong>或是
             <strong>布林值</strong>（1或0）。
     reward_logic_gates:
         title: 邏輯閘
         desc: >-
-            <strong>邏輯閘</strong>已解鎖。 你可以覺得無所謂，但其實邏輯閘其實超酷的！<br><br>
+            <strong>邏輯閘</strong>已解鎖！你可能覺得無所謂，但其實邏輯閘其實超酷的！<br><br>
             有了這些邏輯閘，你可以運算 AND, OR, XOR 與 NOT 邏輯。<br><br>
             錦上添花，我再送你<strong>電晶體</strong>！
     reward_virtual_processing:
@@ -749,7 +765,7 @@ storyRewards:
             備註：設定裡<strong>開啟提示</strong>來啟動教學！"
     reward_filter:
         title: 物件分類器
-        desc: <strong>物件分類器</strong>已解鎖。 它會依據電路層收到的訊號決定輸出端（右方或上方）。<br><br>
+        desc: <strong>物件分類器</strong>已解鎖！ 它會依據電路層收到的訊號決定輸出端（右方或上方）。<br><br>
             你也可以輸入布林值（1或0）來徹底啟用或不啟用此機器。
     reward_demo_end:
         title: 試玩結束

--- a/translations/base-zh-TW.yaml
+++ b/translations/base-zh-TW.yaml
@@ -38,7 +38,7 @@ global:
         xDaysAgo: <x>天前
         secondsShort: <seconds>秒
         minutesAndSecondsShort: <minutes>分 <seconds>秒
-        hoursAndMinutesShort: <hours>小時 <minutes>秒
+        hoursAndMinutesShort: <hours>小時 <minutes>分
         xMinutes: <x>分鐘
     keys:
         tab: TAB
@@ -464,7 +464,7 @@ buildings:
             name: 切割機
             description: 將圖形從上到下切開並輸出。 <strong>如果你只需要其中一半，記得把另一半銷毀掉，否則切割機會停止運作！ </strong>
         quad:
-            name: 切割機（四分）
+            name: 四分切割機
             description: 將輸入的圖形切成四塊。 <strong>如果你只需要其中一塊，記得把其他的銷毀掉，否則切割機會停止運作！ </strong>
     rotater:
         default:
@@ -493,7 +493,7 @@ buildings:
             description: 同時為兩個輸入的圖形上色，每次上色只消耗一份顏色塗料。
         quad:
             name: 上色機（四向）
-            description: 分別為圖形的四個部分上色。 只有 <strong>truthy signal</strong> 的格子會被上色。
+            description: 分別為圖形的四個部分上色。 只有 <strong>有「真」訊號輸入</strong> 的格子會被上色。
         mirrored:
             name: 上色機
             description: 將整個圖形塗上輸入的顏色。
@@ -548,25 +548,24 @@ buildings:
     logic_gate:
         default:
             name: AND 邏輯閘
-            description: 當輸入均為「真」時，輸出才為1。（「真」值代表：形狀正確、顏色正確或布林值為1）
+            description: 當輸入均為「真」訊號時，輸出1（真值）。（「真」訊號代表：形狀訊號、顏色訊號或布林值為1）
         not:
             name: NOT 邏輯閘
-            description: 當輸入之ㄧ為「假」時，輸出才為1。（「假」值代表：形狀不正確、顏色不正確或布林值為0）
+            description: 當輸入為「假」訊號時，輸出1（真值）。（「假」訊號代表：沒有訊號或布林值為0）
         xor:
             name: XOR 邏輯閘
-            description: 當輸入均為「假」時，輸出才為1。（「假」值代表：形狀不正確、顏色不正確或布林值為0）
+            description: 當輸入為一個「真」訊號和一個「假」訊號時，輸出1（真值）。（「假」訊號代表：沒有訊號或布林值為0）
         or:
             name: OR 邏輯閘
-            description: 當輸入之ㄧ為「真」時，輸出才為1。（「真」值代表：形狀正確、顏色正確或布林值為1）
+            description: 當其中一個輸入為「真」時，輸出1（真值）。（「真」訊號代表：形狀訊號、顏色訊號或布林值為1）
     transistor:
         default:
             name: 電晶體
-            description: 如果基極（側面）的輸入訊號為「真」，則把射極（底部）輸入的真假值複製到集極（頂部）的輸出。
+            description: &transistor_desc 如果基極（側面）的輸入訊號為「真」，則把射極（底部）輸入的真假值複製到集極（頂部）的輸出。
                 （「真」值代表：形狀正確、顏色正確或布林值為1）
         mirrored:
             name: 電晶體
-            description: 如果基極（側面）的輸入訊號為「真」，則把射極（底部）輸入的真假值複製到集極（頂部）的輸出。
-                （「真」值代表：形狀正確、顏色正確或布林值為1）
+            description: *transistor_desc
     filter:
         default:
             name: 物件分類器
@@ -593,7 +592,7 @@ buildings:
             description: 虛擬地將圖形從上到下切開並輸出。
         rotater:
             name: 虛擬旋轉機
-            description: 虛擬地將圖形順時針或逆時針旋轉。
+            description: 虛擬地將圖形順時針旋轉。
         unstacker:
             name: 虛擬提取機
             description: 虛擬地提取最上層的圖形到右方輸出，剩下的圖形由左方輸出。
@@ -623,7 +622,7 @@ storyRewards:
     reward_cutter_and_trash:
         title: 切割圖形
         desc: <strong>切割機</strong>已解鎖。不論切割機的方向，它都會把圖形<strong>垂直地</strong>切成兩半。
-            <br><br>記得把不需要的部分處理掉，否則這個這個建築會<strong>停止運作</strong>。
+            <br><br>記得把不需要的部分處理掉，否則這個這個建築會<strong>因為堵塞而停止運作</strong>。
             為此我給你準備了<strong>垃圾桶</strong>，它會把所有放進去的物品銷毀掉。
     reward_rotater:
         title: 順時針旋轉

--- a/translations/base-zh-TW.yaml
+++ b/translations/base-zh-TW.yaml
@@ -443,15 +443,15 @@ shopUpgrades:
 buildings:
     belt:
         default:
-            name: 輸送帶
+            name: &belt 輸送帶
             description: 運送物品，按住並拖曳來放置多個。
     miner:
         default:
-            name: 開採機
-            description: 在圖形或者顏色上放置來開採他們。
+            name: &miner 開採機
+            description: &miner_desc 在圖形礦脈或者顏色礦脈上放置開採機來開採。
         chainable:
-            name: 鏈式開採機
-            description: 在圖形或者顏色上放置來開採他們。可以被鏈接在一起。
+            name: &chainable_miner 鏈式開採機
+            description: *miner_desc （鏈式開採機可以鏈結）
     underground_belt:
         default:
             name: 隧道
@@ -508,14 +508,14 @@ buildings:
         endOfDemo: 試玩結束
     wire:
         default:
-            name: 能量電線
-            description: 傳輸能量。
+            name: &wire 電線
+            description: &wire_desc 傳輸訊號，訊號可以是物件，顏色或布林值（0或1）。 不同顏色的電線無法互相連接。
         second:
-            name: 電線
-            description: 傳輸訊號，訊號可以是物件，顏色或布林值（0或1）。 不同顏色的電線無法互相連接。
+            name: *wire
+            description: *wire_desc
     balancer:
         default:
-            name: 平衡機
+            name: &balancer 平衡機
             description: 多功能——將所有輸入平均分配到所有輸出。
         merger:
             name: 合流機（右）
@@ -539,63 +539,63 @@ buildings:
             description: 電線彼此交叉但不互相連接。
     constant_signal:
         default:
-            name: 固定信號
-            description: 輸出固定信號，可以是形狀、顏色或布林值（1或0）。
+            name: &constant_signal 固定信號
+            description: 輸出固定信號，可以是形狀、顏料或布林值（1或0）。
     lever:
         default:
-            name: 信號切換器
-            description: 切換電路層的輸出布林值（1或0），舉例來說，它可以操控物件分類器。
+            name: &lever 信號切換器
+            description: 切換「1（真值）」或「0（假值）」輸出，舉例來說，它可以操控物件分類器。
     logic_gate:
         default:
             name: AND 邏輯閘
-            description: 當輸入均為「真」訊號時，輸出1（真值）。（「真」訊號代表：形狀訊號、顏色訊號或布林值為1）
+            description: 當輸入均為「真」訊號時，輸出「1（真值）」。（「真」訊號代表：形狀訊號、顏色訊號或布林值為1）
         not:
             name: NOT 邏輯閘
-            description: 當輸入為「假」訊號時，輸出1（真值）。（「假」訊號代表：沒有訊號或布林值為0）
+            description: 當輸入為「假」訊號時，輸出「1（真值）」。（「假」訊號代表：沒有訊號或布林值為0）
         xor:
             name: XOR 邏輯閘
-            description: 當輸入為一個「真」訊號和一個「假」訊號時，輸出1（真值）。（「假」訊號代表：沒有訊號或布林值為0）
+            description: 當輸入為一個「真」訊號和一個「假」訊號時，輸出「1（真值）」。（「假」訊號代表：沒有訊號或布林值為0）
         or:
             name: OR 邏輯閘
-            description: 當其中一個輸入為「真」時，輸出1（真值）。（「真」訊號代表：形狀訊號、顏色訊號或布林值為1）
+            description: 當其中一個輸入為「真」訊號時，輸出「1（真值）」。（「真」訊號代表：形狀訊號、顏色訊號或布林值為1）
     transistor:
         default:
-            name: 電晶體
+            name: &transistor 電晶體
             description: &transistor_desc 如果基極（側面）的輸入訊號為「真」，則把射極（底部）輸入的真假值複製到集極（頂部）的輸出。
-                （「真」值代表：形狀正確、顏色正確或布林值為1）
+                （「真」訊號代表：形狀訊號、顏色訊號或布林值為1）
         mirrored:
-            name: 電晶體
+            name: *transistor
             description: *transistor_desc
     filter:
         default:
-            name: 物件分類器
-            description: 它會依據電路層收到的訊號分類，符合的會到上方，不符合的到右方。 它也可以被布林值訊號控制。
+            name: &filter 物件分類器
+            description: 它會依據電路層收到的訊號，從分類器底部輸入的物件如符合輸入信號的會輸出到頂部，不符合的會從右方（交叉標記）排出。 它也可以被布林值訊號控制，「1（真值）」時全部輸出到。
     display:
         default:
-            name: 顯示器
-            description: 連接一個訊號到顯示器上顯示，訊號可以是形狀、物件或布林值。
+            name: &display 顯示器
+            description: 連接一個訊號到顯示器上顯示，訊號可以是形狀、顏料或布林值。
     reader:
         default:
-            name: 輸送帶讀取機
+            name: &reader 輸送帶讀取機
             description: 它會讀取輸送帶的平均流量，（解鎖後）在電路層輸出最後讀取的物件。
     analyzer:
         default:
-            name: 形狀分析機
-            description: 分析最底層右上角的圖形並輸出他的形狀跟顏色。
+            name: &analyzer 形狀分析機
+            description: 分析輸入的圖形訊號中最底層右上角的圖形並輸出其形狀和顏色。
     comparator:
         default:
-            name: 比較機
+            name: &comparator 比較機
             description: 當兩個輸入訊號完全相等時，輸出布林值「1」。它可以比較形狀、物件或布林值。
     virtual_processor:
         default:
             name: 虛擬切割機
-            description: 虛擬地將圖形從上到下切開並輸出。
+            description: 虛擬地將圖形訊號從上到下切開並輸出。
         rotater:
             name: 虛擬旋轉機
-            description: 虛擬地將圖形順時針旋轉。
+            description: 虛擬地將圖形訊號順時針旋轉。
         unstacker:
             name: 虛擬提取機
-            description: 虛擬地提取最上層的圖形到右方輸出，剩下的圖形由左方輸出。
+            description: 虛擬地提取圖形訊號最上層的圖形到右方輸出，剩下的圖形由左方輸出。
         stacker:
             name: 虛擬堆疊機
             description: 虛擬地將輸入的圖形拼貼在一起。如果不能被直接拼貼，右邊的圖形會被疊在左邊的圖形上面。
@@ -896,7 +896,7 @@ keybindings:
         menuOpenStats: 統計選單
         toggleHud: 開關基地
         toggleFPSInfo: 開關幀數與除錯信息
-        belt: 輸送帶
+        belt: *belt
         underground_belt: 隧道
         miner: 開採機
         cutter: 切割機

--- a/translations/base-zh-TW.yaml
+++ b/translations/base-zh-TW.yaml
@@ -458,7 +458,7 @@ buildings:
             description: 可以從其他輸送帶或建築底下方運送物品。
         tier2:
             name: 二級隧道
-            description: 可以從其他輸送帶或建築底下方運送物品，運送距離更長。
+            description: 可以從其他輸送帶或建築底下方運送物品。
     cutter:
         default:
             name: &cutter 切割機
@@ -490,7 +490,7 @@ buildings:
             description: &painter_desc 將整個圖形塗上輸入的顏料。
         double:
             name: 雙倍上色機
-            description: 同時為兩個輸入的圖形上色，每次上色只消耗一份顏色塗料。
+            description: 同時為兩個輸入的圖形上色，每次上色只消耗一份顏料。
         quad:
             name: 四分上色機
             description: 分別為圖形的四個部分上色。 只有從 <strong>有「真」訊號輸入</strong> 的顏料輸入端輸入的顏料會用來為相對的四分位上色。
@@ -605,7 +605,7 @@ buildings:
     item_producer:
         default:
             name: 物品製造機
-            description: 沙盒模式專有，將電路層的輸入轉化成一般層的輸出。
+            description: 沙盒模式專有，將電路層的輸入轉化成實體層的輸出。
     constant_producer:
         default:
             name: &constant_producer 恆定生產機
@@ -621,46 +621,58 @@ buildings:
 storyRewards:
     reward_cutter_and_trash:
         title: 切割圖形
-        desc: <strong>切割機</strong>已解鎖。不論切割機的方向，它都會把圖形<strong>垂直地</strong>切成兩半。
+        desc: >-
+            <strong>切割機</strong>已解鎖。不論切割機的方向，它都會把圖形<strong>垂直地</strong>切成兩半。
             <br><br>記得把不需要的部分處理掉，否則切割機會<strong>因為堵塞而停止運作</strong>。
             為此我給你準備了<strong>垃圾桶</strong>，它會把所有放進去的物品銷毀掉。
     reward_rotater:
         title: 順時針旋轉
-        desc: <strong>順時針旋轉機</strong>已解鎖。它會順時針旋轉輸入的圖形90度。
+        desc: >-
+            <strong>順時針旋轉機</strong>已解鎖。它會順時針旋轉輸入的圖形90度。
     reward_painter:
         title: 上色
-        desc: <strong>上色機</strong>已解鎖。開採一些顏色，用上色機把顏色和圖形混合，就可以為圖形著色。<br><br>備註：如果你是色盲，設定中有<strong>色盲模式</strong>可以選。
+        desc: >-
+            <strong>上色機</strong>已解鎖。開採一些顏色，用上色機把顏色和圖形混合，就可以為圖形著色。<br><br>備註：如果你是色盲，設定中有<strong>色盲模式</strong>可以選。
     reward_mixer:
         title: 混色
-        desc: <strong>混色器</strong>已解鎖-在此建築物中使用<strong>附加混合</strong>結合兩種顏色！
+        desc: >-
+            <strong>混色器</strong>已解鎖-在此建築物中使用<strong>附加混合</strong>結合兩種顏色！
     reward_stacker:
         title: 拼貼
-        desc: <strong>圖形拼貼機</strong>已解鎖。如果沒有重疊的部分，圖形拼貼機會嘗試把兩個輸入的圖形<strong>拼貼</strong>在一起。如果有重疊的部分，右邊的輸入會被<strong>疊</strong>到左邊的輸入上方！
+        desc: >-
+            <strong>圖形拼貼機</strong>已解鎖。如果沒有重疊的部分，圖形拼貼機會嘗試把兩個輸入的圖形<strong>拼貼</strong>在一起。如果有重疊的部分，右邊的輸入會被<strong>疊</strong>到左邊的輸入上方！
     reward_splitter:
         title: 分流
-        desc: <strong>分流機</strong>（<strong>平衡機</strong>的變體）已解鎖。 - 它將單個輸送帶分流成兩個。
+        desc: >-
+            <strong>分流機</strong>（<strong>平衡機</strong>的變體）已解鎖。 - 它將單個輸送帶分流成兩個。
     reward_tunnel:
         title: 隧道
-        desc: <strong>隧道</strong>已解鎖。你現在可以從其他輸送帶或建築底下運送物品了！
+        desc: >-
+            <strong>隧道</strong>已解鎖。你現在可以從其他輸送帶或建築底下運送物品了！
     reward_rotater_ccw:
         title: 逆時針旋轉
-        desc: <strong>逆時針旋轉機</strong>已解鎖。它會逆時針旋轉輸入的圖形90度。
+        desc: >-
+            <strong>逆時針旋轉機</strong>已解鎖。它會逆時針旋轉輸入的圖形90度。
             逆時針旋轉機是順時針旋轉機的變體。選擇「順時針旋轉機」並<strong>按「T」來切換變體</strong>就能建立。
     reward_miner_chainable:
         title: 鏈式開採
-        desc: "<strong>鏈式開採機</strong>變體已解鎖。它是開採機的一個變體。
-            它可以將開採出來的資源<strong>傳遞</strong>給其他的開採機，使得資源提取更加高效！<br><br> PS:
-            工具列中舊的開採機已被取代。"
+        desc: >-
+            <strong>鏈式開採機</strong>已解鎖。它是開採機的一個變體。
+            它可以將開採出來的資源<strong>傳遞</strong>給其他的開採機，使得資源提取更加高效！<br><br>
+            PS: 工具列中舊的開採機已被取代。
     reward_underground_belt_tier_2:
         title: 二級隧道
-        desc: <strong>二級隧道</strong>變體已解鎖。這個隧道有<strong>更長的傳輸距離</strong>。你還可以混用不同的隧道變體！
+        desc: >-
+            <strong>二級隧道</strong>已解鎖。這個隧道變體有<strong>更長的傳輸距離</strong>。你還可以混用不同的隧道變體！
     reward_cutter_quad:
         title: 四分切割
-        desc: 您已解鎖了<strong>切割機</strong>的變體：四分切割機。
+        desc: >-
+            您已解鎖了<strong>切割機</strong>的變體：四分切割機。
             它允許您將形狀直接切割為<strong>四個部分</strong>，而不是兩個！
     reward_painter_double:
         title: 雙倍上色
-        desc: 您已經解鎖了<strong>上色機</strong>的變體：雙倍上色機。
+        desc: >-
+            您已經解鎖了<strong>上色機</strong>的變體：雙倍上色機。
             它的運作方式跟上色機類似，但一次能處理<strong>兩個形狀</strong>，而且只消耗一種顏色而不是兩種顏色！
     reward_storage:
         title: 倉庫
@@ -669,17 +681,18 @@ storyRewards:
     reward_freeplay:
         title: 自由模式
         desc: 你做到了！你解鎖了<strong>自由模式</strong>！現在圖形將會是<strong>隨機</strong>生成的！<br><br>
-            從現在開始，基地會要求<strong>流量</strong>下限，因此我強烈建議你建造全自動化的生產線。<br><br>
+            從現在開始，基地會有<strong>交付速率下限</strong>的要求，因此我強烈建議你建造全自動化的生產線。<br><br>
             基地會在電路層輸出他需要的形狀，你只需要分析這些訊號，然後依照需求自動調整你的工廠。
     reward_blueprints:
         title: 藍圖
-        desc: 你現在可以<strong>複製貼上</strong>你的工廠某些區域。 選擇一個區域（按住 CTRL
-            並拖曳滑鼠），再按「C」來複製。<br><br>
-            貼上<strong>不是免費的</strong>，你必須製造（剛才生成的）<strong>藍圖形狀</strong>來給付。
+        desc: >-
+            你現在可以<strong>複製貼上</strong>你的工廠某些區域。 選擇一個區域（按住 CTRL 並拖曳滑鼠），再按「C」來複製。<br><br>
+            貼上藍圖<strong>不是免費的</strong>，你必須製造（剛才生成的）<strong>藍圖形狀</strong>來給付。
     no_reward:
         title: 下一關
-        desc: "這一關沒有獎勵，但是下一關有！ <br><br> PS:
-            你生產過的<strong>所有</strong>圖形都會被用來<strong>升級建築</strong>。"
+        desc: >-
+            這一關沒有獎勵，但是下一關有！ <br><br>
+            備註：你生產過的<strong>所有</strong>圖形都會被用來<strong>升級建築</strong>。
     no_reward_freeplay:
         title: 下一關
         desc: 恭喜你！另外，我們已經計劃在單機版中加入更多內容！
@@ -688,17 +701,22 @@ storyRewards:
         desc: <strong>平衡機</strong>已解鎖。在大型工廠中，平衡機負責<strong>合流或分流</strong>多個輸送帶上的物品。
     reward_merger:
         title: 合流
-        desc: <strong>合流機</strong>（<strong>平衡機</strong>的變體）已解鎖。 - 它會將兩個輸送帶整合成一個。
+        desc: >-
+            <strong>合流機</strong>（<strong>平衡機</strong>的變體）已解鎖。 - 它會將兩個輸送帶整合成一個。
     reward_belt_reader:
         title: 讀取輸送帶
-        desc: <strong>輸送帶讀取機</strong>已解鎖。 它會讀取輸送帶的流量。<br><br> 當你解鎖電路層時，它會變得超有用！
+        desc: >-
+            <strong>輸送帶讀取機</strong>已解鎖。 它會讀取輸送帶的流量。<br><br>
+            當你解鎖電路層時，它會變得超有用！
     reward_rotater_180:
         title: 180度旋轉
-        desc: 180度<strong>旋轉機</strong>已解鎖。 - 它可以180度旋轉物件（驚喜！:D）
+        desc: >-
+            180度<strong>旋轉機</strong>已解鎖。 - 它可以180度旋轉物件（驚喜！:D）
     reward_display:
         title: 顯示器
-        desc: "<strong>顯示器</strong> 已解鎖。 - 在電路層上連接一個訊號到顯示器上顯示！<br><br> PS:
-            你有注意到輸送帶讀取機跟倉庫都會輸出它們最後讀取的物件嗎？ 試試看在顯示器上顯示它吧！"
+        desc: >-
+            <strong>顯示器</strong> 已解鎖。 - 在電路層上連接一個訊號到顯示器上顯示！<br><br>
+            備註：你有注意到輸送帶讀取機跟倉庫都會輸出它們最後讀取的物件嗎？ 試試看在顯示器上顯示它吧！"
     reward_constant_signal:
         title: 固定信號
         desc: 電路層上的<strong>固定信號</strong>已解鎖。
@@ -707,24 +725,32 @@ storyRewards:
             <strong>布林值</strong>（1或0）。
     reward_logic_gates:
         title: 邏輯閘
-        desc: <strong>邏輯閘</strong>已解鎖。 你可以覺得無所謂，但其實邏輯閘其實超酷的！<br><br> 有了這些邏輯閘，你可以運算 AND,
-            OR, XOR 與 NOT。<br><br> 錦上添花，我再送你<strong>電晶體</strong>！
+        desc: >-
+            <strong>邏輯閘</strong>已解鎖。 你可以覺得無所謂，但其實邏輯閘其實超酷的！<br><br>
+            有了這些邏輯閘，你可以運算 AND, OR, XOR 與 NOT 邏輯。<br><br>
+            錦上添花，我再送你<strong>電晶體</strong>！
     reward_virtual_processing:
         title: 虛擬操作
-        desc: <strong>虛擬操作</strong>！<br><br>已解鎖。很多新建築有虛擬版，你可以模擬切割機、旋轉機、推疊機還有更多電路層上的建築。
-            繼續遊玩的你現在有三個選項：<br><br> -
-            蓋一個自動生成任何基地要求圖形的<strong>自動機</strong>（推薦！）。<br><br> -
-            利用電路層蓋一些很酷建築<br><br> - 繼續用原本的方式破關。<br><br> 不論你的選擇是什麼，祝你玩得開心！
+        desc: >-
+            <strong>虛擬操作</strong>已解鎖！
+            我已為您帶來很多原有建築的虛擬版，有切割機、旋轉機、拼貼機還有更多電路層上的虛擬建築。
+            有了虛擬操作的你現在有三個繼續玩下去的方向：<br><br>
+            - 蓋一個自動生成任何基地要求圖形的<strong>自動工廠</strong>（推薦！）。<br><br>
+            - 利用電路層蓋一些很酷建築<br><br>
+            - 繼續用原本的方式破關。<br><br>
+            不論你的選擇是什麼，祝你玩得開心！
     reward_wires_painter_and_levers:
         title: 電路層 & 四角上色機
-        desc: "<strong>電路層</strong>已解鎖。
-            它是一個獨立於一般層之外的存在，將帶給你更多玩法！<br><br> 首先，我為你解鎖<strong>四角上色機</strong>。
-            想要上色的角落記得在電路層通電！<br><br> 按<strong>E</strong>切換至電路層。<br><br> PS:
-            設定裡<strong>開啟提示</strong>來啟動教學！"
+        desc: >-
+            <strong>電路層</strong>已解鎖！
+            它是一個獨立於實體層之外的存在，將帶給你更多玩法！<br><br>
+            首先，我為你解鎖<strong>四角上色機</strong>。記得先在電路層為想要上色的角落通電！<br><br>
+            按<strong>E</strong>切換至電路層。<br><br>
+            備註：設定裡<strong>開啟提示</strong>來啟動教學！"
     reward_filter:
         title: 物件分類器
         desc: <strong>物件分類器</strong>已解鎖。 它會依據電路層收到的訊號決定輸出端（右方或上方）。<br><br>
-            你也可以送一個固定訊號（1或0）來徹底啟用或不啟用此機器。
+            你也可以輸入布林值（1或0）來徹底啟用或不啟用此機器。
     reward_demo_end:
         title: 試玩結束
         desc: 你已破關試玩版！
@@ -864,9 +890,8 @@ settings:
             title: 地圖資源標示大小
             description: 控制地圖資源標示大小（縮小俯瞰時）。
         shapeTooltipAlwaysOn:
-            title: Shape Tooltip - Show Always
-            description: Whether to always show the shape tooltip when hovering buildings,
-                instead of having to hold 'ALT'.
+            title: 常時顯示建築物輸出提示
+            description: 選擇是否常時在焦點移到建築物時顯示它的上一個輸出物件，而不需按「ALT」鍵才會顯示。
     rangeSliderPercentage: <amount> %
     tickrateHz: <amount> Hz
 keybindings:
@@ -884,10 +909,10 @@ keybindings:
     mappings:
         confirm: 確認
         back: 返回
-        mapMoveUp: 上
-        mapMoveRight: 右
-        mapMoveDown: 下
-        mapMoveLeft: 左
+        mapMoveUp: 向上移動
+        mapMoveRight: 向右移動
+        mapMoveDown: 向下移動
+        mapMoveLeft: 向左移動
         centerMap: 回到基地
         mapZoomIn: 放大
         mapZoomOut: 縮小
@@ -949,7 +974,7 @@ keybindings:
         goal_acceptor: *goal_acceptor
         block: *block
         massSelectClear: 清空輸送帶
-        showShapeTooltip: Show shape output tooltip
+        showShapeTooltip: 顯示建築物輸出提示
 about:
     title: 關於遊戲
     body: >-


### PR DESCRIPTION
- **This PR is basically done (base on commit #4c3d83a)**

* fix some translations
  * de-clutter wordings
  * add more detail description to certain help text
    * e.g. splitters (left): split input from bottom to top and left outputs
   
  * rewrite misleading descriptions of logic gates 
  
    *  XOR description was descripting NAND/NOR gates
    * NOT gate description was written as "When 1 of the input is false...", corrected as "When input is false signal..."
    * "truthy signals" was written as "true" 
    * "not truthy signals" was written as "color not correct" and "shape not correct", which is true for comparators but not logic gates.

* re-use pointers from English translation to unify some terms and names, e.g. quad painters translated as 切割機（四分）(in-game descriptions) and 四分切割機 (tips and tricks), to be unified as 四分切割機

* TO DO: translate puzzle DLC texts