### PR TITLE
fixed `mapLanguageCodeToId` to correctly choose between regions

### DIFF
--- a/src/js/translations.js
+++ b/src/js/translations.js
@@ -32,7 +32,10 @@ function mapLanguageCodeToId(languageKey) {
     // Try to match by key or short key
     for (const id in LANGUAGES) {
         const data = LANGUAGES[id];
-        const code = data.code.toLowerCase();
+        const shortCode = data.code.toLowerCase();
+        const region = data.region.toLowerCase();
+        const code = shortCode + (region ? "-" + region : "");
+        
         if (code === key) {
             console.log("-> Match", languageKey, "->", id);
             return id;
@@ -46,8 +49,7 @@ function mapLanguageCodeToId(languageKey) {
     // If none found, try to find a better alternative by using the base language at least
     for (const id in LANGUAGES) {
         const data = LANGUAGES[id];
-        const code = data.code.toLowerCase();
-        const shortCode = code.split("-")[0];
+        const shortCode = data.code.toLowerCase();
 
         if (shortCode === key) {
             console.log("-> Desperate Match", languageKey, "->", id);


### PR DESCRIPTION
Currently when browser language is `zh-TW`, `zh-CN` is chosen instead. Similarly for `pt-PT` over `pt-BR`.

In `language.js`, `LANGUAGES` has two separate fields `code` and `region` for the two parts before and after the "-" of a language code, while in `translations.js`, it seems that the field `code` is interpreted as the whole code, which causes the bug.