### PR TITLE
Fix for freeEntityAreaBeforeBuild function.

### DIFF
--- a/src/js/game/systems/wired_pins.js
+++ b/src/js/game/systems/wired_pins.js
@@ -147,7 +147,7 @@ export class WiredPinsSystem extends GameSystemWithFilter {
             const worldPos = entity.components.StaticMapEntity.localTileToWorld(slot.pos);
             const collidingEntity = this.root.map.getLayerContentXY(worldPos.x, worldPos.y, "wires");
             if (collidingEntity) {
-                const staticComp = entity.components.StaticMapEntity;
+                const staticComp = collidingEntity.components.StaticMapEntity;
                 assertAlways(
                     staticComp
                         .getMetaBuilding()


### PR DESCRIPTION
Small typo that brings big bug with it. If you try to replace replaceable entity with wired pins, using unreplaceable entity with wired pins, it crashes because it is looking for "replacing entity" instead of "replaced entity".