### PR TITLE
Adjust beta overlay position based on demo watermark

### DIFF
--- a/src/css/ingame_hud/beta_overlay.scss
+++ b/src/css/ingame_hud/beta_overlay.scss
@@ -1,6 +1,6 @@
 #ingame_HUD_BetaOverlay {
     position: fixed;
-    @include S(top, 70px);
+    @include S(top, 10px);
     left: 50%;
     transform: translateX(-50%);
     color: $colorRedBright;
@@ -12,6 +12,10 @@
     align-items: center;
     justify-content: center;
     text-align: center;
+
+    &.demo {
+        @include S(top, 70px);
+    }
 
     h2 {
         @include PlainText;

--- a/src/js/game/hud/parts/beta_overlay.js
+++ b/src/js/game/hud/parts/beta_overlay.js
@@ -6,7 +6,7 @@ export class HUDBetaOverlay extends BaseHUDPart {
         this.element = makeDiv(
             parent,
             "ingame_HUD_BetaOverlay",
-            [],
+            this.root.app.restrictionMgr.isLimitedVersion() ? ["demo"] : [],
             "<h2>UNSTABLE BETA VERSION</h2><span>Unfinalized & potential buggy content!</span>"
         );
     }


### PR DESCRIPTION
This PR fixes large gap on top of the screen when beta/staging version is being played, but standalone marketing is not active. This is achieved using a class on HUD element which is applied when standalone marketing is active, and sets `S(top, 10px)` otherwise.

Current behavior:
<img src="https://user-images.githubusercontent.com/32245793/142904672-c18216df-9e4d-4177-a1ec-b8eeb79f02d5.png" width="300">
With this fix applied:
|Marketing active|Marketing inactive|
|:-:|:-:|
|![image](https://user-images.githubusercontent.com/32245793/142905114-9199f23f-4d9b-4858-9e7b-dda6ccbe9e04.png)|![image](https://user-images.githubusercontent.com/32245793/142905154-9ebde16c-c0ca-485e-87df-47927998e528.png)|