### PR TITLE
Simplify colors.js

### DIFF
--- a/src/js/game/colors.js
+++ b/src/js/game/colors.js
@@ -11,19 +11,20 @@ export const enumColors = {
     white: "white",
     uncolored: "uncolored",
 };
+const c = enumColors;
 
 /** @enum {string} */
 export const enumColorToShortcode = {
-    [enumColors.red]: "r",
-    [enumColors.green]: "g",
-    [enumColors.blue]: "b",
+    [c.red]: "r",
+    [c.green]: "g",
+    [c.blue]: "b",
 
-    [enumColors.yellow]: "y",
-    [enumColors.purple]: "p",
-    [enumColors.cyan]: "c",
+    [c.yellow]: "y",
+    [c.purple]: "p",
+    [c.cyan]: "c",
 
-    [enumColors.white]: "w",
-    [enumColors.uncolored]: "u",
+    [c.white]: "w",
+    [c.uncolored]: "u",
 };
 
 /** @enum {enumColors} */
@@ -34,131 +35,41 @@ for (const key in enumColorToShortcode) {
 
 /** @enum {string} */
 export const enumColorsToHexCode = {
-    [enumColors.red]: "#ff666a",
-    [enumColors.green]: "#78ff66",
-    [enumColors.blue]: "#66a7ff",
+    [c.red]: "#ff666a",
+    [c.green]: "#78ff66",
+    [c.blue]: "#66a7ff",
 
     // red + green
-    [enumColors.yellow]: "#fcf52a",
+    [c.yellow]: "#fcf52a",
 
     // red + blue
-    [enumColors.purple]: "#dd66ff",
+    [c.purple]: "#dd66ff",
 
     // blue + green
-    [enumColors.cyan]: "#00fcff",
+    [c.cyan]: "#00fcff",
 
     // blue + green + red
-    [enumColors.white]: "#ffffff",
+    [c.white]: "#ffffff",
 
-    [enumColors.uncolored]: "#aaaaaa",
+    [c.uncolored]: "#aaaaaa",
 };
 
-const c = enumColors;
 /** @enum {Object.<string, string>} */
-export const enumColorMixingResults = {
-    // 255, 0, 0
-    [c.red]: {
-        [c.green]: c.yellow,
-        [c.blue]: c.purple,
+export const enumColorMixingResults = {};
 
-        [c.yellow]: c.yellow,
-        [c.purple]: c.purple,
-        [c.cyan]: c.white,
-
-        [c.white]: c.white,
-    },
-
-    // 0, 255, 0
-    [c.green]: {
-        [c.blue]: c.cyan,
-
-        [c.yellow]: c.yellow,
-        [c.purple]: c.white,
-        [c.cyan]: c.cyan,
-
-        [c.white]: c.white,
-    },
-
-    // 0, 255, 0
-    [c.blue]: {
-        [c.yellow]: c.white,
-        [c.purple]: c.purple,
-        [c.cyan]: c.cyan,
-
-        [c.white]: c.white,
-    },
-
-    // 255, 255, 0
-    [c.yellow]: {
-        [c.purple]: c.white,
-        [c.cyan]: c.white,
-    },
-
-    // 255, 0, 255
-    [c.purple]: {
-        [c.cyan]: c.white,
-    },
-
-    // 0, 255, 255
-    [c.cyan]: {},
-
-    //// SPECIAL COLORS
-
-    // 255, 255, 255
-    [c.white]: {
-        // auto
-    },
-
-    // X, X, X
-    [c.uncolored]: {
-        // auto
-    },
-};
-
-// Create same color lookups
-for (const color in enumColors) {
-    enumColorMixingResults[color][color] = color;
-    enumColorMixingResults[color][c.white] = c.white;
-    // Anything with uncolored is the same color
-    enumColorMixingResults[color][c.uncolored] = color;
-}
-
-// Create reverse lookup and check color mixing lookups
-for (const colorA in enumColorMixingResults) {
-    for (const colorB in enumColorMixingResults[colorA]) {
-        const resultColor = enumColorMixingResults[colorA][colorB];
-        if (!enumColorMixingResults[colorB]) {
-            enumColorMixingResults[colorB] = {
-                [colorA]: resultColor,
-            };
-        } else {
-            const existingResult = enumColorMixingResults[colorB][colorA];
-            if (existingResult && existingResult !== resultColor) {
-                assertAlways(
-                    false,
-                    "invalid color mixing configuration, " +
-                        colorA +
-                        " + " +
-                        colorB +
-                        " is " +
-                        resultColor +
-                        " but " +
-                        colorB +
-                        " + " +
-                        colorA +
-                        " is " +
-                        existingResult
-                );
-            }
-            enumColorMixingResults[colorB][colorA] = resultColor;
-        }
-    }
-}
-
-for (const colorA in enumColorMixingResults) {
-    for (const colorB in enumColorMixingResults) {
-        if (!enumColorMixingResults[colorA][colorB]) {
-            assertAlways(false, "Color mixing of", colorA, "with", colorB, "is not defined");
-        }
+const bitfieldToColor = [
+    /* 000 */ c.uncolored,
+    /* 001 */ c.red,
+    /* 010 */ c.green,
+    /* 011 */ c.yellow,
+    /* 100 */ c.blue,
+    /* 101 */ c.purple,
+    /* 110 */ c.cyan,
+    /* 111 */ c.white,
+];
+for (let i = 0; i < 1 << 3; ++i) {
+    enumColorMixingResults[bitfieldToColor[i]] = {};
+    for (let j = 0; j < 1 << 3; ++j) {
+        enumColorMixingResults[bitfieldToColor[i]][bitfieldToColor[j]] = bitfieldToColor[i | j];
     }
 }


### PR DESCRIPTION
This PR simplifies computing `enumColorMixingResults` by using bitwise OR. It also defines `c = enumColors` earlier on to shorten usage more.