### PR TITLE
Fix weird speed rounding

### DIFF
--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -334,7 +334,7 @@ export function waitNextFrame() {
  * @returns {number}
  */
 export function round1Digit(n) {
-    return Math.floor(n * 10.0) / 10.0;
+    return Math.round(n * 10.0) / 10.0;
 }
 
 /**
@@ -343,7 +343,7 @@ export function round1Digit(n) {
  * @returns {number}
  */
 export function round2Digits(n) {
-    return Math.floor(n * 100.0) / 100.0;
+    return Math.round(n * 100.0) / 100.0;
 }
 
 /**
@@ -352,7 +352,7 @@ export function round2Digits(n) {
  * @returns {number}
  */
 export function round3Digits(n) {
-    return Math.floor(n * 1000.0) / 1000.0;
+    return Math.round(n * 1000.0) / 1000.0;
 }
 
 /**
@@ -361,7 +361,7 @@ export function round3Digits(n) {
  * @returns {number}
  */
 export function round4Digits(n) {
-    return Math.floor(n * 10000.0) / 10000.0;
+    return Math.round(n * 10000.0) / 10000.0;
 }
 
 /**

--- a/src/js/core/utils.js
+++ b/src/js/core/utils.js
@@ -543,6 +543,15 @@ export function formatSeconds(secs) {
 }
 
 /**
+ * Formats a number like 2.51 to "2.51"
+ * @param {number} speed
+ * @param {string=} separator The decimal separator for numbers like 50.1 (separator='.')
+ */
+export function formatNumber(speed, separator = T.global.decimalSeparator) {
+    return speed.toString().replace(".", separator);
+}
+
+/**
  * Formats a number like 2.51 to "2.5"
  * @param {number} speed
  * @param {string=} separator The decimal separator for numbers like 50.1 (separator='.')
@@ -563,7 +572,7 @@ export function formatItemsPerSecond(speed, double = false, separator = T.global
             ? T.ingame.buildingPlacement.infoTexts.oneItemPerSecond
             : T.ingame.buildingPlacement.infoTexts.itemsPerSecond.replace(
                   "<x>",
-                  round2Digits(speed).toString().replace(".", separator)
+                  speed.toString().replace(".", separator)
               )) + (double ? "  " + T.ingame.buildingPlacement.infoTexts.itemsPerSecondDouble : "")
     );
 }

--- a/src/js/game/hub_goals.js
+++ b/src/js/game/hub_goals.js
@@ -55,11 +55,12 @@ export class HubGoals extends BasicSerializableObject {
         for (const upgradeId in upgrades) {
             const tiers = upgrades[upgradeId];
             const level = this.upgradeLevels[upgradeId] || 0;
-            let totalImprovement = 1;
+            let totalImprovement = 10;
             for (let i = 0; i < level; ++i) {
                 totalImprovement += tiers[i].improvement;
             }
-            this.upgradeImprovements[upgradeId] = totalImprovement;
+            this.upgradeImprovements[upgradeId] =
+                (this.upgradeImprovementsExact[upgradeId] = totalImprovement) / 10;
         }
 
         // Compute current goal
@@ -100,11 +101,18 @@ export class HubGoals extends BasicSerializableObject {
          */
         this.upgradeImprovements = {};
 
+        /**
+         * Stores 10x the improvements for all upgrades, to be exact
+         * @type {Object<string, number>}
+         */
+        this.upgradeImprovementsExact = {};
+
         // Reset levels first
         const upgrades = this.root.gameMode.getUpgrades();
         for (const key in upgrades) {
             this.upgradeLevels[key] = 0;
             this.upgradeImprovements[key] = 1;
+            this.upgradeImprovementsExact[key] = 10;
         }
 
         this.computeNextGoal();
@@ -347,7 +355,8 @@ export class HubGoals extends BasicSerializableObject {
         }
 
         this.upgradeLevels[upgradeId] = (this.upgradeLevels[upgradeId] || 0) + 1;
-        this.upgradeImprovements[upgradeId] += tierData.improvement;
+        this.upgradeImprovements[upgradeId] =
+            (this.upgradeImprovementsExact[upgradeId] += tierData.improvement) / 10;
 
         this.root.signals.upgradePurchased.dispatch(upgradeId);
 

--- a/src/js/game/hud/parts/miner_highlight.js
+++ b/src/js/game/hud/parts/miner_highlight.js
@@ -1,5 +1,5 @@
 import { globalConfig } from "../../../core/config";
-import { formatItemsPerSecond, round2Digits } from "../../../core/utils";
+import { formatItemsPerSecond, round4Digits } from "../../../core/utils";
 import { Vector } from "../../../core/vector";
 import { T } from "../../../translations";
 import { Entity } from "../../entity";
@@ -69,7 +69,7 @@ export class HUDMinerHighlight extends BaseHUDPart {
             parameters.context.fill();
         }
 
-        const throughput = round2Digits(connectedEntities.length * this.root.hubGoals.getMinerBaseSpeed());
+        const throughput = round4Digits(connectedEntities.length * this.root.hubGoals.getMinerBaseSpeed());
 
         const maxThroughput = this.root.hubGoals.getBeltBaseSpeed();
 
@@ -84,7 +84,7 @@ export class HUDMinerHighlight extends BaseHUDPart {
         parameters.context.beginRoundedRect(
             tooltipLocation.x + 5 * scale,
             tooltipLocation.y - 3 * scale,
-            (isCapped ? 100 : 65) * scale,
+            (isCapped ? 100 : 75) * scale,
             (isCapped ? 45 : 30) * scale,
             2
         );

--- a/src/js/game/hud/parts/sandbox_controller.js
+++ b/src/js/game/hud/parts/sandbox_controller.js
@@ -98,11 +98,12 @@ export class HUDSandboxController extends BaseHUDPart {
         );
 
         // Compute improvement
-        let improvement = 1;
+        let improvement = 10;
         for (let i = 0; i < this.root.hubGoals.upgradeLevels[id]; ++i) {
             improvement += upgradeTiers[i].improvement;
         }
-        this.root.hubGoals.upgradeImprovements[id] = improvement;
+        this.root.hubGoals.upgradeImprovements[id] =
+            (this.root.hubGoals.upgradeImprovementsExact[id] = improvement) / 10;
         this.root.signals.upgradePurchased.dispatch(id);
         this.root.hud.signals.notification.dispatch(
             "Upgrade '" + id + "' is now at tier " + (this.root.hubGoals.upgradeLevels[id] + 1),

--- a/src/js/game/hud/parts/shop.js
+++ b/src/js/game/hud/parts/shop.js
@@ -1,6 +1,6 @@
 import { ClickDetector } from "../../../core/click_detector";
 import { InputReceiver } from "../../../core/input_receiver";
-import { formatBigNumber, getRomanNumber, makeDiv } from "../../../core/utils";
+import { formatBigNumber, formatNumber, getRomanNumber, makeDiv } from "../../../core/utils";
 import { T } from "../../../translations";
 import { KeyActionMapper, KEYMAPPINGS } from "../../key_action_mapper";
 import { BaseHUDPart } from "../base_hud_part";
@@ -91,15 +91,15 @@ export class HUDShop extends BaseHUDPart {
                 // Max level
                 handle.elemDescription.innerText = T.ingame.shop.maximumLevel.replace(
                     "<currentMult>",
-                    formatBigNumber(currentTierMultiplier)
+                    formatNumber(currentTierMultiplier)
                 );
                 continue;
             }
 
             // Set description
             handle.elemDescription.innerText = T.shopUpgrades[upgradeId].description
-                .replace("<currentMult>", formatBigNumber(currentTierMultiplier))
-                .replace("<newMult>", formatBigNumber(currentTierMultiplier + tierHandle.improvement / 10));
+                .replace("<currentMult>", formatNumber(currentTierMultiplier))
+                .replace("<newMult>", formatNumber(currentTierMultiplier + tierHandle.improvement / 10));
 
             tierHandle.required.forEach(({ shape, amount }) => {
                 const container = makeDiv(handle.elemRequirements, null, ["requirement"]);

--- a/src/js/game/hud/parts/shop.js
+++ b/src/js/game/hud/parts/shop.js
@@ -99,7 +99,7 @@ export class HUDShop extends BaseHUDPart {
             // Set description
             handle.elemDescription.innerText = T.shopUpgrades[upgradeId].description
                 .replace("<currentMult>", formatBigNumber(currentTierMultiplier))
-                .replace("<newMult>", formatBigNumber(currentTierMultiplier + tierHandle.improvement));
+                .replace("<newMult>", formatBigNumber(currentTierMultiplier + tierHandle.improvement / 10));
 
             tierHandle.required.forEach(({ shape, amount }) => {
                 const container = makeDiv(handle.elemRequirements, null, ["requirement"]);

--- a/src/js/game/modes/regular.js
+++ b/src/js/game/modes/regular.js
@@ -79,7 +79,8 @@ function generateUpgrades(limitedVersion = false) {
         return upgradesCache[limitedVersion];
     }
 
-    const fixedImprovements = [0.5, 0.5, 1, 1, 2, 1, 1];
+    // 10x actual amount so all numbers are exact
+    const fixedImprovements = [5, 5, 10, 10, 20, 10, 10];
     const numEndgameUpgrades = limitedVersion ? 0 : 1000 - fixedImprovements.length - 1;
 
     function generateInfiniteUnlocks() {
@@ -96,13 +97,13 @@ function generateUpgrades(limitedVersion = false) {
     // Fill in endgame upgrades
     for (let i = 0; i < numEndgameUpgrades; ++i) {
         if (i < 20) {
-            fixedImprovements.push(0.1);
+            fixedImprovements.push(1);
         } else if (i < 50) {
-            fixedImprovements.push(0.05);
+            fixedImprovements.push(0.5);
         } else if (i < 100) {
-            fixedImprovements.push(0.025);
+            fixedImprovements.push(0.25);
         } else {
-            fixedImprovements.push(0.0125);
+            fixedImprovements.push(0.125);
         }
     }
 


### PR DESCRIPTION
Building speeds and multipliers are imprecise, since they are calculated with imprecise numbers. They are rounded, but since they are actually floored, the imprecision remains. Additionally, with the shrinking sizes of upgrade improvements, the displayed upgrade improvements become seemingly nothing. The effects can be seen in building infoboxes, miner tooltips, and upgrade shop multipliers.

This PR fixes the imprecision in upgrades by internally storing 10 times the actual multiplier, since this can be represented exactly. Since every building accesses `upgradeImprovements` directly (making it inconvenient to update each to handle the 10x factor), an internal `upgradeImprovementsExact` (with 10x values) is added, which handles adding improvements, and `upgradeImprovements` is calculated based directly on the resulting 10x values.

Since speeds and upgrade multipliers are now basically exact, they are also shown precisely. This also means a visible difference can be seen between upgrades with only a tiny improvement between them. (Note the miner tooltip had to be lengthened to accommodate the longer decimals, making it look a bit weird for earlier numbers.)

All the `roundXDigits` utility functions are switched to use rounding instead of flooring. Although they are now only used in one place for speeds (scaling up the miner speed produces an imprecise number), the way they are used seems to make rounding a better fit, to correct imprecision, and it may prevent future confusion on the naming.