### PR TITLE
Fix entity debugger reaching HTML elements

### DIFF
--- a/src/js/game/hud/parts/entity_debugger.js
+++ b/src/js/game/hud/parts/entity_debugger.js
@@ -94,11 +94,12 @@ export class HUDEntityDebugger extends BaseHUDPart {
                             <div>`;
 
             for (const property in val) {
-                const isRoot = val[property] == this.root;
-                const isRecursive = recursion.includes(val[property]);
-
-                let hiddenValue = isRoot ? "<root>" : null;
-                if (isRecursive) {
+                let hiddenValue = null;
+                if (val[property] == this.root) {
+                    hiddenValue = "<root>";
+                } else if (val[property] instanceof Node) {
+                    hiddenValue = `<${val[property].constructor.name}>`;
+                } else if (recursion.includes(val[property])) {
                     // Avoid recursion by not "expanding" object more than once
                     hiddenValue = "<recursion>";
                 }


### PR DESCRIPTION
Currently, when the entity debugger scans an entity's property tree, it can reach the HTML document through a path such as
```js
ItemAcceptor.itemConsumptionAnimations[0].item.cachedSprite.linksByResolution["0.25"].atlas.attributes[0].ownerDocument
```
(a color item's cached sprite is an HTML image). Besides being useless, the excessive number of properties leads to the `html` string the debugger creates growing to exceed the maximum string length, freezing and then crashing the game.

This PR fixes the issue by making the debugger not expand `instanceof Node` elements.

probably fixes #1351