### PR TITLE
Split mod loading procedure into 2 steps

### DIFF
--- a/electron_gog/index.js
+++ b/electron_gog/index.js
@@ -346,17 +346,24 @@ ipcMain.handle("open-mods-folder", async () => {
 
 console.log("Loading mods ...");
 
-function loadMods() {
+/**
+ * Scans the mods directory (unless in safe mode) and --load-mod argument.
+ * @returns {string[]} Array of absolute paths of mod files
+ */
+function scanMods() {
     if (safeMode) {
         console.log("Safe Mode enabled for mods, skipping mod search");
+    } else {
+        console.log("Scanning mods from", modsPath);
     }
-    console.log("Loading mods from", modsPath);
-    let modFiles = safeMode
-        ? []
-        : fs
-              .readdirSync(modsPath)
-              .filter(filename => filename.endsWith(".js"))
-              .map(filename => path.join(modsPath, filename));
+
+    let modFiles = [];
+    if (!safeMode) {
+        modFiles = fs
+            .readdirSync(modsPath)
+            .filter(filename => filename.endsWith(".js"))
+            .map(filename => path.join(modsPath, filename));
+    }
 
     if (externalMod) {
         console.log("Adding external mod source:", externalMod);
@@ -364,18 +371,37 @@ function loadMods() {
         modFiles = modFiles.concat(externalModPaths);
     }
 
-    return modFiles.map(filename => fs.readFileSync(filename, "utf8"));
+    return modFiles;
 }
 
-let mods = [];
-try {
-    mods = loadMods();
-    console.log("Loaded", mods.length, "mods");
-} catch (ex) {
-    console.error("Failed to load mods");
-    dialog.showErrorBox("Failed to load mods:", ex);
+/**
+ * Loads the specified mod files from the file system and returns their source
+ * code.
+ * @param {string[]} files Absolute file paths of mods to load.
+ */
+function loadMods(files = []) {
+    return files.map(filename => fs.readFileSync(filename, "utf8"));
 }
+
+const modFiles = scanMods();
 
 ipcMain.handle("get-mods", async () => {
+    let mods = [];
+
+    try {
+        mods = loadMods(modFiles);
+        console.log("Loaded", mods.length, "mods");
+    } catch (ex) {
+        console.error("Failed to load mods");
+        dialog.showErrorBox("Failed to load mods:", ex);
+    }
+
     return mods;
 });
+
+steam.init(isDev);
+
+// Only allow achievements and puzzle DLC if no mods are loaded
+if (modFiles.length === 0) {
+    steam.listen();
+}


### PR DESCRIPTION
Relatively small change that splits mod loading into 2 steps - *scanning* (searching for files to load) and *loading* (reading source code from the file system). Scanning is done only once, when the game starts. On the other hand, mods are reloaded each time the renderer requests them.

This allows "soft" mod reloading and greatly improves user experience of mod developers while keeping the Steam integration off if any mods are present.