### PR TITLE
Fix double painter bug

### DIFF
--- a/src/js/game/components/item_processor.js
+++ b/src/js/game/components/item_processor.js
@@ -109,6 +109,11 @@ export class ItemProcessorComponent extends Component {
          * @type {number}
          */
         this.bonusTime = 0;
+
+        /**
+         * @type {Array<EjectorItemToEject>}
+         */
+        this.queuedEjects = [];
     }
 
     /**

--- a/src/js/game/systems/item_processor.js
+++ b/src/js/game/systems/item_processor.js
@@ -94,49 +94,16 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
                     }
                 }
 
-                // Check if it finished
-                if (currentCharge.remainingTime <= 0.0) {
+                // Check if it finished and we don't already have queued ejects
+                if (currentCharge.remainingTime <= 0.0 && !processorComp.queuedEjects.length) {
                     const itemsToEject = currentCharge.items;
 
-                    // Go over all items and try to eject them
+                    // Go over all items and add them to the queue
                     for (let j = 0; j < itemsToEject.length; ++j) {
-                        const { item, requiredSlot, preferredSlot } = itemsToEject[j];
-
-                        assert(ejectorComp, "To eject items, the building needs to have an ejector");
-
-                        let slot = null;
-                        if (requiredSlot !== null && requiredSlot !== undefined) {
-                            // We have a slot override, check if that is free
-                            if (ejectorComp.canEjectOnSlot(requiredSlot)) {
-                                slot = requiredSlot;
-                            }
-                        } else if (preferredSlot !== null && preferredSlot !== undefined) {
-                            // We have a slot preference, try using it but otherwise use a free slot
-                            if (ejectorComp.canEjectOnSlot(preferredSlot)) {
-                                slot = preferredSlot;
-                            } else {
-                                slot = ejectorComp.getFirstFreeSlot();
-                            }
-                        } else {
-                            // We can eject on any slot
-                            slot = ejectorComp.getFirstFreeSlot();
-                        }
-
-                        if (slot !== null) {
-                            // Alright, we can actually eject
-                            if (!ejectorComp.tryEject(slot, item)) {
-                                assert(false, "Failed to eject");
-                            } else {
-                                itemsToEject.splice(j, 1);
-                                j -= 1;
-                            }
-                        }
+                        processorComp.queuedEjects.push(itemsToEject[j]);
                     }
 
-                    // If the charge was entirely emptied to the outputs, start the next charge
-                    if (itemsToEject.length === 0) {
-                        processorComp.ongoingCharges.shift();
-                    }
+                    processorComp.ongoingCharges.shift();
                 }
             }
 
@@ -144,6 +111,40 @@ export class ItemProcessorSystem extends GameSystemWithFilter {
             if (processorComp.ongoingCharges.length < MAX_QUEUED_CHARGES) {
                 if (this.canProcess(entity)) {
                     this.startNewCharge(entity);
+                }
+            }
+
+            for (let j = 0; j < processorComp.queuedEjects.length; ++j) {
+                const { item, requiredSlot, preferredSlot } = processorComp.queuedEjects[j];
+
+                assert(ejectorComp, "To eject items, the building needs to have an ejector");
+
+                let slot = null;
+                if (requiredSlot !== null && requiredSlot !== undefined) {
+                    // We have a slot override, check if that is free
+                    if (ejectorComp.canEjectOnSlot(requiredSlot)) {
+                        slot = requiredSlot;
+                    }
+                } else if (preferredSlot !== null && preferredSlot !== undefined) {
+                    // We have a slot preference, try using it but otherwise use a free slot
+                    if (ejectorComp.canEjectOnSlot(preferredSlot)) {
+                        slot = preferredSlot;
+                    } else {
+                        slot = ejectorComp.getFirstFreeSlot();
+                    }
+                } else {
+                    // We can eject on any slot
+                    slot = ejectorComp.getFirstFreeSlot();
+                }
+
+                if (slot !== null) {
+                    // Alright, we can actually eject
+                    if (!ejectorComp.tryEject(slot, item)) {
+                        assert(false, "Failed to eject");
+                    } else {
+                        processorComp.queuedEjects.splice(j, 1);
+                        j -= 1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This pr fixes the double painter bug, by removing reliance on items being removed to start the next charge. Instead, they are pushed to an array, and handled later in update, on the same frame.