### PR TITLE
Fix windmill sub‑shape check in shape generation

### DIFF
--- a/src/js/game/map_chunk.js
+++ b/src/js/game/map_chunk.js
@@ -233,7 +233,8 @@ export class MapChunk {
                 ++windmillCount;
             }
         }
-        if (windmillCount > 1) {
+
+        if (windmillCount > 2) {
             subShapes[0] = enumSubShape.rect;
             subShapes[1] = enumSubShape.rect;
         }


### PR DESCRIPTION
* Fixes <https://github.com/tobspr/shapez.io/issues/1444>

--------------------------------------------------------------------------------

This makes it possible for [<code><img height="24" align="top" src="https://user-images.githubusercontent.com/3889017/174471636-c4869f34-9444-4734-8f8e-16a8fbe259f6.png"/> WuRuWuRu</code>][WuRuWuRu] and other such shapes to spawn naturally.

[WuRuWuRu]: https://viewer.shapez.io/?WuRuWuRu

--------------------------------------------------------------------------------

Supersedes <https://github.com/tobspr/shapez.io/pull/936> in a manner that avoids calling `rng.nextInt()`