### PR TITLE
Button fix when right click with placement building

### DIFF
--- a/src/js/game/hud/parts/lever_toggle.js
+++ b/src/js/game/hud/parts/lever_toggle.js
@@ -22,7 +22,9 @@ export class HUDLeverToggle extends BaseHUDPart {
                     leverComp.toggled = !leverComp.toggled;
                     return STOP_PROPAGATION;
                 } else if (button === enumMouseButton.right) {
-                    this.root.logic.tryDeleteBuilding(contents);
+                    if (!this.root.hud.parts.buildingPlacer.currentMetaBuilding) {
+                        this.root.logic.tryDeleteBuilding(contents);
+                    }
                     return STOP_PROPAGATION;
                 }
             }


### PR DESCRIPTION
When right clicking a button/lever with a placement building it also deletes the button/lever. This PR fixes it by checking if the is a placement building selected.

**Before**
![button-fix-before](https://user-images.githubusercontent.com/44841260/142889480-47ea44c7-90b6-4998-ba27-cbc740b0ffa2.gif)

**After**
![button-fix-after](https://user-images.githubusercontent.com/44841260/142889151-56be4cc5-1a53-4147-8186-6fbb20fcbab8.gif)
