### PR TITLE
Made extrude optional and disabled it for wires to fix wires looking off

### DIFF
--- a/src/js/core/sprites.js
+++ b/src/js/core/sprites.js
@@ -149,8 +149,9 @@ export class AtlasSprite extends BaseSprite {
      * @param {number} w
      * @param {number} h
      * @param {boolean=} clipping Whether to perform culling
+     * @param {boolean=} extrude Whether to extrude
      */
-    drawCached(parameters, x, y, w = null, h = null, clipping = true) {
+    drawCached(parameters, x, y, w = null, h = null, clipping = true, extrude = true) {
         if (G_IS_DEV) {
             assert(parameters instanceof DrawParameters, "Not a valid context");
             assert(!!w && w > 0, "Not a valid width:" + w);
@@ -201,6 +202,7 @@ export class AtlasSprite extends BaseSprite {
             destH = intersection.h;
         }
 
+        const extrudeValue = extrude ? EXTRUDE : 0;
         parameters.context.drawImage(
             link.atlas,
 
@@ -213,10 +215,10 @@ export class AtlasSprite extends BaseSprite {
             srcH,
 
             // dest pos and size
-            destX - EXTRUDE,
-            destY - EXTRUDE,
-            destW + 2 * EXTRUDE,
-            destH + 2 * EXTRUDE
+            destX - extrudeValue,
+            destY - extrudeValue,
+            destW + 2 * extrudeValue,
+            destH + 2 * extrudeValue
         );
     }
 
@@ -228,8 +230,9 @@ export class AtlasSprite extends BaseSprite {
      * @param {number} w
      * @param {number} h
      * @param {Rectangle=} clipRect The rectangle in local space (0 ... 1) to draw of the image
+     * @param {boolean=} extrude Whether to extrude
      */
-    drawCachedWithClipRect(parameters, x, y, w = null, h = null, clipRect = FULL_CLIP_RECT) {
+    drawCachedWithClipRect(parameters, x, y, w = null, h = null, clipRect = FULL_CLIP_RECT, extrude = true) {
         if (G_IS_DEV) {
             assert(parameters instanceof DrawParameters, "Not a valid context");
             assert(!!w && w > 0, "Not a valid width:" + w);
@@ -257,6 +260,7 @@ export class AtlasSprite extends BaseSprite {
         let srcW = link.packedW * clipRect.w;
         let srcH = link.packedH * clipRect.h;
 
+        const extrudeValue = extrude ? EXTRUDE : 0;
         parameters.context.drawImage(
             link.atlas,
 
@@ -269,10 +273,10 @@ export class AtlasSprite extends BaseSprite {
             srcH,
 
             // dest pos and size
-            destX - EXTRUDE,
-            destY - EXTRUDE,
-            destW + 2 * EXTRUDE,
-            destH + 2 * EXTRUDE
+            destX - extrudeValue,
+            destY - extrudeValue,
+            destW + 2 * extrudeValue,
+            destH + 2 * extrudeValue
         );
     }
 

--- a/src/js/game/components/static_map_entity.js
+++ b/src/js/game/components/static_map_entity.js
@@ -255,8 +255,15 @@ export class StaticMapEntityComponent extends Component {
      * @param {AtlasSprite} sprite
      * @param {number=} extrudePixels How many pixels to extrude the sprite
      * @param {Vector=} overridePosition Whether to drwa the entity at a different location
+     * @param {boolean=} extrude Whether to extrude
      */
-    drawSpriteOnBoundsClipped(parameters, sprite, extrudePixels = 0, overridePosition = null) {
+    drawSpriteOnBoundsClipped(
+        parameters,
+        sprite,
+        extrudePixels = 0,
+        overridePosition = null,
+        extrude = true
+    ) {
         if (!this.shouldBeDrawn(parameters) && !overridePosition) {
             return;
         }
@@ -276,7 +283,9 @@ export class StaticMapEntityComponent extends Component {
                 worldX - extrudePixels * size.x,
                 worldY - extrudePixels * size.y,
                 globalConfig.tileSize * size.x + 2 * extrudePixels * size.x,
-                globalConfig.tileSize * size.y + 2 * extrudePixels * size.y
+                globalConfig.tileSize * size.y + 2 * extrudePixels * size.y,
+                true,
+                extrude
             );
         } else {
             const rotationCenterX = worldX + globalConfig.halfTileSize;
@@ -290,7 +299,8 @@ export class StaticMapEntityComponent extends Component {
                 -globalConfig.halfTileSize - extrudePixels * size.y,
                 globalConfig.tileSize * size.x + 2 * extrudePixels * size.x,
                 globalConfig.tileSize * size.y + 2 * extrudePixels * size.y,
-                false // no clipping possible here
+                false, // no clipping possible here
+                extrude
             );
             parameters.context.rotate(-Math.radians(this.rotation));
             parameters.context.translate(-rotationCenterX, -rotationCenterY);

--- a/src/js/game/systems/wire.js
+++ b/src/js/game/systems/wire.js
@@ -616,7 +616,7 @@ export class WireSystem extends GameSystemWithFilter {
                     assert(sprite, "Unknown wire type: " + wireType);
                     const staticComp = entity.components.StaticMapEntity;
                     parameters.context.globalAlpha = opacity;
-                    staticComp.drawSpriteOnBoundsClipped(parameters, sprite, 0);
+                    staticComp.drawSpriteOnBoundsClipped(parameters, sprite, 0, null, false);
 
                     // DEBUG Rendering
                     if (G_IS_DEV && globalConfig.debug.renderWireRotations) {


### PR DESCRIPTION
Fixed the wire sprite error where it seams like they are set off and overlap. The cause of this is the extrude on the sprite. 

**Changes**
* Made the extrude on sprites optional, but default to true. 
* Set extrude on wires to false

**Before**
![Schermafbeelding 2021-11-21 195841](https://user-images.githubusercontent.com/44841260/142775343-fea7cb5f-29a9-4ab9-b7f4-6929de6514dd.png)

**After**
![Schermafbeelding 2021-11-21 195602](https://user-images.githubusercontent.com/44841260/142775295-088bb057-99dd-4651-8b75-bd764f9d1489.png)

