### PR TITLE
Fix edit dialog not showing when placing a constant producer in the puzzle editor

### DIFF
--- a/src/js/game/modes/puzzle_edit.js
+++ b/src/js/game/modes/puzzle_edit.js
@@ -22,6 +22,7 @@ import { MetaTransistorBuilding } from "../buildings/transistor";
 import { HUDPuzzleEditorControls } from "../hud/parts/puzzle_editor_controls";
 import { HUDPuzzleEditorReview } from "../hud/parts/puzzle_editor_review";
 import { HUDPuzzleEditorSettings } from "../hud/parts/puzzle_editor_settings";
+import { HUDConstantSignalEdit } from "../hud/parts/constant_signal_edit";
 
 export class PuzzleEditGameMode extends PuzzleGameMode {
     static getId() {
@@ -58,6 +59,7 @@ export class PuzzleEditGameMode extends PuzzleGameMode {
         this.additionalHudParts.puzzleEditorControls = HUDPuzzleEditorControls;
         this.additionalHudParts.puzzleEditorReview = HUDPuzzleEditorReview;
         this.additionalHudParts.puzzleEditorSettings = HUDPuzzleEditorSettings;
+        this.additionalHudParts.constantSignalEdit = HUDConstantSignalEdit;
     }
 
     getIsEditor() {


### PR DESCRIPTION
During the mod update, the constant signal code was refactored, moving the dialog to choose a signal from `ConstantSignalSystem` to `HUDConstantSignalEdit`. However, the latter is an additional HUD part only added in the regular game mode, meaning the dialog is no longer part of the puzzles editor.

This PR fixes that by adding `HUDConstantSignalEdit` as an additional HUD part in the puzzle editor game mode.