### PR TITLE
Always run the “TypeScript” step regardless of “ESLint” outcome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,12 @@ jobs:
                   yarn
                   cd ..
             - name: Lint
+              id: eslint
               run: |
                   yarn lint
-            - name: TSLint
+            - name: TypeScript
+              id: typescript
+              if: ${{ success() || steps.eslint.outcome == 'failure' }}
               run: |
                   cd gulp
                   yarn gulp translations.fullBuild


### PR DESCRIPTION
This makes it so that the **TypeScript** step is always ran, even when there are **ESLint** errors.

## See also
- <https://github.com/tobspr/shapez.io/pull/1452>

--------------------------------------------------------------------------------

review?(@tobspr)