### PR TITLE
Remove duplicate hub acceptors

### DIFF
--- a/src/js/game/buildings/hub.js
+++ b/src/js/game/buildings/hub.js
@@ -115,22 +115,12 @@ export class MetaHubBuilding extends MetaBuilding {
                         filter: "shape",
                     },
                     {
-                        pos: new Vector(0, 3),
-                        directions: [enumDirection.left],
-                        filter: "shape",
-                    },
-                    {
                         pos: new Vector(3, 1),
                         directions: [enumDirection.right],
                         filter: "shape",
                     },
                     {
                         pos: new Vector(3, 2),
-                        directions: [enumDirection.right],
-                        filter: "shape",
-                    },
-                    {
-                        pos: new Vector(3, 3),
                         directions: [enumDirection.right],
                         filter: "shape",
                     },

--- a/src/js/game/buildings/hub.js
+++ b/src/js/game/buildings/hub.js
@@ -85,6 +85,26 @@ export class MetaHubBuilding extends MetaBuilding {
                         filter: "shape",
                     },
                     {
+                        pos: new Vector(0, 1),
+                        directions: [enumDirection.left],
+                        filter: "shape",
+                    },
+                    {
+                        pos: new Vector(3, 1),
+                        directions: [enumDirection.right],
+                        filter: "shape",
+                    },
+                    {
+                        pos: new Vector(0, 2),
+                        directions: [enumDirection.left],
+                        filter: "shape",
+                    },
+                    {
+                        pos: new Vector(3, 2),
+                        directions: [enumDirection.right],
+                        filter: "shape",
+                    },
+                    {
                         pos: new Vector(0, 3),
                         directions: [enumDirection.bottom, enumDirection.left],
                         filter: "shape",
@@ -102,26 +122,6 @@ export class MetaHubBuilding extends MetaBuilding {
                     {
                         pos: new Vector(3, 3),
                         directions: [enumDirection.bottom, enumDirection.right],
-                        filter: "shape",
-                    },
-                    {
-                        pos: new Vector(0, 1),
-                        directions: [enumDirection.left],
-                        filter: "shape",
-                    },
-                    {
-                        pos: new Vector(0, 2),
-                        directions: [enumDirection.left],
-                        filter: "shape",
-                    },
-                    {
-                        pos: new Vector(3, 1),
-                        directions: [enumDirection.right],
-                        filter: "shape",
-                    },
-                    {
-                        pos: new Vector(3, 2),
-                        directions: [enumDirection.right],
                         filter: "shape",
                     },
                 ],


### PR DESCRIPTION
The hub has duplicate acceptors (left-facing bottom and right-facing bottom). This removes them and reorders the other acceptors to make the positioning clearer.