### PR TITLE
Modloader custom items fix

### DIFF
--- a/mod_examples/new_item_type.js
+++ b/mod_examples/new_item_type.js
@@ -120,19 +120,21 @@ class Mod extends shapez.Mod {
         this.modInterface.registerSprite("sprites/fluids/water.png", RESOURCES["water.png"]);
 
         // Make the item spawn on the map
-        this.modInterface.runAfterMethod(shapez.MapChunk, "generatePatches", function ({
-            rng,
-            chunkCenter,
-            distanceToOriginInChunks,
-        }) {
-            // Generate a simple patch
-            // ALWAYS use rng and NEVER use Math.random() otherwise the map will look different
-            // every time you resume the game
-            if (rng.next() > 0.8) {
-                const fluidType = rng.choice(Array.from(Object.keys(enumFluidType)));
-                this.internalGeneratePatch(rng, 4, FLUID_ITEM_SINGLETONS[fluidType]);
+        this.modInterface.runAfterMethod(
+            shapez.MapChunk,
+            "generatePatches",
+            function ({ rng, chunkCenter, distanceToOriginInChunks }) {
+                // Generate a simple patch
+                // ALWAYS use rng and NEVER use Math.random() otherwise the map will look different
+                // every time you resume the game
+                if (rng.next() > 0.8) {
+                    const fluidType = rng.choice(Array.from(Object.keys(enumFluidType)));
+                    this.internalGeneratePatch(rng, 4, FLUID_ITEM_SINGLETONS[fluidType]);
+                }
             }
-        });
+        );
+
+        this.modInterface.registerItem(FluidItem, itemData => FLUID_ITEM_SINGLETONS[itemData]);
     }
 }
 

--- a/src/js/game/base_item.js
+++ b/src/js/game/base_item.js
@@ -15,7 +15,7 @@ export class BaseItem extends BasicSerializableObject {
         return "base_item";
     }
 
-    /** @returns {object} */
+    /** @returns {import("../savegame/serialization").Schema} */
     static getSchema() {
         return {};
     }

--- a/src/js/game/item_resolver.js
+++ b/src/js/game/item_resolver.js
@@ -4,6 +4,8 @@ import { BooleanItem, BOOL_TRUE_SINGLETON, BOOL_FALSE_SINGLETON } from "./items/
 import { ShapeItem } from "./items/shape_item";
 import { ColorItem, COLOR_ITEM_SINGLETONS } from "./items/color_item";
 
+export const MODS_ADDITIONAL_ITEMS = {};
+
 /**
  * Resolves items so we share instances
  * @param {import("../savegame/savegame_serializer").GameRoot} root
@@ -12,6 +14,10 @@ import { ColorItem, COLOR_ITEM_SINGLETONS } from "./items/color_item";
 export function itemResolverSingleton(root, data) {
     const itemType = data.$;
     const itemData = data.data;
+
+    if (MODS_ADDITIONAL_ITEMS[itemType]) {
+        return MODS_ADDITIONAL_ITEMS[itemType](itemData);
+    }
 
     switch (itemType) {
         case BooleanItem.getId(): {

--- a/src/js/mods/mod_interface.js
+++ b/src/js/mods/mod_interface.js
@@ -17,7 +17,7 @@ import { Loader } from "../core/loader";
 import { LANGUAGES } from "../languages";
 import { matchDataRecursive, T } from "../translations";
 import { gBuildingVariants, registerBuildingVariant } from "../game/building_codes";
-import { gComponentRegistry, gMetaBuildingRegistry } from "../core/global_registries";
+import { gComponentRegistry, gItemRegistry, gMetaBuildingRegistry } from "../core/global_registries";
 import { MODS_ADDITIONAL_SHAPE_MAP_WEIGHTS } from "../game/map_chunk";
 import { MODS_ADDITIONAL_SYSTEMS } from "../game/game_system_manager";
 import { MOD_CHUNK_DRAW_HOOKS } from "../game/map_chunk_view";
@@ -28,6 +28,8 @@ import { ModMetaBuilding } from "./mod_meta_building";
 import { BaseHUDPart } from "../game/hud/base_hud_part";
 import { Vector } from "../core/vector";
 import { GameRoot } from "../game/root";
+import { BaseItem } from "../game/base_item";
+import { MODS_ADDITIONAL_ITEMS } from "../game/item_resolver";
 
 /**
  * @typedef {{new(...args: any[]): any, prototype: any}} constructable
@@ -188,6 +190,15 @@ export class ModInterface {
         if (language === "en") {
             matchDataRecursive(T, translations, true);
         }
+    }
+
+    /**
+     * @param {typeof BaseItem} item
+     * @param {(itemData: any) => BaseItem} resolver
+     */
+    registerItem(item, resolver) {
+        gItemRegistry.register(item);
+        MODS_ADDITIONAL_ITEMS[item.getId()] = resolver;
     }
 
     /**

--- a/src/js/savegame/serialization.js
+++ b/src/js/savegame/serialization.js
@@ -192,7 +192,7 @@ export class BasicSerializableObject {
         return schema;
     }
 
-    /** @returns {object} */
+    /** @returns {object | string | number} */
     serialize() {
         return serializeSchema(
             this,


### PR DESCRIPTION
When loading a world with custom items there is no resolver for this item. This will cause the savegame to be corrupted. This PR adds a `registerItem` to the mod interface to easily add the item to the item registery and add a resolver for savegames.