### PR TITLE
Update CI to use Node.js 16.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v2-beta
               with:
-                  node-version: 10.x
+                  node-version: 16.x
 
             - name: Checkout repo
               uses: actions/checkout@v2


### PR DESCRIPTION
Right now, CI for linting does not run, as Yarn fails to install dependencies (at least Node.js 12.x is required). In order to fix this, the PR bumps Node.js version to 16.x.