### PR TITLE
Update JSDoc for Replacing Methods

### DIFF
--- a/src/js/mods/mod_interface.js
+++ b/src/js/mods/mod_interface.js
@@ -402,7 +402,7 @@ export class ModInterface {
     }
 
     /**
-     * Patches a method on a given class
+     * Runs before a method on a given class
      * @template {constructable} C  the class
      * @template {C["prototype"]} P  the prototype of said class
      * @template {keyof P} M  the name of the method we are overriding
@@ -421,7 +421,7 @@ export class ModInterface {
     }
 
     /**
-     * Patches a method on a given class
+     * Runs after a method on a given class
      * @template {constructable} C  the class
      * @template {C["prototype"]} P  the prototype of said class
      * @template {keyof P} M  the name of the method we are overriding

--- a/src/js/mods/mod_interface.js
+++ b/src/js/mods/mod_interface.js
@@ -26,6 +26,27 @@ import { HUDModalDialogs } from "../game/hud/parts/modal_dialogs";
 import { THEMES } from "../game/theme";
 import { ModMetaBuilding } from "./mod_meta_building";
 
+/**
+ * @typedef {{new(...args: any[]): any, prototype: any}} constructable
+ */
+
+/**
+ * @template {(...args: any[]) => any} F
+ * @template P
+ * @typedef {(...args: [P, Parameters<F>]) => ReturnType<F>} beforePrams IMPORTANT: this puts the original parameters into an array
+ */
+
+/**
+ * @template {(...args: any[]) => any} F
+ * @template P
+ * @typedef {(...args: [...Parameters<F>, P]) => ReturnType<F>} afterPrams
+ */
+
+/**
+ * @template {(...args: any[]) => any} F
+ * @typedef {(...args: [...Parameters<F>, ...any]) => ReturnType<F>} extendsPrams
+ */
+
 export class ModInterface {
     /**
      *
@@ -361,28 +382,58 @@ export class ModInterface {
     }
 
     /**
-     * Patches a method on a given object
+     * Patches a method on a given class
+     * @template {constructable} C  the class
+     * @template {C["prototype"]} P  the prototype of said class
+     * @template {keyof P} M  the name of the method we are overriding
+     * @template {extendsPrams<P[M]>} O the method that will override the old one
+     * @param {C} classHandle
+     * @param {M} methodName
+     * @param {beforePrams<O, P[M]>} override
      */
     replaceMethod(classHandle, methodName, override) {
         const oldMethod = classHandle.prototype[methodName];
         classHandle.prototype[methodName] = function () {
+            //@ts-ignore This is true I just cant tell it that arguments will be Arguments<O>
             return override.call(this, oldMethod.bind(this), arguments);
         };
     }
 
+    /**
+     * Patches a method on a given class
+     * @template {constructable} C  the class
+     * @template {C["prototype"]} P  the prototype of said class
+     * @template {keyof P} M  the name of the method we are overriding
+     * @template {extendsPrams<P[M]>} O the method that will run before the old one
+     * @param {C} classHandle
+     * @param {M} methodName
+     * @param {O} executeBefore
+     */
     runBeforeMethod(classHandle, methodName, executeBefore) {
         const oldHandle = classHandle.prototype[methodName];
         classHandle.prototype[methodName] = function () {
-            executeBefore.apply(this, arguments);
-            return oldHandle.apply(this, arguments);
+            //@ts-ignore Same as above
+            executeBefore.apply(this, ...arguments);
+            return oldHandle.apply(this, ...arguments);
         };
     }
 
+    /**
+     * Patches a method on a given class
+     * @template {constructable} C  the class
+     * @template {C["prototype"]} P  the prototype of said class
+     * @template {keyof P} M  the name of the method we are overriding
+     * @template {extendsPrams<P[M]>} O the method that will run before the old one
+     * @param {C} classHandle
+     * @param {M} methodName
+     * @param {O} executeAfter
+     */
     runAfterMethod(classHandle, methodName, executeAfter) {
         const oldHandle = classHandle.prototype[methodName];
         classHandle.prototype[methodName] = function () {
-            const returnValue = oldHandle.apply(this, arguments);
-            executeAfter.apply(this, arguments);
+            const returnValue = oldHandle.apply(this, ...arguments);
+            //@ts-ignore
+            executeAfter.apply(this, ...arguments);
             return returnValue;
         };
     }


### PR DESCRIPTION
This just gives us some autocomplete and type checking when overwriting or extending methods (so you don't have to keep looking at the original)