### PR TITLE
Allow choosing (dynamic) system theme

### DIFF
--- a/electron/index.js
+++ b/electron/index.js
@@ -1,6 +1,16 @@
 /* eslint-disable quotes,no-undef */
 
-const { app, BrowserWindow, Menu, MenuItem, ipcMain, shell, dialog, session } = require("electron");
+const {
+    app,
+    BrowserWindow,
+    Menu,
+    MenuItem,
+    ipcMain,
+    shell,
+    dialog,
+    session,
+    nativeTheme,
+} = require("electron");
 const path = require("path");
 const url = require("url");
 const fs = require("fs");
@@ -96,6 +106,10 @@ function createWindow() {
     }
     win.webContents.session.clearCache();
     win.webContents.session.clearStorageData();
+
+    nativeTheme.on("updated", () => {
+        win.webContents.send("system-theme-updated");
+    });
 
     ////// SECURITY
 
@@ -379,6 +393,10 @@ try {
 
 ipcMain.handle("get-mods", async () => {
     return mods;
+});
+
+ipcMain.handle("get-system-theme", async () => {
+    return nativeTheme.shouldUseDarkColors ? "dark" : "light";
 });
 
 steam.init(isDev);

--- a/src/js/game/theme.js
+++ b/src/js/game/theme.js
@@ -6,10 +6,16 @@ export const THEMES = {
 export let THEME = THEMES.light;
 let currentThemePreference = "light";
 
-THEMES.system = THEMES.light;
-ipcRenderer.on("system-theme-updated", detectSystemTheme);
+if (G_IS_STANDALONE) {
+    THEMES.system = THEMES.light;
+    ipcRenderer.on("system-theme-updated", detectSystemTheme);
+}
 
 export function detectSystemTheme() {
+    if (!G_IS_STANDALONE) {
+        return;
+    }
+
     return ipcRenderer
         .invoke("get-system-theme")
         .then(theme => (THEMES.system = THEMES[theme]))

--- a/src/js/game/theme.js
+++ b/src/js/game/theme.js
@@ -4,7 +4,42 @@ export const THEMES = {
 };
 
 export let THEME = THEMES.light;
+let currentThemePreference = "light";
+
+THEMES.system = THEMES.light;
+ipcRenderer.on("system-theme-updated", detectSystemTheme);
+
+export function detectSystemTheme() {
+    return ipcRenderer
+        .invoke("get-system-theme")
+        .then(theme => (THEMES.system = THEMES[theme]))
+        .catch(() => (THEMES.system = THEMES.light))
+        .then(() => {
+            // Re-apply the theme, this only affects system
+            applyGameTheme();
+        });
+}
 
 export function applyGameTheme(id) {
-    THEME = THEMES[id];
+    if (id === undefined) {
+        id = currentThemePreference;
+    }
+
+    const isSystem = id === "system";
+    const themeId = isSystem ? THEMES.system.id : id;
+
+    if (!isSystem && id === undefined) {
+        // Re-applying light/dark themes is not needed
+        return;
+    }
+
+    if (document.body.id != "state_InGameState") {
+        // Only set the theme if not playing, otherwise this causes bugs
+        // Main menu re-applies the theme anyway
+        THEME = THEMES[themeId];
+        document.documentElement.setAttribute("data-theme", themeId);
+    }
+
+    // Keep the theme to re-apply system theme
+    currentThemePreference = id;
 }

--- a/src/js/game/themes/dark.json
+++ b/src/js/game/themes/dark.json
@@ -1,4 +1,6 @@
 {
+    "id": "dark",
+
     "map": {
         "background": "#3e3f47",
         "gridRegular": "rgba(255, 255, 255, 0.02)",

--- a/src/js/game/themes/light.json
+++ b/src/js/game/themes/light.json
@@ -1,4 +1,6 @@
 {
+    "id": "light",
+
     "map": {
         "background": "#eceef2",
 

--- a/src/js/mods/mod_interface.js
+++ b/src/js/mods/mod_interface.js
@@ -399,6 +399,8 @@ export class ModInterface {
      */
     registerGameTheme({ id, name, theme }) {
         THEMES[id] = theme;
+        theme.id = id;
+
         this.registerTranslations("en", {
             settings: {
                 labels: {

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -6,7 +6,7 @@ import { ReadWriteProxy } from "../core/read_write_proxy";
 import { BoolSetting, EnumSetting, RangeSetting, BaseSetting } from "./setting_types";
 import { createLogger } from "../core/logging";
 import { ExplainedResult } from "../core/explained_result";
-import { THEMES, applyGameTheme } from "../game/theme";
+import { THEMES, applyGameTheme, detectSystemTheme } from "../game/theme";
 import { T } from "../translations";
 import { LANGUAGES } from "../languages";
 
@@ -209,14 +209,7 @@ function initializeSettings() {
             textGetter: theme => T.settings.labels.theme.themes[theme],
             category: enumCategories.userInterface,
             restartRequired: false,
-            changeCb:
-                /**
-                 * @param {Application} app
-                 */
-                (app, id) => {
-                    applyGameTheme(id);
-                    document.documentElement.setAttribute("data-theme", id);
-                },
+            changeCb: (app, id) => applyGameTheme(id),
             enabledCb: /**
              * @param {Application} app
              */ app => app.restrictionMgr.getHasExtendedSettings(),
@@ -298,7 +291,7 @@ class SettingsStorage {
         this.soundVolume = 1.0;
         this.musicVolume = 1.0;
 
-        this.theme = "light";
+        this.theme = "system";
         this.refreshRate = "60";
         this.scrollWheelSensitivity = "regular";
         this.movementSpeed = "regular";
@@ -344,6 +337,10 @@ export class ApplicationSettings extends ReadWriteProxy {
     initialize() {
         // Read and directly write latest data back
         return this.readAsync()
+            .then(() => {
+                // Make sure it's ready
+                return detectSystemTheme();
+            })
             .then(() => {
                 // Apply default setting callbacks
                 const settings = this.getAllSettings();

--- a/src/js/profile/application_settings.js
+++ b/src/js/profile/application_settings.js
@@ -291,7 +291,7 @@ class SettingsStorage {
         this.soundVolume = 1.0;
         this.musicVolume = 1.0;
 
-        this.theme = "system";
+        this.theme = G_IS_STANDALONE ? "system" : "light";
         this.refreshRate = "60";
         this.scrollWheelSensitivity = "regular";
         this.movementSpeed = "regular";

--- a/src/js/states/main_menu.js
+++ b/src/js/states/main_menu.js
@@ -16,6 +16,7 @@ import {
     waitNextFrame,
 } from "../core/utils";
 import { HUDModalDialogs } from "../game/hud/parts/modal_dialogs";
+import { detectSystemTheme } from "../game/theme";
 import { MODS } from "../mods/modloader";
 import { PlatformWrapperImplBrowser } from "../platform/browser/wrapper";
 import { PlatformWrapperImplElectron } from "../platform/electron/wrapper";
@@ -347,6 +348,9 @@ export class MainMenuState extends GameState {
                 T.dialogs.gameLoadFailure.text + "<br><br>" + payload.loadError
             );
         }
+
+        // Apply the system theme if returning from InGameState
+        detectSystemTheme();
 
         if (G_IS_DEV && globalConfig.debug.testPuzzleMode) {
             this.onPuzzleModeButtonClicked(true);

--- a/src/js/states/preload.js
+++ b/src/js/states/preload.js
@@ -6,6 +6,7 @@ import { createLogger } from "../core/logging";
 import { getLogoSprite } from "../core/utils";
 import { getRandomHint } from "../game/hints";
 import { HUDModalDialogs } from "../game/hud/parts/modal_dialogs";
+import { detectSystemTheme } from "../game/theme";
 import { PlatformWrapperImplBrowser } from "../platform/browser/wrapper";
 import { autoDetectLanguageId, T, updateApplicationLanguage } from "../translations";
 
@@ -108,6 +109,7 @@ export class PreloadState extends GameState {
             .then(() => this.fetchDiscounts())
 
             .then(() => this.setStatus("Initializing settings", 20))
+            .then(() => detectSystemTheme())
             .then(() => {
                 return this.app.settings.initialize();
             })

--- a/translations/base-en.yaml
+++ b/translations/base-en.yaml
@@ -1267,6 +1267,7 @@ settings:
             themes:
                 dark: Dark
                 light: Light
+                system: System
 
         refreshRate:
             title: Tick Rate


### PR DESCRIPTION
This PR implements system theme preference and makes it the default theme preference. This theme gets re-applied whenever the system setting changes, unless the user is in the `InGameState` - in that case applying is deferred until Main Menu is open. As much backwards compatibility as possible is kept - theme API is the same. **Note:** This was only throughly tested on the dev standalone. Promise `.catch` is there for Wegame and other cases where IPC handler could be missing or erroring.

## Changes

* "System" is now available in theme selection. `"system"` is the default theme for new settings storage instances.
* Theme JSONs now have `id` property, used to detect system theme id.  Mod Interface automatically sets the ID to ensure compatibility.
* `applyGameTheme` can be used without theme id, this re-applies system theme or does nothing if the preference is not the system theme.
* HTML `data-theme` property is now set in `applyGameTheme` instead of application settings handler.
* `G_IS_STANDALONE` is checked before attempting to use IPC or set the system theme, `web-localhost` seems to run fine.

## Dirty code

* It would be nice to redraw the in-game stuff when the theme changes, but it'd likely require some refactoring to make themes part of the app object.
* Two-way IPC is used to make sure that the theme gets correctly applied, but it could be simplified.