### PR TITLE
Prevent double registering of mods

### DIFF
--- a/src/js/mods/modloader.js
+++ b/src/js/mods/modloader.js
@@ -135,14 +135,18 @@ export class ModLoader {
         };
 
         mods.forEach(modCode => {
-            modCode += `
-                        if (typeof Mod !== 'undefined') {
-                            if (typeof METADATA !== 'object') {
-                                throw new Error("No METADATA variable found");
-                            }
-                            window.$shapez_registerMod(Mod, METADATA);
+            modCode += modCode.includes("window.$shapez_registerMod")
+                ? ""
+                : `
+                    if (typeof Mod !== 'undefined') {
+                        if (typeof METADATA !== 'object') {
+                            throw new Error("No METADATA variable found");
                         }
-                    `;
+                        window.$shapez_registerMod(Mod, METADATA);
+                    } else {
+                        throw new Error('No "Mod" class found')
+                    }
+                `;
             try {
                 const func = new Function(modCode);
                 func();


### PR DESCRIPTION
Some tools or users may choose to register mods themselves, in which case they should not try to be registered twice