### PR TITLE
fixes typo in base-es.yaml translation file

### DIFF
--- a/translations/base-es.yaml
+++ b/translations/base-es.yaml
@@ -1178,7 +1178,7 @@ tips:
       <b>T</b>
     - Tener una buena proporción entre edificion maximizará su eficiencia
     - A su máximo nivel, 5 extractores llenarán por completo una cinta
-      trasnportadora.
+      transportadora.
     - ¡No te olvides de utilizár túneles!
     - No es necesario dividir los items de manera uniforme para conseguír la
       mayor eficiencia.


### PR DESCRIPTION
Just found a typo in Spanish translations, "trasnportadora" -> "transportadora"