### PR TITLE
Fix slight error in FPS calculation

### DIFF
--- a/src/js/game/dynamic_tickrate.js
+++ b/src/js/game/dynamic_tickrate.js
@@ -42,7 +42,7 @@ export class DynamicTickrate {
         const now = performance.now();
         const timeDuration = now - this.accumulatedFpsLastUpdate;
         if (timeDuration > fpsAccumulationTime) {
-            const avgFps = (this.accumulatedFps / fpsAccumulationTime) * 1000;
+            const avgFps = (this.accumulatedFps / timeDuration) * 1000;
             this.averageFps = avgFps;
             this.accumulatedFps = 0;
             this.accumulatedFpsLastUpdate = now;


### PR DESCRIPTION
Currently, FPS is calculated as the number of frames (`this.accumulatedFps`) divided by the constant `fpsAccumulationTime`. However, `fpsAccumulationTime` is only the minimum time needed to pass, and `timeDuration` represents the actual amount of time that passed.

This PR changes the FPS division to use `timeDuration` instead of `fpsAccumulationTime`.