### PR TITLE
Fixed missing belt on corners of hub, splitter and merger

### DIFF
--- a/src/js/game/buildings/balancer.js
+++ b/src/js/game/buildings/balancer.js
@@ -197,6 +197,14 @@ export class MetaBalancerBuilding extends MetaBuilding {
 
                 entity.components.BeltUnderlays.underlays = [
                     { pos: new Vector(0, 0), direction: enumDirection.top },
+                    {
+                        pos: new Vector(0, 0),
+                        direction:
+                            variant === enumBalancerVariants.mergerInverse
+                                ? enumDirection.right
+                                : enumDirection.left,
+                        corner: true,
+                    },
                 ];
 
                 break;
@@ -226,6 +234,14 @@ export class MetaBalancerBuilding extends MetaBuilding {
 
                 entity.components.BeltUnderlays.underlays = [
                     { pos: new Vector(0, 0), direction: enumDirection.top },
+                    {
+                        pos: new Vector(0, 0),
+                        direction:
+                            variant === enumBalancerVariants.splitterInverse
+                                ? enumDirection.left
+                                : enumDirection.right,
+                        corner: true,
+                    },
                 ];
 
                 break;

--- a/src/js/game/buildings/hub.js
+++ b/src/js/game/buildings/hub.js
@@ -5,6 +5,7 @@ import { enumItemProcessorTypes, ItemProcessorComponent } from "../components/it
 import { Entity } from "../entity";
 import { MetaBuilding } from "../meta_building";
 import { WiredPinsComponent, enumPinSlotType } from "../components/wired_pins";
+import { BeltUnderlaysComponent } from "../components/belt_underlays";
 
 export class MetaHubBuilding extends MetaBuilding {
     constructor() {
@@ -133,6 +134,53 @@ export class MetaHubBuilding extends MetaBuilding {
                         pos: new Vector(3, 3),
                         directions: [enumDirection.right],
                         filter: "shape",
+                    },
+                ],
+            })
+        );
+
+        entity.addComponent(
+            new BeltUnderlaysComponent({
+                underlays: [
+                    {
+                        pos: new Vector(0, 0),
+                        direction: enumDirection.right,
+                        corner: true,
+                    },
+                    {
+                        pos: new Vector(0, 0),
+                        direction: enumDirection.bottom,
+                        corner: true,
+                    },
+                    {
+                        pos: new Vector(0, 3),
+                        direction: enumDirection.right,
+                        corner: true,
+                    },
+                    {
+                        pos: new Vector(0, 3),
+                        direction: enumDirection.top,
+                        corner: true,
+                    },
+                    {
+                        pos: new Vector(3, 0),
+                        direction: enumDirection.left,
+                        corner: true,
+                    },
+                    {
+                        pos: new Vector(3, 0),
+                        direction: enumDirection.bottom,
+                        corner: true,
+                    },
+                    {
+                        pos: new Vector(3, 3),
+                        direction: enumDirection.left,
+                        corner: true,
+                    },
+                    {
+                        pos: new Vector(3, 3),
+                        direction: enumDirection.top,
+                        corner: true,
                     },
                 ],
             })

--- a/src/js/game/components/belt_underlays.js
+++ b/src/js/game/components/belt_underlays.js
@@ -16,6 +16,7 @@ export const enumClippedBeltUnderlayType = {
     topOnly: "topOnly",
     topCorner: "topCorner",
     bottomCorner: "bottomCorner",
+    cornerFull: "cornerFull",
     none: "none",
 };
 

--- a/src/js/game/components/belt_underlays.js
+++ b/src/js/game/components/belt_underlays.js
@@ -14,6 +14,8 @@ export const enumClippedBeltUnderlayType = {
     full: "full",
     bottomOnly: "bottomOnly",
     topOnly: "topOnly",
+    topCorner: "topCorner",
+    bottomCorner: "bottomCorner",
     none: "none",
 };
 
@@ -21,6 +23,7 @@ export const enumClippedBeltUnderlayType = {
  * @typedef {{
  *   pos: Vector,
  *   direction: enumDirection,
+ *   corner?: boolean,
  *   cachedType?: enumClippedBeltUnderlayType
  * }} BeltUnderlayTile
  */

--- a/src/js/game/components/item_ejector.js
+++ b/src/js/game/components/item_ejector.js
@@ -1,4 +1,4 @@
-import { enumDirection, enumDirectionToVector, Vector } from "../../core/vector";
+import { enumDirection, enumDirectionToVector, enumInvertedDirections, Vector } from "../../core/vector";
 import { types } from "../../savegame/serialization";
 import { BaseItem } from "../base_item";
 import { BeltPath } from "../belt_path";
@@ -150,5 +150,34 @@ export class ItemEjectorComponent extends Component {
         slot.item = null;
         slot.progress = 0.0;
         return item;
+    }
+
+    /**
+     * Tries to find a slot which ejects the current item
+     * @param {Vector} targetLocalTile
+     * @param {enumDirection} fromLocalDirection
+     * @returns {ItemEjectorSlot|null}
+     */
+    findMatchingSlot(targetLocalTile, fromLocalDirection) {
+        // We need to invert our direction since the ejector specifies *from* which direction
+        // it ejects items, but the acceptor specifies *into* which direction it accepts items.
+        // E.g.: Acceptor ejects into "right" direction but ejector accepts from "left" direction.
+        const desiredDirection = enumInvertedDirections[fromLocalDirection];
+
+        // Go over all slots and try to find a target slot
+        for (let slotIndex = 0; slotIndex < this.slots.length; ++slotIndex) {
+            const slot = this.slots[slotIndex];
+
+            // Make sure the acceptor slot is on the right position
+            if (!slot.pos.equals(targetLocalTile)) {
+                continue;
+            }
+
+            if (desiredDirection === slot.direction) {
+                return slot;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/js/game/systems/belt_underlays.js
+++ b/src/js/game/systems/belt_underlays.js
@@ -185,10 +185,7 @@ export class BeltUnderlaysSystem extends GameSystemWithFilter {
         }
 
         const staticComp = entity.components.StaticMapEntity;
-
         const transformedPos = staticComp.localTileToWorld(underlayTile.pos);
-        const destX = transformedPos.x * globalConfig.tileSize;
-        const destY = transformedPos.y * globalConfig.tileSize;
 
         // Extract direction and angle
         const worldDirection = staticComp.localDirectionToWorld(underlayTile.direction);

--- a/src/js/game/systems/belt_underlays.js
+++ b/src/js/game/systems/belt_underlays.js
@@ -203,6 +203,8 @@ export class BeltUnderlaysSystem extends GameSystemWithFilter {
                 enumInvertedDirections[underlayTile.direction]
             );
             if (!ejectorSlot) connectedTop = false;
+        } else {
+            connectedTop = false;
         }
 
         // Figure out if there is anything connected at the bottom
@@ -214,6 +216,8 @@ export class BeltUnderlaysSystem extends GameSystemWithFilter {
         if (acceptorComp) {
             const acceptorSlot = acceptorComp.findMatchingSlot(underlayTile.pos, underlayTile.direction);
             if (!acceptorSlot) connectedBottom = false;
+        } else {
+            connectedBottom = false;
         }
 
         let flag = enumClippedBeltUnderlayType.none;

--- a/src/js/game/systems/belt_underlays.js
+++ b/src/js/game/systems/belt_underlays.js
@@ -29,6 +29,8 @@ const enumUnderlayTypeToClipRect = {
     [enumClippedBeltUnderlayType.full]: FULL_CLIP_RECT,
     [enumClippedBeltUnderlayType.topOnly]: new Rectangle(0, 0, 1, 0.5),
     [enumClippedBeltUnderlayType.bottomOnly]: new Rectangle(0, 0.5, 1, 0.5),
+    [enumClippedBeltUnderlayType.topCorner]: new Rectangle(0, 0, 1, 0.04),
+    [enumClippedBeltUnderlayType.bottomCorner]: new Rectangle(0, 0.96, 1, 0.04),
 };
 
 export class BeltUnderlaysSystem extends GameSystemWithFilter {
@@ -208,9 +210,13 @@ export class BeltUnderlaysSystem extends GameSystemWithFilter {
         if (connectedTop && connectedBottom) {
             flag = enumClippedBeltUnderlayType.full;
         } else if (connectedTop) {
-            flag = enumClippedBeltUnderlayType.topOnly;
+            flag = underlayTile.corner
+                ? enumClippedBeltUnderlayType.topCorner
+                : enumClippedBeltUnderlayType.topOnly;
         } else if (connectedBottom) {
-            flag = enumClippedBeltUnderlayType.bottomOnly;
+            flag = underlayTile.corner
+                ? enumClippedBeltUnderlayType.bottomCorner
+                : enumClippedBeltUnderlayType.bottomOnly;
         }
 
         return (underlayTile.cachedType = flag);

--- a/src/js/game/systems/belt_underlays.js
+++ b/src/js/game/systems/belt_underlays.js
@@ -192,32 +192,34 @@ export class BeltUnderlaysSystem extends GameSystemWithFilter {
         const worldDirectionVector = enumDirectionToVector[worldDirection];
 
         // Figure out if there is anything connected at the top
-        let connectedTop = this.checkIsAcceptorConnected(
-            transformedPos.add(worldDirectionVector),
-            enumInvertedDirections[worldDirection]
-        );
+        let connectedTop = false;
         const ejectorComp = entity.components.ItemEjector;
         if (ejectorComp) {
             const ejectorSlot = ejectorComp.findMatchingSlot(
                 underlayTile.pos,
                 enumInvertedDirections[underlayTile.direction]
             );
-            if (!ejectorSlot) connectedTop = false;
-        } else {
-            connectedTop = false;
+
+            if (ejectorSlot) {
+                connectedTop = this.checkIsAcceptorConnected(
+                    transformedPos.add(worldDirectionVector),
+                    enumInvertedDirections[worldDirection]
+                );
+            }
         }
 
         // Figure out if there is anything connected at the bottom
-        let connectedBottom = this.checkIsEjectorConnected(
-            transformedPos.sub(worldDirectionVector),
-            worldDirection
-        );
+        let connectedBottom = false;
         const acceptorComp = entity.components.ItemAcceptor;
         if (acceptorComp) {
             const acceptorSlot = acceptorComp.findMatchingSlot(underlayTile.pos, underlayTile.direction);
-            if (!acceptorSlot) connectedBottom = false;
-        } else {
-            connectedBottom = false;
+
+            if (acceptorSlot) {
+                connectedBottom = this.checkIsEjectorConnected(
+                    transformedPos.sub(worldDirectionVector),
+                    worldDirection
+                );
+            }
         }
 
         let flag = enumClippedBeltUnderlayType.none;


### PR DESCRIPTION
This PR fixes missing belts on the hub, splitter and merger. Due to the corners on the hub, splitter and merger sprites, pieces of the belt sprite seem to be missing. This PR adds those missing piece with the help of the underlay belt system.

### Changes
* BeltUnderlayTile has new property corner it is a boolean and optional
* enumClippedBeltUnderlayType has two new types, topCorner and bottomCorner
* enumUnderlayTypeToClipRect has two new rects for the topCorner and bottomCorner types
* When computing the BeltUnderlayType if corner is true on the underlayTile topCorner and bottomCorner are choosing instead of topOnly and bottomOnly
* The balancer and hub buildings have the appropriate belt underlays to fix the missing belt sprite

### Hub
**Before**
![unknown](https://cdn.discordapp.com/attachments/708586448240115723/912344242133827644/unknown.png)</p>
**After**
![unknown](https://cdn.discordapp.com/attachments/708586448240115723/912344241877954560/unknown.png)


### Merger
**Before**
![unknown](https://cdn.discordapp.com/attachments/708586448240115723/912341131432460318/unknown.png)
**After**
![unknown](https://cdn.discordapp.com/attachments/708586448240115723/912341021629767750/unknown.png)

### Splitter
**Before**
![unknown](https://cdn.discordapp.com/attachments/708586448240115723/912341961166430258/unknown.png)
**After**
![unknown](https://cdn.discordapp.com/attachments/708586448240115723/912341961489387560/unknown.png)


