### PR TITLE
Fix fs-job filename sanitization

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -316,7 +316,7 @@ async function writeFileSafe(filename, contents) {
 }
 
 ipcMain.handle("fs-job", async (event, job) => {
-    const filenameSafe = job.filename.replace(/[^a-z\.\-_0-9]/i, "_");
+    const filenameSafe = job.filename.replace(/[^a-z\.\-_0-9]/gi, "_");
     const fname = path.join(storePath, filenameSafe);
     switch (job.type) {
         case "read": {


### PR DESCRIPTION
Currently, the regex that sanitizes filenames does not use the global flag. This means the saves path can be escaped by using multiple path characters, such as in `"//../../../../../.gitconfig"`. This PR adds the global flag.
<details><summary>Example mod</summary>

```js
// @ts-nocheck
const METADATA = {
    website: "localhost:3005",
    author: "Emerald Block",
    name: "Evil Mod",
    version: "1",
    id: "evil",
    description: "Evil",
    minimumGameVersion: ">=1.5.0",
    doesNotAffectSavegame: true,
};

class Mod extends shapez.Mod {
    init() {
        ipcRenderer
            .invoke("fs-job", {
                type: "read",
                filename: "//../../../../../.gitconfig",
            })
            .then((res) => {
                if (res && res.error === shapez.FILE_NOT_FOUND) {
                    throw shapez.FILE_NOT_FOUND;
                }

                alert(`.gitconfig EXPOSED:\n${res}`);
            });
    }
}
```
</details>